### PR TITLE
Vertex colors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 option(FCOption_TESTS "Run tests to the project to see any potential problems." OFF)
 option(FCOption_SDL2_VENDORED "Use SDL2 vendored library. Make sure the submodule is there before using this option." OFF)
 option(FCOption_GLM_VENDORED "Use GLM or OpenGL Mathematics vendored library. Make sure the submodule is there before using this option." OFF)
-option( FC_OPTION_EXPERIMENTAL_BLEND_COLORS "Enable experimental blend colors on Ctils which makes maps." OFF )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,21 @@ else()
   include_directories(${GLM_INCLUDE_DIRS})
 endif()
 
+# Use the vendor version if the SDL2 find files could not be found.
+if( FCOption_SDL2_VENDORED )
+  add_subdirectory(submodules/SDL2 EXCLUDE_FROM_ALL)
+
+  # This is a workaround made to make this project compile. There might be a better way.
+  include_directories(${PROJECT_BINARY_DIR}/submodules/SDL2/include-config-/) # TODO Make sure this works.
+elseif( WIN32 )
+  # If SDL2 is not there or SDL2 or SDL2main are missing then Windows will not work with this build.
+  find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
+else()
+  # 1. Look for a SDL2 package, 2. look for the SDL2 component and 3. fail if none can be found
+  find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2)
+  find_package(SDL2 REQUIRED CONFIG COMPONENTS SDL2main) # SDL2main is optional for this build.
+endif()
+
 find_package( JSON_CPP REQUIRED )
 
 find_package( OpenGL REQUIRED)
