### PR TITLE
Clean up graphics

### DIFF
--- a/src/FCMapViewer.cpp
+++ b/src/FCMapViewer.cpp
@@ -171,7 +171,7 @@ int main(int argc, char** argv)
 
     window->setWindowTitle( title );
     if( window->center() != 1 )
-        std::cout << "The window had failed to center! " << window->center();
+        std::cout << "The window had failed to center! " << window->center() << std::endl;
     window->setDimensions( glm::u32vec2( width, height ) );
     window->setFullScreen( true );
     
@@ -221,7 +221,7 @@ int main(int argc, char** argv)
     auto number_of_iffs = manager.setLoad( load_all );
 
     if( number_of_iffs < 2 ) {
-        std::cout << "The number IFF " << number_of_iffs << " is not enough.";
+        std::cout << "The number IFF " << number_of_iffs << " is not enough." << std::endl;
         return -3;
     }
 
@@ -229,12 +229,12 @@ int main(int argc, char** argv)
     Data::Mission::IFF   *global_r = manager.getIFFEntry( global_id ).getIFF( platform );
 
     if( resource_r == nullptr ) {
-        std::cout << "The mission IFF " << iff_mission_id << " did not load.";
+        std::cout << "The mission IFF " << iff_mission_id << " did not load." << std::endl;
         return -4;
     }
 
     if( global_r == nullptr ) {
-        std::cout << "The global IFF did not load.";
+        std::cout << "The global IFF did not load." << std::endl;
         return -5;
     }
 
@@ -245,7 +245,7 @@ int main(int argc, char** argv)
         int status = environment->setupTextures( cbmp_resources );
 
         if( status < 0 )
-            std::cout << (-status) << " general textures had failed to load out of " << cbmp_resources.size();
+            std::cout << (-status) << " general textures had failed to load out of " << cbmp_resources.size() << std::endl;
     }
 
     // Load all the 3D meshes from the resource as well.
@@ -255,7 +255,7 @@ int main(int argc, char** argv)
         int status = environment->setModelTypes( cobj_resources );
 
         if( status < 0 )
-            std::cout << (-status) << " 3d meshes had failed to load out of " << cobj_resources.size();
+            std::cout << (-status) << " 3d meshes had failed to load out of " << cobj_resources.size() << std::endl;
     }
     
     // Get the font from the resource file.
@@ -268,14 +268,10 @@ int main(int argc, char** argv)
         else
         {
             font_resources = Data::Mission::FontResource::getVector( *global_r );
-
-            for( auto i : font_resources ) {
-                std::cout << "Pointer " << i;
-            }
             
             Graphics::Text2DBuffer::loadFonts( *environment, font_resources );
             if( font_resources.size() == 0 )
-                std::cout << " general fonts had failed to load out of " << font_resources.size();
+                std::cout << " general fonts had failed to load out of " << font_resources.size() << std::endl;
         }
     }
 
@@ -327,7 +323,7 @@ int main(int argc, char** argv)
     bool isCameraMoving = false;
 
     if( window->center() != 1 )
-        std::cout << "The window had failed to center! " << window->center();
+        std::cout << "The window had failed to center! " << window->center() << std::endl;
 
     // Setup the controls
     auto control_system_p = Controls::System::getSingleton(); // create the new system for controls