@@ -98,27 +113,18 @@ include_directories( src/Graphics/SDL2/GLES2/glad/include )
 file(GLOB_RECURSE GRAPHICS_SDL2_GLES2_SOURCE_FILES src/Graphics/SDL2/GLES2/*.cpp src/Graphics/SDL2/GLES2/*.c )
 
 add_library(FC_Engine STATIC ${CONTROL_SOURCE_FILES} ${CONTROL_SDL2_SOURCE_FILES} ${GRAPHICS_SOURCE_FILES} ${GRAPHICS_SDL2_SOURCE_FILES} ${GRAPHICS_SDL2_GLES2_SOURCE_FILES} )
-add_executable(FCModelViewer WIN32 src/FCModelViewer.cpp )
-add_executable(FCMapViewer WIN32 src/FCMapViewer.cpp )
+target_link_libraries (FC_Engine PRIVATE SDL2::SDL2)
 
-# Use the vendor version if the SDL2 find files could not be found.
-if( FCOption_SDL2_VENDORED )
-  add_subdirectory(submodules/SDL2 EXCLUDE_FROM_ALL)
-
-   # This might fix anoying SDL2 but on whatever end caused it.
-  include_directories( ${PROJECT_BINARY_DIR}/submodules/SDL2/include )
-  configure_file(${PROJECT_BINARY_DIR}/submodules/SDL2/SDL_config.h.intermediate ${PROJECT_BINARY_DIR}/SDL_config.h COPYONLY)
+if( WIN32 )
+  add_executable(FCModelViewer WIN32 src/FCModelViewer.cpp )
 else()
-  if( WIN32 )
-    # If SDL2 is not there or SDL2 or SDL2main are missing then Windows will not work with this build.
-    find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
-  else()
-    # 1. Look for a SDL2 package, 2. look for the SDL2 component and 3. fail if none can be found
-    find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2)
-    find_package(SDL2 REQUIRED CONFIG COMPONENTS SDL2main) # SDL2main is optional for this build.
-  endif()
+  add_executable(FCModelViewer src/FCModelViewer.cpp )
+endif()
 
-  include_directories(${SDL2_INCLUDE_DIRS})
+if( WIN32 )
+  add_executable(FCMapViewer WIN32 src/FCMapViewer.cpp )
+else()
+  add_executable(FCMapViewer src/FCMapViewer.cpp )
 endif()
 
 if( TARGET SDL2::SDL2main )

--- a/src/Config.h.in
+++ b/src/Config.h.in
@@ -13,9 +13,4 @@
 #endif // PNG_FOUND
 #endif // ZLIB_FOUND
 
-// This is a temporary value to enable when the
-// blended color algorithm gets found and is not
-//  ugly.
-#cmakedefine FC_OPTION_EXPERIMENTAL_BLEND_COLORS
-
 #endif // FUTURE_COP_MIT_CONFIG_H

--- a/src/Data/Mission/ACT/Internal/Hash.cpp
+++ b/src/Data/Mission/ACT/Internal/Hash.cpp
@@ -15,6 +15,9 @@ private:
     const static size_t TABLE_SIZE = 0x100;
 
     Data::Mission::ACTResource* table_p[ TABLE_SIZE ];
+    
+    // Type ID 16 - 36 Unknown bytes - Precinct Assault Powerups.
+    // Type ID 32 - 32 Unknown bytes - Police Locker Unit Contianing Powerups.
 
     void setupTable() {
         table_p[ Data::Mission::ACT::X1Alpha::TYPE_ID ] = new Data::Mission::ACT::X1Alpha();

--- a/src/Data/Mission/ACTResource.cpp
+++ b/src/Data/Mission/ACTResource.cpp
@@ -5,7 +5,6 @@
 #include "ACT/Unknown.h"
 
 #include <fstream>
-#include <iostream>
 #include <cassert>
 
 #include <json/json.h>
@@ -135,7 +134,7 @@ uint32_t Data::Mission::ACTResource::readACTChunk( Utilities::Buffer::Reader &da
         return 0;
 }
 uint32_t Data::Mission::ACTResource::readRSLChunk( Utilities::Buffer::Reader &data_reader, Utilities::Buffer::Endian endian, const ParseSettings &settings ) {
-    // const uint32_t Cobj_INT = 0x436F626A; // This spells out Cobj.
+    const uint32_t Cobj_INT = 0x436F626A; // This spells out Cobj.
 
     if( RSL_CHUNK_ID == data_reader.readU32( endian ) )
     {

--- a/src/Data/Mission/FUNResource.cpp
+++ b/src/Data/Mission/FUNResource.cpp
@@ -117,6 +117,10 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                         
                         bool found_item = false;
                         
+                        // faction = 1, identifier = 5 Probably means initialization!
+                        // FORCE_ACTOR_SPAWN = NUMBER, { 0xC7, 0x80, 0x3C }
+                        // NEUTRAL_TURRET_INIT = NUMBER, { 0xC7, 0x80, 0x3D }
+                        
                         if( code.size() >= 5) {
                             const size_t ELEMENT = code.at( (code.end() - code.begin()) - 2 );
                             
@@ -136,10 +140,10 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                         }
                         
                         if( found_item ) {
-                            *settings.output_ref << "i = " << std::dec << i << std::endl;
-                            *settings.output_ref << "faction = " << std::dec << functions.at( i ).faction << std::endl;
-                            *settings.output_ref << "identifier = " << std::dec << functions.at( i ).identifier << std::endl;
-                            *settings.output_ref << "start = " << std::dec << functions.at( i ).start_parameter_offset << "\n" << std::endl;
+                            *settings.output_ref << "i[" << std::dec << i  << "], ";
+                            *settings.output_ref << "f[" << functions.at( i ).faction << "], ";
+                            *settings.output_ref << "id[" << functions.at( i ).identifier << "], ";
+                            *settings.output_ref << "offset = " << functions.at( i ).start_parameter_offset << "\n" << std::endl;
                             *settings.output_ref << std::hex << "Code = ";
                             for( auto f = code.begin(); f < code.end(); f++ ) {
                                 *settings.output_ref<< "0x" << static_cast<unsigned>( (*f) ) << ", ";

--- a/src/Data/Mission/FUNResource.cpp
+++ b/src/Data/Mission/FUNResource.cpp
@@ -95,10 +95,10 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                         auto code = getFunctionCode( i );
                         
                         if( settings.output_level >= 3 ) {
-                            *settings.output_ref << "i = " << std::dec << i << std::endl;
-                            *settings.output_ref << "faction = " << std::dec << functions.at( i ).faction << std::endl;
-                            *settings.output_ref << "identifier = " << std::dec << functions.at( i ).identifier << std::endl;
-                            *settings.output_ref << "start = " << std::dec << functions.at( i ).start_parameter_offset << "\n" << std::endl;
+                            *settings.output_ref << "i[" << std::dec << i  << "], ";
+                            *settings.output_ref << "f[" << functions.at( i ).faction << "], ";
+                            *settings.output_ref << "id[" << functions.at( i ).identifier << "], ";
+                            *settings.output_ref << "offset = " << functions.at( i ).start_parameter_offset << "\n" << std::endl;
                             
                             *settings.output_ref << std::hex << "Parameters = ";
                             for( auto f = parameters.begin(); f < parameters.end(); f++ ) {
@@ -121,35 +121,18 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                         // FORCE_ACTOR_SPAWN = NUMBER, { 0xC7, 0x80, 0x3C }
                         // NEUTRAL_TURRET_INIT = NUMBER, { 0xC7, 0x80, 0x3D }
                         
-                        if( code.size() >= 5) {
-                            const size_t ELEMENT = code.at( (code.end() - code.begin()) - 2 );
-                            
-                            if( ELEMENT == NEUTRAL_TURRET_INIT[2] ) {
-                                if( code.at( (code.end() - code.begin()) - 3 ) == NEUTRAL_TURRET_INIT[1] && code.at( (code.end() - code.begin()) - 4 ) == NEUTRAL_TURRET_INIT[0] ) {
-                                    std::cout << "Found Neutral Turret!" << std::endl;
-                                    found_item = true;
-                                }
-                            }
-                            else
-                            if( ELEMENT == FORCE_ACTOR_SPAWN[2] ) {
-                                if( code.at( (code.end() - code.begin()) - 3 ) == FORCE_ACTOR_SPAWN[1] && code.at( (code.end() - code.begin()) - 4 ) == FORCE_ACTOR_SPAWN[0] ) {
-                                    std::cout << "Found Base Turret!" << std::endl;
-                                    found_item = true;
-                                }
-                            }
-                        }
+                        // JOKE/SLIM has faction 1 and identifier 5, and it appears to be something else. I can deduce no pattern in this sequence.
+                        // However, I have enough knowedge to write an inaccurate parser.
                         
-                        if( found_item ) {
-                            *settings.output_ref << "i[" << std::dec << i  << "], ";
-                            *settings.output_ref << "f[" << functions.at( i ).faction << "], ";
-                            *settings.output_ref << "id[" << functions.at( i ).identifier << "], ";
-                            *settings.output_ref << "offset = " << functions.at( i ).start_parameter_offset << "\n" << std::endl;
+                        if( functions.at( i ).faction == 1 && functions.at( i ).identifier == 5 ) {
+                            std::cout << "Init code here! " << i << std::endl;
                             *settings.output_ref << std::hex << "Code = ";
                             for( auto f = code.begin(); f < code.end(); f++ ) {
                                 *settings.output_ref<< "0x" << static_cast<unsigned>( (*f) ) << ", ";
                             }
-                            std::cout << std::endl;
+                            *settings.output_ref << std::dec << "\n" << std::endl;
                         }
+                        
                         
                         assert( parameters.size() > 1 );
                         assert( code.size() > 1 );

--- a/src/Data/Mission/FUNResource.cpp
+++ b/src/Data/Mission/FUNResource.cpp
@@ -1,16 +1,10 @@
 #include "FUNResource.h"
 #include <limits>
 #include <cassert>
-#include <iostream>
 
 const std::string Data::Mission::FUNResource::FILE_EXTENSION = "fun";
 // which is { 0x43, 0x66, 0x75, 0x6E } or { 'C', 'f', 'u', 'n' } or "Cfun"
 const uint32_t Data::Mission::FUNResource::IDENTIFIER_TAG = 0x4366756e;
-
-namespace {
-const uint8_t FORCE_ACTOR_SPAWN[] = { 0xC7, 0x80, 0x3C };
-const uint8_t NEUTRAL_TURRET_INIT[] = { 0xC7, 0x80, 0x3D }; // Always has 0xB2 or 178. Which might mean a value of 50 if converted.
-}
 
 Data::Mission::FUNResource::FUNResource() {
 }
@@ -123,16 +117,6 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                         
                         // JOKE/SLIM has faction 1 and identifier 5, and it appears to be something else. I can deduce no pattern in this sequence.
                         // However, I have enough knowedge to write an inaccurate parser.
-                        
-                        if( functions.at( i ).faction == 1 && functions.at( i ).identifier == 5 ) {
-                            std::cout << "Init code here! " << i << std::endl;
-                            *settings.output_ref << std::hex << "Code = ";
-                            for( auto f = code.begin(); f < code.end(); f++ ) {
-                                *settings.output_ref<< "0x" << static_cast<unsigned>( (*f) ) << ", ";
-                            }
-                            *settings.output_ref << std::dec << "\n" << std::endl;
-                        }
-                        
                         
                         assert( parameters.size() > 1 );
                         assert( code.size() > 1 );

--- a/src/Data/Mission/Resource.cpp
+++ b/src/Data/Mission/Resource.cpp
@@ -84,19 +84,15 @@ bool Data::Mission::Resource::noResourceID() const {
 }
 
 std::string Data::Mission::Resource::getFullName( unsigned int index ) const {
-    std::string full_name;
-
-    if( swvr_name.empty() ) {
-        // full_name = "dat_60"
-        full_name  = getFileExtension();
-        full_name += "_";
+    std::string full_name = getFileExtension();
+    full_name += "_";
+    
+    if( swvr_name.empty() )
         full_name += std::to_string( index );
-    }
-    else {
-        full_name = swvr_name;
-        full_name += "_";
-        full_name += getFileExtension();
-    }
+    else
+        full_name += swvr_name;
+    
+    // full_name = "dat_60"
 
     return full_name;
 }

--- a/src/Data/Mission/Til/Colorizer.cpp
+++ b/src/Data/Mission/Til/Colorizer.cpp
@@ -87,13 +87,23 @@ unsigned int Data::Mission::Til::Colorizer::setSquareColors( const Input &input,
                 break;
             case 0b01: // Dynamic Monochrome
                 {
-                    result_r[1].x = static_cast<double>( TilResource::TileGraphics( input.til_graphics.at( (input.tile_index + 1) % input.til_graphics.size() ) ).shading ) * SHADING_VALUE;
+                    const auto primary = TilResource::TileGraphics( input.til_graphics[ input.tile_index ] );
+                    
+                    result_r[0].x = static_cast<double>(primary.shading & 0xFC) * SHADING_VALUE;
+                    result_r[0].y = result_r[0].x;
+                    result_r[0].z = result_r[0].x;
+                    
+                    uint8_t second = ((primary.shading & 0x03) << 4) | TilResource::DynamicMonoGraphics( input.til_graphics[ input.tile_index + 1] ).second_lower;
+                    result_r[1].x = static_cast<double>( second << 2 ) * SHADING_VALUE;
                     result_r[1].y = result_r[1].x;
                     result_r[1].z = result_r[1].x;
-                    result_r[2].x = static_cast<double>( TilResource::TileGraphics( input.til_graphics.at( (input.tile_index + 1) % input.til_graphics.size() ) ).getOtherShading() ) * SHADING_VALUE;
+                    
+                    result_r[2].x = static_cast<double>( TilResource::DynamicMonoGraphics( input.til_graphics[ input.tile_index + 1] ).third << 2 ) * SHADING_VALUE;
                     result_r[2].y = result_r[2].x;
                     result_r[2].z = result_r[2].x;
-                    result_r[3] = result_r[0];
+                    result_r[3].x = static_cast<double>( TilResource::DynamicMonoGraphics( input.til_graphics[ input.tile_index + 1] ).forth << 2 ) * SHADING_VALUE;
+                    result_r[3].y = result_r[3].x;
+                    result_r[3].z = result_r[3].x;
                 }
                 break;
             case 0b10: // Dynamic Color
@@ -101,7 +111,9 @@ unsigned int Data::Mission::Til::Colorizer::setSquareColors( const Input &input,
                     result_r[0] = accessColor( TilResource::TileGraphics( input.til_graphics.at( input.tile_index ) ).shading, input.colors );
                     result_r[1] = accessColor( TilResource::DynamicColorGraphics( input.til_graphics.at( input.tile_index + 1 ) ).second, input.colors );
                     result_r[2] = accessColor( TilResource::DynamicColorGraphics( input.til_graphics.at( input.tile_index + 1 ) ).third, input.colors );
-                    result_r[3] = accessColor( TilResource::DynamicColorGraphics( input.til_graphics.at( input.tile_index + 2 ) ).second, input.colors );
+                    
+                    // This shows that vertex colors are in fact optional.
+                    result_r[3] = accessColor( TilResource::DynamicColorGraphics( input.til_graphics.at( (input.tile_index + 2) % input.til_graphics.size() ) ).second, input.colors );
                 }
                 break;
             case 0b11: // Lava Animation

--- a/src/Data/Mission/Til/Colorizer.cpp
+++ b/src/Data/Mission/Til/Colorizer.cpp
@@ -7,38 +7,6 @@
 namespace {
 const double SHADING_VALUE = 0.0078125;
 
-Utilities::PixelFormatColor::GenericColor getColor(
-    Data::Mission::TilResource::TileGraphics tile,
-    const std::vector<Utilities::PixelFormatColor::GenericColor> &colors )
-{
-    Utilities::PixelFormatColor::GenericColor color = { 0, 0, 0, 1 };
-    
-    switch( tile.type ) {
-        case 0b00: // Solid Monochrome
-            {
-                color.setValue( static_cast<double>( tile.shading ) * SHADING_VALUE );
-            }
-        case 0b01: // Dynamic Monochrome
-            {
-                color.setValue( static_cast<double>( tile.shading & 0xFC ) * SHADING_VALUE );
-            }
-            break;
-        case 0b10: // Dynamic Color
-            {
-                if( !colors.empty() )
-                    color = colors.at( tile.shading % colors.size() );
-            }
-            break;
-        case 0b11: // Lava Animation
-            {
-                color.red = 0.5;
-            }
-            break;
-    }
-    
-    return color;
-}
-
 glm::vec3 colorToVec3( Utilities::PixelFormatColor::GenericColor color )
 {
     glm::vec3 vertex_value;
@@ -59,15 +27,6 @@ glm::vec3 accessColor( uint8_t index, const std::vector<Utilities::PixelFormatCo
     return colorToVec3( color );
 }
 
-glm::vec3 getColorVec3(
-    Data::Mission::TilResource::TileGraphics tile,
-    const std::vector<Utilities::PixelFormatColor::GenericColor> &colors )
-{
-    Utilities::PixelFormatColor::GenericColor color = getColor( tile, colors );
-    
-    return colorToVec3( color );
-}
-
 }
 
 unsigned int Data::Mission::Til::Colorizer::setSquareColors( const Input &input, glm::vec3 *result_r )
@@ -77,7 +36,9 @@ unsigned int Data::Mission::Til::Colorizer::setSquareColors( const Input &input,
         switch( TilResource::TileGraphics( input.til_graphics[ input.tile_index ] ).type ) {
             case 0b00: // Solid Monochrome
                 {
-                    result_r[0] = getColorVec3( TilResource::TileGraphics( input.til_graphics[ input.tile_index ] ), input.colors );
+                    result_r[0].x = static_cast<double>(TilResource::TileGraphics( input.til_graphics[ input.tile_index ] ).shading) * SHADING_VALUE;
+                    result_r[0].y = result_r[0].x;
+                    result_r[0].z = result_r[0].x;
                     result_r[1] = result_r[0];
                     result_r[2] = result_r[0];
                     result_r[3] = result_r[0];

--- a/src/Data/Mission/Til/Colorizer.cpp
+++ b/src/Data/Mission/Til/Colorizer.cpp
@@ -70,8 +70,6 @@ glm::vec3 getColorVec3(
 
 }
 
-#ifdef FC_OPTION_EXPERIMENTAL_BLEND_COLORS
-
 unsigned int Data::Mission::Til::Colorizer::setSquareColors( const Input &input, glm::vec3 *result_r )
 {
     if( result_r != nullptr )
@@ -130,22 +128,3 @@ unsigned int Data::Mission::Til::Colorizer::setSquareColors( const Input &input,
     else
         return -1;
 }
-
-#else
-
-unsigned int Data::Mission::Til::Colorizer::setSquareColors( const Input &input, glm::vec3 *result_r )
-{
-    if( result_r != nullptr )
-    {
-        result_r[0] = getColorVec3( input.til_graphics[ input.tile_index ], input.colors );
-        result_r[1] = result_r[0];
-        result_r[2] = result_r[0];
-        result_r[3] = result_r[0];
-        
-        return 1;
-    }
-    else
-        return -1;
-}
-
-#endif

--- a/src/Data/Mission/Til/Colorizer.h
+++ b/src/Data/Mission/Til/Colorizer.h
@@ -13,16 +13,11 @@ namespace Colorizer {
 
     struct Input {
         const std::vector<Utilities::PixelFormatColor::GenericColor> &colors;
-        const TilResource::ColorMap &color_map;
-        const std::vector<TilResource::TileGraphics> &til_graphics;
+        const std::vector<uint16_t> &til_graphics;
         unsigned tile_index;
         int unk;
         glm::u8vec3 position;
     };
-
-    Utilities::PixelFormatColor::GenericColor getColor( Data::Mission::TilResource::TileGraphics tile, const std::vector<Utilities::PixelFormatColor::GenericColor> &colors );
-
-    glm::vec3 getColorVec3( Data::Mission::TilResource::TileGraphics tile, const std::vector<Utilities::PixelFormatColor::GenericColor> &colors );
 
     /**
      * Set the colors for the square.

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -128,10 +128,6 @@ public:
                 ((uint16_t)rectangle << 13) |
                 ((uint16_t)type << 14);
         }
-        
-        uint8_t getOtherShading() const {
-            return (texture_index) | (unknown_0 << 3) | (rectangle << 5) | (type << 6);
-        }
     };
     
     static constexpr size_t AMOUNT_OF_TILES = 16;

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -71,6 +71,36 @@ public:
             graphics_type_index = (bitfield >> 22) & ((1 << 10) - 1);
         }
     };
+    struct DynamicMonoGraphics {
+        uint16_t forth : 6;
+        uint16_t third : 6;
+        uint16_t second_lower : 4;
+        
+        DynamicMonoGraphics() {}
+        DynamicMonoGraphics( const uint16_t bitfield ) {
+            set( bitfield );
+        }
+        
+        void set( const uint16_t bitfield ) {
+            forth        = (bitfield >>  0) & ((1 << 6) - 1);
+            third        = (bitfield >>  6) & ((1 << 6) - 1);
+            second_lower = (bitfield >> 12) & ((1 << 4) - 1);
+        }
+    };
+    struct DynamicColorGraphics {
+        uint16_t third  : 8;
+        uint16_t second : 8;
+        
+        DynamicColorGraphics() {}
+        DynamicColorGraphics( const uint16_t bitfield ) {
+            set( bitfield );
+        }
+        
+        void set( const uint16_t bitfield ) {
+            third  = (bitfield >>  0) & ((1 << 8) - 1);
+            second = (bitfield >>  8) & ((1 << 8) - 1);
+        }
+    };
     struct TileGraphics {
         uint16_t shading : 8; // Lighting information, but they do change meaning depending type bitfield
         uint16_t texture_index : 3; // Holds the index of the texture the tile references.
@@ -91,21 +121,17 @@ public:
             type           = (bitfield >> 14) & ((1 << 2) - 1);
         }
         
+        uint16_t get() const {
+            return ((uint16_t)shading << 0) |
+                ((uint16_t)texture_index << 8) |
+                ((uint16_t)unknown_0 << 11) |
+                ((uint16_t)rectangle << 13) |
+                ((uint16_t)type << 14);
+        }
+        
         uint8_t getOtherShading() const {
             return (texture_index) | (unknown_0 << 3) | (rectangle << 5) | (type << 6);
         }
-    };
-    class ColorMap {
-    private:
-        Utilities::GridBase2D<TileGraphics> map;
-    public:
-        ColorMap();
-        
-        Utilities::PixelFormatColor::GenericColor getColor( glm::u8vec3 position, const std::vector<Utilities::PixelFormatColor::GenericColor>& colors ) const;
-        void gatherColors(
-            const std::vector<TileGraphics>& tile_graphics,
-            const Tile *const tiles_r, unsigned number,
-            glm::u8vec2 position );
     };
     
     static constexpr size_t AMOUNT_OF_TILES = 16;
@@ -130,8 +156,7 @@ private:
 
     std::vector<glm::u8vec2> texture_cords; // They contain the UV's for the tiles, they are often read as quads
     std::vector<Utilities::PixelFormatColor::GenericColor> colors;
-    std::vector<TileGraphics> tile_texture_type;
-    ColorMap color_map;
+    std::vector<uint16_t> tile_graphics_bitfield;
     
     std::string texture_names[8]; // There can only be 2*2*2 or 8 texture names;
     

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -154,6 +154,8 @@ private:
     std::vector<Utilities::PixelFormatColor::GenericColor> colors;
     std::vector<uint16_t> tile_graphics_bitfield;
     
+    uint32_t slfx_bitfield;
+    
     std::string texture_names[8]; // There can only be 2*2*2 or 8 texture names;
     
     std::vector<Utilities::Collision::Triangle> all_triangles; // This stores all the triangles in the Til Resource.


### PR DESCRIPTION
The compiling option FC_OPTION_EXPERIMENTAL_BLEND_COLORS has been removed because now my project can read the vertex color data more correctly.

I also reverted SDL2 to a previous version, because the other one is causing problems.

![screenshot](https://user-images.githubusercontent.com/101094904/221348000-09dd3792-ddcf-4747-a4c3-0915be309544.jpg)