--- a/src/Graphics/SDL2/GLES2/Internal/FontSystem.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/FontSystem.cpp
@@ -417,9 +417,9 @@ int Graphics::SDL2::GLES2::Internal::FontSystem::compileProgram() {
         texture_uniform_id = glGetUniformLocation( program.getProgramID(), "Texture" );
         matrix_uniform_id = glGetUniformLocation( program.getProgramID(), "Transform" );
 
-        vertex_array.addAttribute( "POSITION",   2, GL_FLOAT,         false, sizeof( TextVertex ), 0, false );
-        vertex_array.addAttribute( "TEXCOORD_0", 2, GL_FLOAT,         false, sizeof( TextVertex ), reinterpret_cast<void*>(2 * alignof( TextVertex )), false );
-        vertex_array.addAttribute( "COLOR_0",    4, GL_UNSIGNED_BYTE, true,  sizeof( TextVertex ), reinterpret_cast<void*>(4 * alignof( TextVertex )), false );
+        vertex_array.addAttribute( "POSITION",   2, GL_FLOAT,         false, sizeof( TextVertex ), 0 );
+        vertex_array.addAttribute( "TEXCOORD_0", 2, GL_FLOAT,         false, sizeof( TextVertex ), reinterpret_cast<void*>(2 * alignof( TextVertex )) );
+        vertex_array.addAttribute( "COLOR_0",    4, GL_UNSIGNED_BYTE, true,  sizeof( TextVertex ), reinterpret_cast<void*>(4 * alignof( TextVertex )) );
 
         vertex_array.allocate( program );
     

--- a/src/Graphics/SDL2/GLES2/Internal/FontSystem.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/FontSystem.cpp
@@ -417,9 +417,9 @@ int Graphics::SDL2::GLES2::Internal::FontSystem::compileProgram() {
         texture_uniform_id = glGetUniformLocation( program.getProgramID(), "Texture" );
         matrix_uniform_id = glGetUniformLocation( program.getProgramID(), "Transform" );
 
-        vertex_array.addAttribute( "POSITION",   2, GL_FLOAT,         false, sizeof( TextVertex ), 0 );
-        vertex_array.addAttribute( "TEXCOORD_0", 2, GL_FLOAT,         false, sizeof( TextVertex ), reinterpret_cast<void*>(2 * alignof( TextVertex )) );
-        vertex_array.addAttribute( "COLOR_0",    4, GL_UNSIGNED_BYTE, true,  sizeof( TextVertex ), reinterpret_cast<void*>(4 * alignof( TextVertex )) );
+        vertex_array.addAttribute( "POSITION",   2, GL_FLOAT,         false, sizeof( TextVertex ), 0, false );
+        vertex_array.addAttribute( "TEXCOORD_0", 2, GL_FLOAT,         false, sizeof( TextVertex ), reinterpret_cast<void*>(2 * alignof( TextVertex )), false );
+        vertex_array.addAttribute( "COLOR_0",    4, GL_UNSIGNED_BYTE, true,  sizeof( TextVertex ), reinterpret_cast<void*>(4 * alignof( TextVertex )), false );
 
         vertex_array.allocate( program );
     

--- a/src/Graphics/SDL2/GLES2/Internal/Mesh.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Mesh.cpp
@@ -77,7 +77,7 @@ void Graphics::SDL2::GLES2::Internal::Mesh::setup( Utilities::ModelBuilder &mode
     
     // If there is some kind of bug where there are some attributes not recognized
     // then cull them. They will just spam Mesh with countless errors.
-    vertex_array.cullUnfound( &std::cout );
+    vertex_array.cullUnfound();
 
     Utilities::ModelBuilder::TextureMaterial material;
 

--- a/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.cpp
@@ -122,7 +122,7 @@ int Graphics::SDL2::GLES2::Internal::MorphModelDraw::compilieProgram() {
     sample_next_uniform_id = program.getUniform( "SampleNext", &std::cout, &uniform_failed );
     sample_last_uniform_id = program.getUniform( "SampleLast", &std::cout, &uniform_failed );
 
-    glUniform1f( sample_next_uniform_id, 0.0f ); // Next is unused.
+    glUniform1f( sample_next_uniform_id, 0.0f );
     glUniform1f( sample_last_uniform_id, 1.0f );
 
     morph_attribute_array_last.addAttribute( "POSITION_Last", 3, GL_FLOAT, GL_FALSE, MORPH_BUFFER_SIZE, 0 );

--- a/src/Graphics/SDL2/GLES2/Internal/Program.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Program.cpp
@@ -111,7 +111,7 @@ bool Graphics::SDL2::GLES2::Internal::Program::isAttribute( const std::basic_str
     if( glGetAttribLocation( this->getProgramID(), name.c_str() ) == -1 )
     {
         if( output_r != nullptr )
-            *output_r << "Attribute Error: " << name << " is not found." << std::endl;
+            *output_r << "Attribute Error: " << name << " is not in the program below." << std::endl;
         return false;
     }
     else

--- a/src/Graphics/SDL2/GLES2/Internal/Program.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Program.cpp
@@ -110,7 +110,8 @@ bool Graphics::SDL2::GLES2::Internal::Program::isAttribute( const std::basic_str
 {
     if( glGetAttribLocation( this->getProgramID(), name.c_str() ) == -1 )
     {
-        *output_r << "Error: " << name << " is not found." << std::endl;
+        if( output_r != nullptr )
+            *output_r << "Attribute Error: " << name << " is not found." << std::endl;
         return false;
     }
     else
@@ -124,7 +125,7 @@ GLint Graphics::SDL2::GLES2::Internal::Program::getUniform( const std::basic_str
     if( uniform_id == -1 )
     {
         if( output_r != nullptr )
-            *output_r << "Error: " << name << " is not in the program below!" << std::endl;
+            *output_r << "Uniform Error: " << name << " is not in the program below!" << std::endl;
         
         if( success_r != nullptr )
             *success_r |= (uniform_id == -1);

--- a/src/Graphics/SDL2/GLES2/Internal/Program.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Program.cpp
@@ -106,6 +106,17 @@ GLuint Graphics::SDL2::GLES2::Internal::Program::getShaderID( Shader* shader_r )
         return 0;
 }
 
+bool Graphics::SDL2::GLES2::Internal::Program::isAttribute( const std::basic_string<GLchar> &name, std::ostream *output_r ) const
+{
+    if( glGetAttribLocation( this->getProgramID(), name.c_str() ) == -1 )
+    {
+        *output_r << "Error: " << name << " is not found." << std::endl;
+        return false;
+    }
+    else
+        return true;
+}
+
 GLuint Graphics::SDL2::GLES2::Internal::Program::getVertexShaderID() const {
     return getShaderID( vertex_r );
 }

--- a/src/Graphics/SDL2/GLES2/Internal/Program.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Program.cpp
@@ -1,12 +1,12 @@
 #include "Program.h"
 
-Graphics::SDL2::GLES2::Internal::Program::Program() : is_allocated( false ), vertex_ref( nullptr ), fragment_ref( nullptr ), shader_program( 0 ) {
+Graphics::SDL2::GLES2::Internal::Program::Program() : is_allocated( false ), vertex_r( nullptr ), fragment_r( nullptr ), shader_program_id( 0 ) {
 }
 
-Graphics::SDL2::GLES2::Internal::Program::Program( Shader *vertex_reference, Shader *fragment_reference ) : is_allocated( false ), vertex_ref( nullptr ), fragment_ref( nullptr ), shader_program( 0 ) {
+Graphics::SDL2::GLES2::Internal::Program::Program( Shader *vertex_r, Shader *fragment_r ) : is_allocated( false ), vertex_r( nullptr ), fragment_r( nullptr ), shader_program_id( 0 ) {
     allocate();
-    setVertexShader( vertex_reference );
-    setFragmentShader( fragment_reference );
+    setVertexShader( vertex_r );
+    setFragmentShader( fragment_r );
     link();
 }
 
@@ -19,46 +19,46 @@ void Graphics::SDL2::GLES2::Internal::Program::allocate() {
     {
         is_allocated = true;
         
-        shader_program = glCreateProgram();
+        shader_program_id = glCreateProgram();
     }
 }
 
 void Graphics::SDL2::GLES2::Internal::Program::deallocate() {
     if( is_allocated )
-        glDeleteProgram( shader_program );
+        glDeleteProgram( shader_program_id );
     
     is_allocated = false;
-    vertex_ref   = nullptr;
-    fragment_ref = nullptr;
-    shader_program = 0;
+    vertex_r   = nullptr;
+    fragment_r = nullptr;
+    shader_program_id = 0;
 }
 
-Graphics::SDL2::GLES2::Internal::Shader* Graphics::SDL2::GLES2::Internal::Program::setShader( Shader *newShader, Shader *oldShader ) {
-    if( oldShader != nullptr )
-        glDetachShader( shader_program, oldShader->getShader() );
+Graphics::SDL2::GLES2::Internal::Shader* Graphics::SDL2::GLES2::Internal::Program::setShader( Shader *new_shader_r, Shader *old_shader_r ) {
+    if( old_shader_r != nullptr )
+        glDetachShader( shader_program_id, old_shader_r->getShader() );
     
-    glAttachShader( shader_program, newShader->getShader() );
+    glAttachShader( shader_program_id, new_shader_r->getShader() );
     
-    return newShader;
+    return new_shader_r;
 }
 
-void Graphics::SDL2::GLES2::Internal::Program::setVertexShader( Graphics::SDL2::GLES2::Internal::Shader *new_vertex_reference ) {
-    vertex_ref = setShader( new_vertex_reference, vertex_ref );
+void Graphics::SDL2::GLES2::Internal::Program::setVertexShader( Graphics::SDL2::GLES2::Internal::Shader *new_vertex_r ) {
+    vertex_r = setShader( new_vertex_r, vertex_r );
 }
 
 
-void Graphics::SDL2::GLES2::Internal::Program::setFragmentShader( Graphics::SDL2::GLES2::Internal::Shader *new_fragment_reference  ) {
-    fragment_ref = setShader( new_fragment_reference, fragment_ref );
+void Graphics::SDL2::GLES2::Internal::Program::setFragmentShader( Graphics::SDL2::GLES2::Internal::Shader *new_fragment_r  ) {
+    fragment_r = setShader( new_fragment_r, fragment_r);
 }
 
 bool Graphics::SDL2::GLES2::Internal::Program::link() {
     GLint program_linked_status;
     
-    glLinkProgram( shader_program );
+    glLinkProgram( shader_program_id );
     
-    glGetProgramiv( shader_program, GL_LINK_STATUS, &program_linked_status);
+    glGetProgramiv( shader_program_id, GL_LINK_STATUS, &program_linked_status);
     
-    return program_linked_status == 1;
+    return (program_linked_status == 1);
 }
 
 std::string Graphics::SDL2::GLES2::Internal::Program::getInfoLog() const {
@@ -67,7 +67,7 @@ std::string Graphics::SDL2::GLES2::Internal::Program::getInfoLog() const {
     GLint info_length;
     GLsizei actual_info_length;
     
-    glGetProgramiv(shader_program, GL_INFO_LOG_LENGTH, &info_length);
+    glGetProgramiv(shader_program_id, GL_INFO_LOG_LENGTH, &info_length);
     
     if( info_length > 0 )
     {
@@ -77,8 +77,9 @@ std::string Graphics::SDL2::GLES2::Internal::Program::getInfoLog() const {
         {
             returnry.reserve( info_length );
             
-            glGetProgramInfoLog(shader_program, info_length, &actual_info_length, temporary_string_p );
+            glGetProgramInfoLog(shader_program_id, info_length, &actual_info_length, temporary_string_p );
             
+            // TODO Remove this horiable code
             for( GLsizei a = 0; a < actual_info_length; a++ ) {
                 returnry.push_back( temporary_string_p[ a ] );
             }
@@ -95,20 +96,20 @@ std::string Graphics::SDL2::GLES2::Internal::Program::getInfoLog() const {
 }
 
 void Graphics::SDL2::GLES2::Internal::Program::use() {
-    glUseProgram( shader_program );
+    glUseProgram( shader_program_id );
 }
 
-GLuint Graphics::SDL2::GLES2::Internal::Program::getShaderID( Shader* shader_id ) const {
-    if( shader_id != nullptr )
-        return shader_id->getShader();
+GLuint Graphics::SDL2::GLES2::Internal::Program::getShaderID( Shader* shader_r ) const {
+    if( shader_r != nullptr )
+        return shader_r->getShader();
     else
         return 0;
 }
 
 GLuint Graphics::SDL2::GLES2::Internal::Program::getVertexShaderID() const {
-    return getShaderID( vertex_ref );
+    return getShaderID( vertex_r );
 }
 
 GLuint Graphics::SDL2::GLES2::Internal::Program::getFragmentShaderID() const {
-    return getShaderID( fragment_ref );
+    return getShaderID( fragment_r );
 }

--- a/src/Graphics/SDL2/GLES2/Internal/Program.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Program.cpp
@@ -117,6 +117,22 @@ bool Graphics::SDL2::GLES2::Internal::Program::isAttribute( const std::basic_str
         return true;
 }
 
+GLint Graphics::SDL2::GLES2::Internal::Program::getUniform( const std::basic_string<GLchar> &name, std::ostream *output_r, bool *success_r ) const
+{
+    GLint uniform_id = glGetUniformLocation( this->getProgramID(), name.c_str() );
+    
+    if( uniform_id == -1 )
+    {
+        if( output_r != nullptr )
+            *output_r << "Error: " << name << " is not in the program below!" << std::endl;
+        
+        if( success_r != nullptr )
+            *success_r |= (uniform_id == -1);
+    }
+    
+    return uniform_id;
+}
+
 GLuint Graphics::SDL2::GLES2::Internal::Program::getVertexShaderID() const {
     return getShaderID( vertex_r );
 }

--- a/src/Graphics/SDL2/GLES2/Internal/Program.h
+++ b/src/Graphics/SDL2/GLES2/Internal/Program.h
@@ -3,6 +3,7 @@
 
 #include "Shader.h"
 #include <string>
+#include <vector>
 
 namespace Graphics {
 namespace SDL2 {
@@ -22,25 +23,27 @@ namespace Internal {
 class Program {
 protected:
     bool is_allocated; // This is used to store the allocation state of the program.
-    Shader *vertex_ref;
-    Shader *fragment_ref;
-    GLuint shader_program;
+    Shader *vertex_r;
+    Shader *fragment_r;
+    GLuint shader_program_id;
+    
+    std::vector<std::basic_string<GLchar>> required_vertex_attributes;
 
     /**
      * This is a helper method used to set the shader to a new shader.
      * @warning This does not deallocate the old shader in program memory.
-     * @param new_shader This is the shader that will be the new shader.
-     * @param old_shader This is the shader that will be replaced.
+     * @param new_shader_r This is the shader that will be the new shader.
+     * @param old_shader_r This is the shader that will be replaced.
      * @return The newly attached shader. Be sure to make the pointer to the shader point to the new one.
      */
-    Shader* setShader( Shader *new_shader, Shader *old_shader );
+    Shader* setShader( Shader *new_shader_r, Shader *old_shader_r );
 
     /**
      * This is a helper method used to get the OpenGL shader id.
-     * @param shader_id The shader to get the shader id from.
+     * @param shader_r The shader to get the shader id from.
      * @return The shader id or else a 0 for a nullptr for a shader address.
      */
-    GLuint getShaderID( Shader* shader_id ) const;
+    GLuint getShaderID( Shader* shader_r ) const;
 public:
     /**
      * This sets up the program and sets it to an empty memory state.
@@ -52,12 +55,23 @@ public:
      * @param vertex_reference The vertex shader for this program to use.
      * @param fragment_reference The fragment shader or pixel shader for this program to use.
      */
-    Program( Shader *vertex_reference, Shader *fragment_reference );
+    Program( Shader *vertex_r, Shader *fragment_r );
 
     /**
      * This calls deallocate to handle the deletion of this program.
      */
     virtual ~Program();
+    
+    /**
+     * The program should complain to the console if it did not see anything.
+     * @param attribute The OpenGL attribute name.
+     */
+    void addRequiredAttribute( std::basic_string<GLchar> attribute );
+    
+    /**
+     * @return the number of attributes that are actually required.
+     */
+    std::vector<std::basic_string<GLchar>> getRequiredAttributes() const;
 
     /**
      * Allocate this program in OpenGL memory.
@@ -75,18 +89,18 @@ public:
      * @warning Call this method after allocate() and before link() or else this class will not work properly.
      * @param vertex_reference The vertex shader for this program to use.
      */
-    void setVertexShader( Shader *vertex_reference );
+    void setVertexShader( Shader *vertex_r );
 
     /**
      * Set the program to use this as a fragment shader or a pixel shader.
      * @warning Call this method after allocate() and before link() or else this class will not work properly.
-     * @param fragment_reference The fragment shader or pixel shader for this program to use.
+     * @param fragment_r The fragment shader or pixel shader for this program to use.
      */
-    void setFragmentShader( Shader *fragment_reference );
+    void setFragmentShader( Shader *fragment_r );
 
     /**
      * This completes the process of allocating the program by settting it to link with all of the shaders.
-     * @warning Call this method after allocate() and set*Shader() or else this program will not work properly.
+     * @warning Call this method after allocate() and setShader() or else this program will not work properly.
      * @return If the shader is successfully linked then this would return true.
      */
     bool link();
@@ -117,17 +131,17 @@ public:
     /**
      * @return The pointer to the Shader object stored in the vertex shader.
      */
-    Shader *getVertexShader() { return vertex_ref; }
+    Shader *getVertexShader() { return vertex_r; }
 
     /**
      * @return The pointer to the Shader object stored in the fragment shader.
      */
-    Shader *getFragmentShader() { return fragment_ref; }
+    Shader *getFragmentShader() { return fragment_r; }
 
     /**
      * @return The OpenGL id from this class. However, if this returns a zero then there is probably no program allocated.
      */
-    GLuint getProgramID() const { return shader_program; }
+    GLuint getProgramID() const { return shader_program_id; }
 };
 
 }

--- a/src/Graphics/SDL2/GLES2/Internal/Program.h
+++ b/src/Graphics/SDL2/GLES2/Internal/Program.h
@@ -111,6 +111,8 @@ public:
      * @return If the attribute exists return true.
      */
     bool isAttribute( const std::basic_string<GLchar> &name, std::ostream *output_r = nullptr ) const;
+    
+    GLint getUniform( const std::basic_string<GLchar> &name, std::ostream *output_r = nullptr, bool *success_r = nullptr ) const;
 
     /**
      * This is the method that gets the vertex shader id from this program.

--- a/src/Graphics/SDL2/GLES2/Internal/Program.h
+++ b/src/Graphics/SDL2/GLES2/Internal/Program.h
@@ -26,8 +26,6 @@ protected:
     Shader *vertex_r;
     Shader *fragment_r;
     GLuint shader_program_id;
-    
-    std::vector<std::basic_string<GLchar>> required_vertex_attributes;
 
     /**
      * This is a helper method used to set the shader to a new shader.
@@ -61,17 +59,6 @@ public:
      * This calls deallocate to handle the deletion of this program.
      */
     virtual ~Program();
-    
-    /**
-     * The program should complain to the console if it did not see anything.
-     * @param attribute The OpenGL attribute name.
-     */
-    void addRequiredAttribute( std::basic_string<GLchar> attribute );
-    
-    /**
-     * @return the number of attributes that are actually required.
-     */
-    std::vector<std::basic_string<GLchar>> getRequiredAttributes() const;
 
     /**
      * Allocate this program in OpenGL memory.

--- a/src/Graphics/SDL2/GLES2/Internal/Program.h
+++ b/src/Graphics/SDL2/GLES2/Internal/Program.h
@@ -4,6 +4,7 @@
 #include "Shader.h"
 #include <string>
 #include <vector>
+#include <ostream>
 
 namespace Graphics {
 namespace SDL2 {
@@ -102,6 +103,14 @@ public:
      * Set the pipeline to use this as a shader.
      */
     void use();
+    
+    /**
+     * This exports the attribute.
+     * @name This is the name of the attribute.
+     * @output This is the output of the method if it finds a non-existent output.
+     * @return If the attribute exists return true.
+     */
+    bool isAttribute( const std::basic_string<GLchar> &name, std::ostream *output_r = nullptr ) const;
 
     /**
      * This is the method that gets the vertex shader id from this program.

--- a/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
@@ -3,6 +3,7 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <cassert>
 #include <SDL2/SDL.h>
+#include <iostream>
 
 Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::SkeletalAnimation::SkeletalAnimation( unsigned int num_bones, unsigned int amount_of_frames ) {
     this->num_bones = num_bones;
@@ -121,11 +122,27 @@ const GLchar* Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::getDefaultVert
 
 int Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::compilieProgram() {
     auto ret = Graphics::SDL2::GLES2::Internal::StaticModelDraw::compilieProgram();
+    bool uniform_failed = false;
+    bool attribute_failed = false;
 
-    mat4_array_uniform_id = glGetUniformLocation( program.getProgramID(), "Bone" );
-
-    assert( mat4_array_uniform_id >= 0 ); // If this ID is negative then it is invalid.
-
+    mat4_array_uniform_id = program.getUniform( "Bone", &std::cout, &uniform_failed );
+    
+    attribute_failed |= !program.isAttribute( "JOINTS_0", &std::cout );
+    // attribute_failed |= !program.isAttribute( "WEIGHTS_0", &std::cout ); // WEIGHTS_0 is not a requirement.
+    
+    if( !uniform_failed && !attribute_failed )
+        return ret;
+    else
+    {
+        std::cout << "Skeletal Model Draw Error\n";
+        std::cout << program.getInfoLog();
+        std::cout << "\nVertex shader log\n";
+        std::cout << vertex_shader.getInfoLog();
+        std::cout << "\nFragment shader log\n";
+        std::cout << fragment_shader.getInfoLog() << std::endl;
+        return 0;
+    }
+    
     return ret;
 }
 

--- a/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
@@ -142,8 +142,6 @@ int Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::compilieProgram() {
         std::cout << fragment_shader.getInfoLog() << std::endl;
         return 0;
     }
-    
-    return ret;
 }
 
 void Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::setNumModelTypes( size_t model_amount ) {

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -232,6 +232,8 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::loadFragmentShader( const 
 }
 
 int Graphics::SDL2::GLES2::Internal::StaticModelDraw::compilieProgram() {
+    bool uniform_failure = 0;
+    
     // The two shaders should be allocated first.
     if( vertex_shader.getType() == Shader::TYPE::VERTEX && fragment_shader.getType() == Shader::TYPE::FRAGMENT ) {
 
@@ -247,12 +249,36 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::compilieProgram() {
         {
             // Setup the uniforms for the map.
             diffusive_texture_uniform_id = glGetUniformLocation( program.getProgramID(), "Texture" );
+            uniform_failure |= diffusive_texture_uniform_id == -1;
             sepecular_texture_uniform_id = glGetUniformLocation( program.getProgramID(), "Shine" );
+            uniform_failure |= sepecular_texture_uniform_id == -1;
             texture_offset_uniform_id    = glGetUniformLocation( program.getProgramID(), "TextureTranslation" );
+            uniform_failure |= texture_offset_uniform_id == -1;
 
             matrix_uniform_id = glGetUniformLocation(   program.getProgramID(), "Transform" );
+            uniform_failure |= matrix_uniform_id == -1;
             view_uniform_id = glGetUniformLocation(     program.getProgramID(), "ModelView" );
+            uniform_failure |= view_uniform_id == -1;
             view_inv_uniform_id = glGetUniformLocation( program.getProgramID(), "ModelViewInv" );
+            uniform_failure |= view_inv_uniform_id == -1;
+            
+            if( glGetAttribLocation( program.getProgramID(), "POSITION" ) == -1 )
+                std::cout << "Error StaticModelDraw: POSITION is not found." << std::endl;
+            if( glGetAttribLocation( program.getProgramID(), "NORMAL" ) == -1 )
+                std::cout << "Error StaticModelDraw: NORMAL is not found." << std::endl;
+            if( glGetAttribLocation( program.getProgramID(), "TEXCOORD_0" ) == -1 )
+                std::cout << "Error StaticModelDraw: TEXCOORD_0 is not found." << std::endl;
+            if( glGetAttribLocation( program.getProgramID(), "_Specular" ) == -1 )
+                std::cout << "Error StaticModelDraw: _Specular is not found." << std::endl;
+            
+            if( uniform_failure ) {
+                std::cout << "StaticModelDraw program has failed to compile" << std::endl;
+                std::cout << program.getInfoLog() << std::endl;
+                std::cout << "Vertex shader log" << std::endl;
+                std::cout << vertex_shader.getInfoLog() << std::endl;
+                std::cout << "Fragment shader log" << std::endl;
+                std::cout << fragment_shader.getInfoLog() << std::endl;
+            }
 
             return 1;
         }

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -232,7 +232,7 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::loadFragmentShader( const 
 }
 
 int Graphics::SDL2::GLES2::Internal::StaticModelDraw::compilieProgram() {
-    bool uniform_failure = false;
+    bool uniform_failed = false;
     bool attribute_failed = false;
     bool link_success = true;
     
@@ -252,36 +252,29 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::compilieProgram() {
         else
         {
             // Setup the uniforms for the map.
-            diffusive_texture_uniform_id = glGetUniformLocation( program.getProgramID(), "Texture" );
-            uniform_failure |= diffusive_texture_uniform_id == -1;
-            sepecular_texture_uniform_id = glGetUniformLocation( program.getProgramID(), "Shine" );
-            uniform_failure |= sepecular_texture_uniform_id == -1;
-            texture_offset_uniform_id    = glGetUniformLocation( program.getProgramID(), "TextureTranslation" );
-            uniform_failure |= texture_offset_uniform_id == -1;
-
-            matrix_uniform_id = glGetUniformLocation(   program.getProgramID(), "Transform" );
-            uniform_failure |= matrix_uniform_id == -1;
-            view_uniform_id = glGetUniformLocation(     program.getProgramID(), "ModelView" );
-            uniform_failure |= view_uniform_id == -1;
-            view_inv_uniform_id = glGetUniformLocation( program.getProgramID(), "ModelViewInv" );
-            uniform_failure |= view_inv_uniform_id == -1;
+            diffusive_texture_uniform_id = program.getUniform( "Texture", &std::cout, &uniform_failed );
+            sepecular_texture_uniform_id = program.getUniform( "Shine", &std::cout, &uniform_failed );
+            texture_offset_uniform_id = program.getUniform( "TextureTranslation", &std::cout, &uniform_failed );
+            matrix_uniform_id = program.getUniform( "Transform", &std::cout, &uniform_failed );
+            view_uniform_id = program.getUniform( "ModelView", &std::cout, &uniform_failed );
+            view_inv_uniform_id = program.getUniform( "ModelViewInv", &std::cout, &uniform_failed );
             
-            attribute_failed |= program.isAttribute( "POSITION", &std::cout );
-            attribute_failed |= program.isAttribute( "NORMAL", &std::cout );
-            attribute_failed |= program.isAttribute( "TEXCOORD_0", &std::cout );
-            attribute_failed |= program.isAttribute( "_Specular", &std::cout );
+            attribute_failed |= !program.isAttribute( "POSITION", &std::cout );
+            attribute_failed |= !program.isAttribute( "NORMAL", &std::cout );
+            attribute_failed |= !program.isAttribute( "TEXCOORD_0", &std::cout );
+            attribute_failed |= !program.isAttribute( "_Specular", &std::cout );
 
             link_success = true;
         }
         
-        if( !link_success || uniform_failure || attribute_failed ) {
+        if( !link_success || uniform_failed || attribute_failed ) {
             std::cout << "StaticModelDraw program has failed." << std::endl;
             
             if( !link_success )
                 std::cout << "There is trouble with linking." << std::endl;
-            if( !uniform_failure )
+            if( uniform_failed )
                 std::cout << "There is trouble with the uniforms." << std::endl;
-            if( !attribute_failed )
+            if( attribute_failed )
                 std::cout << "There is trouble with the attributes." << std::endl;
             
             std::cout << program.getInfoLog();

--- a/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.cpp
@@ -9,7 +9,7 @@ Graphics::SDL2::GLES2::Internal::VertexAttributeArray::~VertexAttributeArray() {
     // There is nothing to delete.
 }
 
-bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const std::basic_string<GLchar>& name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, void *pointer_r, bool is_optional ) {
+bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const std::basic_string<GLchar>& name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, void *pointer_r ) {
     bool name_is_not_found = true;
 
     for( unsigned int i = 0; i < attributes.size(); i++ )
@@ -29,7 +29,6 @@ bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const 
         attributes.back().normalized = normalized;
         attributes.back().stride = stride;
         attributes.back().offset_r = pointer_r;
-        attributes.back().is_optional = is_optional;
 
         return true;
     }
@@ -48,16 +47,16 @@ int Graphics::SDL2::GLES2::Internal::VertexAttributeArray::allocate( Graphics::S
     return found_attributes;
 }
 
-int Graphics::SDL2::GLES2::Internal::VertexAttributeArray::cullUnfound( std::ostream *output ) {
+int Graphics::SDL2::GLES2::Internal::VertexAttributeArray::cullUnfound( std::ostream *output_r ) {
     int amount_culled = 0;
 
     for( signed int d = 0; d < attributes.size(); d++ ) {
         auto i = (attributes.begin() + d);
         if( (*i).index < 0 ) {
-            if( output != nullptr && !(*i).is_optional ) {
+            if( output_r != nullptr ) {
                 if( amount_culled == 0 )
-                    *output << "Warning: These vertex attributes had been culled for either two reasons." << std::endl << "They did not exist or they have been culled by GLSL itself." << std::endl;
-                *output << "Vertex Attribute " << (*i).name << std::endl;
+                    *output_r << "Warning: These vertex attributes had been culled for either two reasons." << std::endl << "They did not exist or they have been culled by GLSL itself." << std::endl;
+                *output_r << "Vertex Attribute " << (*i).name << std::endl;
             }
             attributes.erase( i );
             d--; // Move d to the last position.

--- a/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.cpp
@@ -9,7 +9,7 @@ Graphics::SDL2::GLES2::Internal::VertexAttributeArray::~VertexAttributeArray() {
     // There is nothing to delete.
 }
 
-bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const GLchar *name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, void * pointer ) {
+bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const std::basic_string<GLchar>& name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, void *pointer_r, bool is_optional ) {
     bool name_is_not_found = true;
 
     for( unsigned int i = 0; i < attributes.size(); i++ )
@@ -28,7 +28,8 @@ bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const 
         attributes.back().type = type;
         attributes.back().normalized = normalized;
         attributes.back().stride = stride;
-        attributes.back().offset = pointer;
+        attributes.back().offset_r = pointer_r;
+        attributes.back().is_optional = is_optional;
 
         return true;
     }
@@ -53,7 +54,7 @@ int Graphics::SDL2::GLES2::Internal::VertexAttributeArray::cullUnfound( std::ost
     for( signed int d = 0; d < attributes.size(); d++ ) {
         auto i = (attributes.begin() + d);
         if( (*i).index < 0 ) {
-            if( output != nullptr ) {
+            if( output != nullptr && !(*i).is_optional ) {
                 if( amount_culled == 0 )
                     *output << "Warning: These vertex attributes had been culled for either two reasons." << std::endl << "They did not exist or they have been culled by GLSL itself." << std::endl;
                 *output << "Vertex Attribute " << (*i).name << std::endl;
@@ -110,6 +111,6 @@ void Graphics::SDL2::GLES2::Internal::VertexAttributeArray::bind( size_t buffer_
     for( auto i = attributes.begin(); i < attributes.end(); i++ )
     {
         glEnableVertexAttribArray( (*i).index );
-        glVertexAttribPointer( (*i).index, (*i).size, (*i).type, (*i).normalized, (*i).stride, reinterpret_cast<void*>( reinterpret_cast<size_t>((*i).offset) + buffer_offset ) );
+        glVertexAttribPointer( (*i).index, (*i).size, (*i).type, (*i).normalized, (*i).stride, reinterpret_cast<void*>( reinterpret_cast<size_t>( (*i).offset_r ) + buffer_offset ) );
     }
 }

--- a/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.h
+++ b/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.h
@@ -18,7 +18,7 @@ namespace Internal {
 class VertexAttributeArray {
 protected:
     struct AttributeType {
-        std::string name;
+        std::basic_string<GLchar> name;
 
         // These are the parameters for glVertexAttribPointer.
         GLint index;
@@ -26,7 +26,10 @@ protected:
         GLenum type;
         GLboolean normalized;
         GLsizei stride;
-        void *offset;
+        
+        bool is_optional;
+        
+        void *offset_r;
     };
     std::vector<AttributeType> attributes;
 public:
@@ -39,13 +42,13 @@ public:
      * @note The parameters will be directly passed into an AttributeType.
      * @return If a name already exists then return false.
      */
-    bool addAttribute( const GLchar *name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, void * pointer );
+    bool addAttribute( const std::basic_string<GLchar>& name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, void *pointer_r, bool is_optional = false );
 
     /**
      * The VertexAttributeArray has to be filled in order for this method to work.
      * @return The number of successfull attributeTypeBinds.
      */
-    int allocate( Graphics::SDL2::GLES2::Internal::Program & program );
+    int allocate( Graphics::SDL2::GLES2::Internal::Program &program );
 
     /**
      * This deletes every attribute type that was not allocated.

--- a/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.h
+++ b/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.h
@@ -27,8 +27,6 @@ protected:
         GLboolean normalized;
         GLsizei stride;
         
-        bool is_optional;
-        
         void *offset_r;
     };
     std::vector<AttributeType> attributes;
@@ -42,7 +40,7 @@ public:
      * @note The parameters will be directly passed into an AttributeType.
      * @return If a name already exists then return false.
      */
-    bool addAttribute( const std::basic_string<GLchar>& name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, void *pointer_r, bool is_optional = false );
+    bool addAttribute( const std::basic_string<GLchar>& name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, void *pointer_r );
 
     /**
      * The VertexAttributeArray has to be filled in order for this method to work.

--- a/src/Graphics/SDL2/GLES2/Window.cpp
+++ b/src/Graphics/SDL2/GLES2/Window.cpp
@@ -40,7 +40,7 @@ int Graphics::SDL2::GLES2::Window::attach() {
         window_p = SDL_CreateWindow( getWindowTitle().c_str(),
                                     getPosition().x, getPosition().y,
                                     getDimensions().x, getDimensions().y,
-                                    flags | SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL );
+                                    flags | SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL );
         
         if( window_p != nullptr ) {
             GL_context = SDL_GL_CreateContext( window_p );
@@ -81,6 +81,9 @@ int Graphics::SDL2::GLES2::Window::attach() {
             std::cout << "SDL Error: " << SDL_GetError() << " for " << CONTEXT_NAMES[ i ] << std::endl;
         }
     }
+    
+    if( window_p != nullptr )
+        SDL_ShowWindow( window_p );
     
     env_r->window_p = this;
     

--- a/src/Graphics/SDL2/GLES2/Window.cpp
+++ b/src/Graphics/SDL2/GLES2/Window.cpp
@@ -57,7 +57,7 @@ int Graphics::SDL2::GLES2::Window::attach() {
         }
         else
         {
-            std::cout << "SDL Error: " << SDL_GetError() << std::endl;
+            std::cout << "SDL Window Error: " << SDL_GetError() << std::endl;
         }
         
         if( GL_context != nullptr ) {

--- a/src/Graphics/SDL2/GLES2/Window.cpp
+++ b/src/Graphics/SDL2/GLES2/Window.cpp
@@ -15,6 +15,7 @@ int Graphics::SDL2::GLES2::Window::attach() {
     int major_version = 0;
     int success = -1;
     
+    const std::string CONTEXT_NAMES[ 2 ] = { "OpenGLES", "OpenGL" };
     const int SDL2_CONTEXTS[ 2 ] = { SDL_GL_CONTEXT_PROFILE_ES, 0 };
     
     for( int i = 0; i < 2 && major_version != 2; i++ ) {
@@ -46,18 +47,18 @@ int Graphics::SDL2::GLES2::Window::attach() {
             
             int version = gladLoadGLES2((GLADloadfunc) SDL_GL_GetProcAddress);
 
-            if( version != 0 ) {
-                std::cout << "GLAD INIT Failure: ";
+            if( version == 0 ) {
+                std::cout << "GLAD INIT Failure for ";
                 // TODO Print out the problem if failure is detected.
             }
             else
-                std::cout << "GLAD INIT Success: ";
+                std::cout << "GLAD INIT Success for ";
             
-            std::cout << std::endl;
+            std::cout << CONTEXT_NAMES[ i ] << std::endl;
         }
         else
         {
-            std::cout << "SDL Window Error: " << SDL_GetError() << std::endl;
+            std::cout << "SDL Window Error: " << SDL_GetError() << " for " << CONTEXT_NAMES[ i ] << std::endl;
         }
         
         if( GL_context != nullptr ) {
@@ -71,13 +72,13 @@ int Graphics::SDL2::GLES2::Window::attach() {
             }
             else
             {
-                std::cout << "SDL Error: " << SDL_GetError() << std::endl;
+                std::cout << "SDL Context Status Error: " << SDL_GetError() << " for " << CONTEXT_NAMES[ i ] << std::endl;
             }
         }
         else
         {
             std::cout << "Context Allocation Failure!\n";
-            std::cout << "SDL Error: " << SDL_GetError() << std::endl;
+            std::cout << "SDL Error: " << SDL_GetError() << " for " << CONTEXT_NAMES[ i ] << std::endl;
         }
     }
     

--- a/src/Graphics/SDL2/GLES2/Window.cpp
+++ b/src/Graphics/SDL2/GLES2/Window.cpp
@@ -11,7 +11,6 @@ Graphics::SDL2::GLES2::Window::~Window() {
 }
 
 int Graphics::SDL2::GLES2::Window::attach() {
-    Uint32 flags = 0;
     int major_version = 0;
     int success = -1;
     
@@ -36,6 +35,12 @@ int Graphics::SDL2::GLES2::Window::attach() {
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL2_CONTEXTS[ i ] );
         SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
         SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+        
+        // This simple logic is there to determine if the window is centered or not.
+        auto position = getPosition();
+        
+        if( this->is_centered )
+            position = glm::u32vec2( SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED );
         
         window_p = SDL_CreateWindow( getWindowTitle().c_str(),
                                     getPosition().x, getPosition().y,

--- a/src/Graphics/SDL2/Window.cpp
+++ b/src/Graphics/SDL2/Window.cpp
@@ -1,6 +1,6 @@
 #include "Window.h" // Include the internal class
 
-Graphics::SDL2::Window::Window( Environment &env ) : Graphics::Window( env ), window_p( nullptr )
+Graphics::SDL2::Window::Window( Environment &env ) : Graphics::Window( env ), window_p( nullptr ), flags( 0 ), is_centered( false )
 {
 }
 
@@ -38,11 +38,10 @@ int Graphics::SDL2::Window::center() {
     int display_index;
     SDL_Rect screen;
 
-    if( status.window_status != Status::FULL_SCREEN && window_p != nullptr )
-    {
+    if( window_p != nullptr ) {
         // First we need the display index of the window.
         display_index = SDL_GetWindowDisplayIndex( window_p );
-
+        
         // Check if the display index is valid.
         if( display_index >= 0 )
         {
@@ -50,15 +49,18 @@ int Graphics::SDL2::Window::center() {
             if( SDL_GetDisplayBounds( display_index, &screen ) == 0 )
             {
                 setPosition( glm::u32vec2( (screen.w - dimensions.x) / 2, (screen.h - dimensions.y) / 2 ) );
-
+                
                 return 1;
             }
             else
-                return -3;
+                return -2;
         }
         else
-            return -2;
+            return -1;
     }
     else
-        return -1;
+    {
+        this->is_centered = true;
+        return 1;
+    }
 }

--- a/src/Graphics/SDL2/Window.h
+++ b/src/Graphics/SDL2/Window.h
@@ -10,6 +10,9 @@ namespace SDL2 {
 
 class Window : public Graphics::Window {
 protected:
+    Uint32 flags;
+    bool is_centered;
+    
     Window( Environment &env_r );
 public:
     SDL_Window *window_p;


### PR DESCRIPTION
I had removed errors that I deem to be unnecessary.

These "errors" are simply memory optimization and performance problems. Users should not gets entire dumps of what attributes are culled or not.

I also added more verbose error reporting behavior. This time if important attributes or uniforms are missing. This program will dump an entire info log on the shaders. This will hopefully make the Windows build easier to debug.