### PR TITLE
Transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Open Source Game Engine Project
 * [Thanks](#thanks)
 
 ## About
-This is an **_incomplete_** re-implementation attempt of the [Future Cop: LAPD][fcop-lapd-wikipedia-link] game, developed by Visceral Games (named **EA Redwod Shores** at the time) and released in 1998 for the PlayStation, Mac OS and Windows platforms.
+This is an **_incomplete_** re-implementation attempt of the [Future Cop: LAPD][fcop-lapd-wikipedia-link] game, developed by Visceral Games (named **EA Redwood Shores** at the time) and released in 1998 for the PlayStation, Mac OS and Windows platforms.
 
 [fcop-lapd-wikipedia-link]: https://en.wikipedia.org/wiki/Future_Cop:_LAPD "Wikipiedia article about the game"
 
@@ -37,7 +37,7 @@ Right now there is no gameplay yet. However, there is a map viewer that can disp
 ## System Requirements
 There are no clearly defined system requirements at this time, however the project's aim is to run on very low spec computers by today standards (but not on the original computers that ran Future Cop when it was released). This should encompass most of today's devices, as the project successful compiled on a Raspberry PI 4.
 
-Although another aim is to create portable code, this code will not work on the PlayStation 1 due to its lack of C++11 support - as developing for C99 would be harder with the constant worry of memory management. However, the code might be able to run on the Raspberry PI Nano.
+Although another aim is to create portable code, this code will not work on the PlayStation 1 due to its lack of C++17 support - as developing for C99 would be harder with the constant worry of memory management. However, the code might be able to run on the Raspberry PI Zero.
 
 ## Original game data
 All these tools (and the actual game when ready) require the presence of the original game data in order to function.
@@ -260,7 +260,7 @@ This is list of exported resource formats and the corresponding internal format 
 
 * BahKooJ for various information about Future Cop.
 
-* Killermosi for improving most of the parameter system.
+* Killermosi for improving most of the terminal parameter system.
 
 ### Libraries
 

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -368,7 +368,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                     TextureQuad* texture_quad_r = nullptr;
 
                     if( !texture_quads.empty() )
-                        texture_quad_r = &texture_quads.at(triangle_quad_index);
+                        texture_quad_r = &texture_quads.at(triangle_quad_index % texture_quads.size()); // TODO Investigate workaround.
 
                     /*
                     // Add to the indexes of this texture to the list when it is not contained in the data base.

--- a/src/Data/Mission/Til/TileSet.h
+++ b/src/Data/Mission/Til/TileSet.h
@@ -411,9 +411,9 @@ Data::Mission::Til::Mesh::Polygon default_mesh[POLYGON_COUNT] = {
     },
     { // 45
         {
+             {Data::Mission::Til::Mesh::FRONT_LEFT, Data::Mission::Til::Mesh::RED},
              {Data::Mission::Til::Mesh::BACK_LEFT, Data::Mission::Til::Mesh::GREEN},
              {Data::Mission::Til::Mesh::FRONT_RIGHT, Data::Mission::Til::Mesh::GREEN},
-             {Data::Mission::Til::Mesh::FRONT_LEFT, Data::Mission::Til::Mesh::RED},
              {Data::Mission::Til::Mesh::FRONT_LEFT, Data::Mission::Til::Mesh::NO_ELEMENT}
         },
         false

--- a/src/FCMapViewer.cpp
+++ b/src/FCMapViewer.cpp
@@ -329,6 +329,8 @@ int main(int argc, char** argv)
         delete environment_p;
         return -4;
     }
+
+    bool update_culling = false;
     
     auto til_resources = Data::Mission::TilResource::getVector( *resource_r );
     
@@ -465,6 +467,12 @@ int main(int argc, char** argv)
                     }
                 }
             }
+
+            input_r = player_1_controller_r->getInput( Controls::StandardInputSet::Buttons::JUMP );
+            if( input_r->isChanged() && input_r->getState() > 0.5 )
+            {
+                update_culling = !update_culling;
+            }
         }
 
         if( control_cursor_r != nullptr && control_cursor_r->isChanged() )
@@ -541,6 +549,9 @@ int main(int argc, char** argv)
             text_2d_buffer_r->setPosition( glm::vec2( 0, 80 ) );
             text_2d_buffer_r->print( "Ctil Offset = " + std::to_string( til_resources.at(current_tile_selected)->getOffset() ) );
         }
+
+        if( update_culling )
+            environment_p->setupFrame();
 
         environment_p->drawFrame();
         environment_p->advanceTime( delta_f );

--- a/src/Graphics/Camera.cpp
+++ b/src/Graphics/Camera.cpp
@@ -143,6 +143,8 @@ std::vector<glm::vec3> generateCubeData( glm::vec3 scale, glm::vec3 center = glm
 }
 }
 
+#include <iostream>
+
 Utilities::Collision::GJKPolyhedron Graphics::Camera::getProjection3DShape() const {
     auto projection = generateCubeData( glm::vec3( 1, 1, 1 ), glm::vec3( 0, 0, 0 ) );
 
@@ -155,6 +157,12 @@ Utilities::Collision::GJKPolyhedron Graphics::Camera::getProjection3DShape() con
         projection[ i ].x = value.x * scale;
         projection[ i ].y = value.y * scale;
         projection[ i ].z = value.z * scale;
+
+        std::ostringstream out;
+        std::cout.precision(16);
+        out << std::fixed;
+
+        std::cout << "camera_data[" << i << "] = glm::vec3( " << projection[ i ].x << "," << projection[ i ].y << " ," << projection[ i ].z << " );" << std::endl;
     }
 
     return Utilities::Collision::GJKPolyhedron( projection );

--- a/src/Graphics/Camera.cpp
+++ b/src/Graphics/Camera.cpp
@@ -125,3 +125,26 @@ int Graphics::Camera::removeText2DBuffer( Graphics::Text2DBuffer* buffer_p ) {
 
     return erased_value;
 }
+
+namespace {
+std::vector<glm::vec3> generateCubeData( glm::vec3 scale, glm::vec3 center = glm::vec3(0,0,0) ) {
+    std::vector<glm::vec3> cube_data;
+
+    cube_data.push_back( glm::vec3( -scale.x, -scale.y, -scale.z ) + center );
+    cube_data.push_back( glm::vec3(  scale.x, -scale.y, -scale.z ) + center );
+    cube_data.push_back( glm::vec3( -scale.x,  scale.y, -scale.z ) + center );
+    cube_data.push_back( glm::vec3(  scale.x,  scale.y, -scale.z ) + center );
+    cube_data.push_back( glm::vec3( -scale.x, -scale.y,  scale.z ) + center );
+    cube_data.push_back( glm::vec3(  scale.x, -scale.y,  scale.z ) + center );
+    cube_data.push_back( glm::vec3( -scale.x,  scale.y,  scale.z ) + center );
+    cube_data.push_back( glm::vec3(  scale.x,  scale.y,  scale.z ) + center );
+
+    return cube_data;
+}
+}
+
+Utilities::Collision::GJKPolyhedron Graphics::Camera::getProjection3DShape() const {
+    Utilities::Collision::GJKPolyhedron camera_polyhedron( generateCubeData( glm::vec3( 32, 32, 96), glm::vec3( 96, 0, 108) ) );
+
+    return camera_polyhedron;
+}

--- a/src/Graphics/Camera.cpp
+++ b/src/Graphics/Camera.cpp
@@ -144,7 +144,18 @@ std::vector<glm::vec3> generateCubeData( glm::vec3 scale, glm::vec3 center = glm
 }
 
 Utilities::Collision::GJKPolyhedron Graphics::Camera::getProjection3DShape() const {
-    Utilities::Collision::GJKPolyhedron camera_polyhedron( generateCubeData( glm::vec3( 32, 32, 96 ), glm::vec3( 96, 0, 112 ) ) );
+    auto projection = generateCubeData( glm::vec3( 1, 1, 1 ), glm::vec3( 0, 0, 0 ) );
 
-    return camera_polyhedron;
+    glm::mat4 inverse = glm::inverse( PV3D );
+
+    for( size_t i = 0; i < projection.size(); i++ ) {
+        auto value = inverse * glm::vec4( projection[ i ], 1 );
+        auto scale = 1.0f / value.w;
+
+        projection[ i ].x = value.x * scale;
+        projection[ i ].y = value.y * scale;
+        projection[ i ].z = value.z * scale;
+    }
+
+    return Utilities::Collision::GJKPolyhedron( projection );
 }

--- a/src/Graphics/Camera.cpp
+++ b/src/Graphics/Camera.cpp
@@ -157,12 +157,6 @@ Utilities::Collision::GJKPolyhedron Graphics::Camera::getProjection3DShape() con
         projection[ i ].x = value.x * scale;
         projection[ i ].y = value.y * scale;
         projection[ i ].z = value.z * scale;
-
-        std::ostringstream out;
-        std::cout.precision(16);
-        out << std::fixed;
-
-        std::cout << "camera_data[" << i << "] = glm::vec3( " << projection[ i ].x << "," << projection[ i ].y << " ," << projection[ i ].z << " );" << std::endl;
     }
 
     return Utilities::Collision::GJKPolyhedron( projection );

--- a/src/Graphics/Camera.cpp
+++ b/src/Graphics/Camera.cpp
@@ -144,7 +144,7 @@ std::vector<glm::vec3> generateCubeData( glm::vec3 scale, glm::vec3 center = glm
 }
 
 Utilities::Collision::GJKPolyhedron Graphics::Camera::getProjection3DShape() const {
-    Utilities::Collision::GJKPolyhedron camera_polyhedron( generateCubeData( glm::vec3( 32, 32, 96), glm::vec3( 96, 0, 108) ) );
+    Utilities::Collision::GJKPolyhedron camera_polyhedron( generateCubeData( glm::vec3( 32, 32, 96 ), glm::vec3( 96, 0, 112 ) ) );
 
     return camera_polyhedron;
 }

--- a/src/Graphics/Camera.h
+++ b/src/Graphics/Camera.h
@@ -3,6 +3,7 @@
 
 #include "Text2DBuffer.h"
 #include "../Utilities/DataTypes.h"
+#include "../Utilities/Collision/GJKShape.h"
 #include <glm/vec2.hpp>
 #include <glm/mat4x4.hpp>
 #include <vector>
@@ -41,7 +42,7 @@ protected:
     void updatePV2D();
 
 public:
-    std::vector<float> culling_info;
+    std::vector<float> culling_info; // Only graphic
 
     Camera();
     virtual ~Camera();
@@ -163,6 +164,18 @@ public:
      * @return true if the buffer is found and deleted.
      */
     int removeText2DBuffer( Text2DBuffer* buffer_p );
+
+    /**
+     * This sets up the 3D culling data structure that this camera has.
+     * @note Only graphics should invoke this.
+     */
+    void updateCulling();
+
+    /**
+     * This gets the 3D camera shape from the projection matrix.
+     * @note This might actually be useful for gameplay purposes.
+     */
+    Utilities::Collision::GJKShape getProjection3DShape() const;
 };
 
 }

--- a/src/Graphics/Camera.h
+++ b/src/Graphics/Camera.h
@@ -166,12 +166,6 @@ public:
     int removeText2DBuffer( Text2DBuffer* buffer_p );
 
     /**
-     * This sets up the 3D culling data structure that this camera has.
-     * @note Only graphics should invoke this.
-     */
-    void updateCulling();
-
-    /**
      * This gets the 3D camera shape from the projection matrix.
      * @note This might actually be useful for gameplay purposes.
      */

--- a/src/Graphics/Camera.h
+++ b/src/Graphics/Camera.h
@@ -41,6 +41,8 @@ protected:
     void updatePV2D();
 
 public:
+    std::vector<float> culling_info;
+
     Camera();
     virtual ~Camera();
 

--- a/src/Graphics/Camera.h
+++ b/src/Graphics/Camera.h
@@ -3,7 +3,7 @@
 
 #include "Text2DBuffer.h"
 #include "../Utilities/DataTypes.h"
-#include "../Utilities/Collision/GJKShape.h"
+#include "../Utilities/Collision/GJKPolyhedron.h"
 #include <glm/vec2.hpp>
 #include <glm/mat4x4.hpp>
 #include <vector>
@@ -169,7 +169,7 @@ public:
      * This gets the 3D camera shape from the projection matrix.
      * @note This might actually be useful for gameplay purposes.
      */
-    Utilities::Collision::GJKShape getProjection3DShape() const;
+    Utilities::Collision::GJKPolyhedron getProjection3DShape() const;
 };
 
 }

--- a/src/Graphics/Environment.h
+++ b/src/Graphics/Environment.h
@@ -117,6 +117,11 @@ public:
     virtual int setTilPolygonBlink( unsigned polygon_type, float rate = 1.0f) = 0;
 
     /**
+     * Setup the draw graph for the renderer.
+     */
+    virtual void setupFrame() = 0;
+
+    /**
      * Draw a single frame onto the main context.
      */
     virtual void drawFrame() const = 0;

--- a/src/Graphics/SDL2/GLES2/Environment.cpp
+++ b/src/Graphics/SDL2/GLES2/Environment.cpp
@@ -240,9 +240,13 @@ void Environment::drawFrame() const {
             {
                 // Enable culling on the world map.
                 glEnable( GL_CULL_FACE );
+
+                std::vector<bool> culling_info( this->world_p->getNumberSections(), true );
+
+                this->world_p->updateCulling( culling_info );
                 
                 // Draw the map.
-                this->world_p->draw( *current_camera );
+                this->world_p->draw( *current_camera, &culling_info );
                 
                 // Disable culling on the world map.
                 glDisable( GL_CULL_FACE );

--- a/src/Graphics/SDL2/GLES2/Environment.cpp
+++ b/src/Graphics/SDL2/GLES2/Environment.cpp
@@ -241,7 +241,7 @@ void Environment::drawFrame() const {
                 // Enable culling on the world map.
                 glEnable( GL_CULL_FACE );
 
-                std::vector<bool> culling_info( this->world_p->getNumberSections(), true );
+                std::vector<float> culling_info( this->world_p->getNumberSections(), 1 );
 
                 this->world_p->updateCulling( culling_info );
                 

--- a/src/Graphics/SDL2/GLES2/Environment.cpp
+++ b/src/Graphics/SDL2/GLES2/Environment.cpp
@@ -244,7 +244,9 @@ void Environment::drawFrame() const {
                 if( current_camera->culling_info.empty() )
                     current_camera->culling_info = std::vector<float>( this->world_p->getNumberSections(), 1 );
 
-                this->world_p->updateCulling( current_camera->culling_info );
+                auto projection_shape = current_camera->getProjection3DShape();
+
+                this->world_p->updateCulling( current_camera->culling_info, projection_shape );
                 
                 // Draw the map.
                 this->world_p->draw( *current_camera, &current_camera->culling_info );

--- a/src/Graphics/SDL2/GLES2/Environment.cpp
+++ b/src/Graphics/SDL2/GLES2/Environment.cpp
@@ -206,6 +206,24 @@ int Environment::setTilPolygonBlink( unsigned polygon_type, float rate ) {
         return -1; // The world_p needs allocating first!
 }
 
+void Environment::setupFrame() {
+    for( unsigned int i = 0; i < window_p->getCameras()->size(); i++ )
+    {
+        // Setup the current camera.
+        auto current_camera_r = window_p->getCameras()->at( i );
+
+        if( current_camera_r != nullptr && this->world_p != nullptr )
+        {
+            if( current_camera_r->culling_info.empty() )
+                current_camera_r->culling_info = std::vector<float>( this->world_p->getNumberSections(), 1 );
+
+            auto projection_shape = current_camera_r->getProjection3DShape();
+
+            this->world_p->updateCulling( current_camera_r->culling_info, projection_shape );
+        }
+    }
+}
+
 void Environment::drawFrame() const {
     auto window_r =  window_p;
     
@@ -240,16 +258,12 @@ void Environment::drawFrame() const {
             {
                 // Enable culling on the world map.
                 glEnable( GL_CULL_FACE );
-
-                if( current_camera->culling_info.empty() )
-                    current_camera->culling_info = std::vector<float>( this->world_p->getNumberSections(), 1 );
-
-                auto projection_shape = current_camera->getProjection3DShape();
-
-                this->world_p->updateCulling( current_camera->culling_info, projection_shape );
                 
                 // Draw the map.
-                this->world_p->draw( *current_camera, &current_camera->culling_info );
+                if( current_camera->culling_info.empty() )
+                    this->world_p->draw( *current_camera );
+                else
+                    this->world_p->draw( *current_camera, &current_camera->culling_info );
                 
                 // Disable culling on the world map.
                 glDisable( GL_CULL_FACE );

--- a/src/Graphics/SDL2/GLES2/Environment.cpp
+++ b/src/Graphics/SDL2/GLES2/Environment.cpp
@@ -241,12 +241,13 @@ void Environment::drawFrame() const {
                 // Enable culling on the world map.
                 glEnable( GL_CULL_FACE );
 
-                std::vector<float> culling_info( this->world_p->getNumberSections(), 1 );
+                if( current_camera->culling_info.empty() )
+                    current_camera->culling_info = std::vector<float>( this->world_p->getNumberSections(), 1 );
 
-                this->world_p->updateCulling( culling_info );
+                this->world_p->updateCulling( current_camera->culling_info );
                 
                 // Draw the map.
-                this->world_p->draw( *current_camera, &culling_info );
+                this->world_p->draw( *current_camera, &current_camera->culling_info );
                 
                 // Disable culling on the world map.
                 glDisable( GL_CULL_FACE );

--- a/src/Graphics/SDL2/GLES2/Environment.h
+++ b/src/Graphics/SDL2/GLES2/Environment.h
@@ -42,6 +42,7 @@ public:
     virtual size_t getTilAmount() const;
     virtual int setTilBlink( unsigned til_index, float seconds );
     virtual int setTilPolygonBlink( unsigned polygon_type, float rate = 1.0f);
+    virtual void setupFrame();
     virtual void drawFrame() const;
     virtual bool screenshot( Utilities::Image2D &image ) const;
     virtual void advanceTime( float seconds_passed );

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -198,14 +198,9 @@ bool Graphics::SDL2::GLES2::Internal::World::updateCulling( std::vector<float> &
         return false;
     }
 
-    // Clear the sections.
-    for( size_t i = 0; i < culling_info.size(); i++ ) {
-        culling_info[i] = -1.0f;
-    }
-
     std::vector<glm::vec3> section_data( 8, glm::vec3() );
-    const glm::vec3 MIN = glm::vec3(0,-16,0);
-    const glm::vec3 MAX = glm::vec3( Data::Mission::TilResource::AMOUNT_OF_TILES, 16, Data::Mission::TilResource::AMOUNT_OF_TILES );
+    const glm::vec3 MIN = glm::vec3(0, Data::Mission::TilResource::MAX_HEIGHT, 0);
+    const glm::vec3 MAX = glm::vec3( Data::Mission::TilResource::AMOUNT_OF_TILES, Data::Mission::TilResource::MIN_HEIGHT, Data::Mission::TilResource::AMOUNT_OF_TILES );
 
     for( auto m : tiles ) {
         for( auto s : m.sections ) {
@@ -225,8 +220,9 @@ bool Graphics::SDL2::GLES2::Internal::World::updateCulling( std::vector<float> &
             section_data[7] = glm::vec3( max.x, max.y, max.z );
 
             Utilities::Collision::GJKPolyhedron section_shape( section_data );
+            size_t limit = 16;
 
-            if( Utilities::Collision::GJK::hasCollision( projection, section_shape ) ) {
+            if( Utilities::Collision::GJK::hasCollision( projection, section_shape, limit ) ) {
                 culling_info[ s.camera_visable_index ] = 1.0f;
             }
             else

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -237,7 +237,7 @@ bool Graphics::SDL2::GLES2::Internal::World::updateCulling( std::vector<float> &
             out << std::fixed;
 
             out << "Error Limit reached at " << "(" << min.x << ", " << min.y << ", "  << min.z << ") ";
-            out << "(" << max.x << ", " << max.y << ", " << max.z << ") ";
+            out << "(" << max.x << ", " << max.y << ", " << max.z << ") " << projection.toString();
 
             if( limit == 0 ) throw std::runtime_error( out.str() );
         }

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -6,18 +6,16 @@
 #include <glm/ext/matrix_transform.hpp>
 #include "SDL.h"
 #include <iostream>
-#include <stdexcept>
 
 const GLchar* Graphics::SDL2::GLES2::Internal::World::default_vertex_shader =
     // Vertex shader uniforms
     "uniform mat4  Transform;\n" // projection * view * model.
     "uniform float GlowTime;\n"
     "uniform float SelectedTile;\n"
-    "uniform float Blueness;\n"
 
     "void main()\n"
     "{\n"
-    "   vertex_colors = COLOR_0 * vec3(Blueness, Blueness, 1.0 );\n"
+    "   vertex_colors = COLOR_0;\n"
     "   texture_coord_1 = TEXCOORD_0;\n"
     "   _flashing = GlowTime * float(SelectedTile > _TileType - 0.5 && SelectedTile < _TileType + 0.5);\n"
     "   gl_Position = Transform * vec4(POSITION.xyz, 1.0);\n"
@@ -222,22 +220,12 @@ bool Graphics::SDL2::GLES2::Internal::World::updateCulling( std::vector<float> &
             section_data[7] = glm::vec3( max.x, max.y, max.z );
 
             Utilities::Collision::GJKPolyhedron section_shape( section_data );
-            size_t limit = 128;
 
-            if( Utilities::Collision::GJK::hasCollision( projection, section_shape, limit ) ) {
-                culling_info[ s.camera_visable_index ] = 1.0f;
-            }
-            else if( limit == 0 )
-                culling_info[ s.camera_visable_index ] = -0.25f;
-            else
+            if( Utilities::Collision::GJK::hasCollision( projection, section_shape ) == Utilities::Collision::GJK::NO_COLLISION ) {
                 culling_info[ s.camera_visable_index ] = -1.0f;
-
-            std::ostringstream out;
-
-            out << "Error Limit reached at " << "(" << min.x << ", " << min.y << ", "  << min.z << ") ";
-            out << "(" << max.x << ", " << max.y << ", " << max.z << ")\n" << projection.toString();
-
-            if( limit == 0 ) throw std::runtime_error( out.str() );
+            }
+            else
+                culling_info[ s.camera_visable_index ] = 1.0f;
         }
     }
 
@@ -251,8 +239,6 @@ void Graphics::SDL2::GLES2::Internal::World::draw( const Graphics::Camera &camer
     program.use();
 
     camera.getProjectionView3D( projection_view );
-
-    const auto blueness_uniform_id = program.getUniform( "Blueness" );
     
     if( this->glow_time > 1.0f )
         glUniform1f( glow_time_uniform_id, 2.0f - this->glow_time );
@@ -270,12 +256,6 @@ void Graphics::SDL2::GLES2::Internal::World::draw( const Graphics::Camera &camer
         if( (*i).current >= 0.0 )
         for( unsigned int d = 0; d < (*i).sections.size(); d++ ) {
             if( culling_info_r == nullptr || (*culling_info_r)[ (*i).sections[d].camera_visable_index ] >= -0.5 ) {
-
-                if( culling_info_r != nullptr && (*culling_info_r)[ (*i).sections[d].camera_visable_index ] < 0.0 )
-                    glUniform1f( blueness_uniform_id, 0.0f );
-                else
-                    glUniform1f( blueness_uniform_id, 1.0f );
-
                 final_position = glm::translate( projection_view, glm::vec3( (((*i).sections[d].position.x * Data::Mission::TilResource::AMOUNT_OF_TILES + Data::Mission::TilResource::SPAN_OF_TIL) + TILE_SPAN), 0, (((*i).sections[d].position.y * Data::Mission::TilResource::AMOUNT_OF_TILES + Data::Mission::TilResource::SPAN_OF_TIL) + TILE_SPAN) ) );
 
                 // We can now send the matrix to the program.

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -6,6 +6,7 @@
 #include <glm/ext/matrix_transform.hpp>
 #include "SDL.h"
 #include <iostream>
+#include <stdexcept>
 
 const GLchar* Graphics::SDL2::GLES2::Internal::World::default_vertex_shader =
     // Vertex shader uniforms
@@ -221,7 +222,7 @@ bool Graphics::SDL2::GLES2::Internal::World::updateCulling( std::vector<float> &
             section_data[7] = glm::vec3( max.x, max.y, max.z );
 
             Utilities::Collision::GJKPolyhedron section_shape( section_data );
-            size_t limit = 16;
+            size_t limit = 128;
 
             if( Utilities::Collision::GJK::hasCollision( projection, section_shape, limit ) ) {
                 culling_info[ s.camera_visable_index ] = 1.0f;
@@ -230,6 +231,15 @@ bool Graphics::SDL2::GLES2::Internal::World::updateCulling( std::vector<float> &
                 culling_info[ s.camera_visable_index ] = -0.25f;
             else
                 culling_info[ s.camera_visable_index ] = -1.0f;
+
+            std::ostringstream out;
+            out.precision(16);
+            out << std::fixed;
+
+            out << "Error Limit reached at " << "(" << min.x << ", " << min.y << ", "  << min.z << ") ";
+            out << "(" << max.x << ", " << max.y << ", " << max.z << ") ";
+
+            if( limit == 0 ) throw std::runtime_error( out.str() );
         }
     }
 

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -211,11 +211,12 @@ void Graphics::SDL2::GLES2::Internal::World::draw( const Graphics::Camera &camer
     }
 
      // TODO Add culling logic! camera should be modified to have collision boxes of the Ctils and a projection shape to check if the projection box intersects with the camera.
+     const float TILE_SPAN = 0.5;
 
     for( auto i = tiles.begin(); i != tiles.end(); i++ ) {
         if( (*i).current >= 0.0 )
         for( unsigned int d = 0; d < (*i).sections.size(); d++ ) {
-            final_position = glm::translate( projection_view, glm::vec3( ((*i).sections[d].position.x * 16 + 8.5), 0, ((*i).sections[d].position.y * 16  + 8.5) ) );
+            final_position = glm::translate( projection_view, glm::vec3( (((*i).sections[d].position.x * Data::Mission::TilResource::AMOUNT_OF_TILES + Data::Mission::TilResource::SPAN_OF_TIL) + TILE_SPAN), 0, (((*i).sections[d].position.y * Data::Mission::TilResource::AMOUNT_OF_TILES + Data::Mission::TilResource::SPAN_OF_TIL) + TILE_SPAN) ) );
 
             // We can now send the matrix to the program.
             glUniformMatrix4fv( matrix_uniform_id, 1, GL_FALSE, reinterpret_cast<const GLfloat*>( &final_position[0][0] ) );

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -233,11 +233,9 @@ bool Graphics::SDL2::GLES2::Internal::World::updateCulling( std::vector<float> &
                 culling_info[ s.camera_visable_index ] = -1.0f;
 
             std::ostringstream out;
-            out.precision(16);
-            out << std::fixed;
 
             out << "Error Limit reached at " << "(" << min.x << ", " << min.y << ", "  << min.z << ") ";
-            out << "(" << max.x << ", " << max.y << ", " << max.z << ") " << projection.toString();
+            out << "(" << max.x << ", " << max.y << ", " << max.z << ")\n" << projection.toString();
 
             if( limit == 0 ) throw std::runtime_error( out.str() );
         }

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -123,7 +123,7 @@ public:
      * @param projection The projection shape to make the culling info from.
      * @return true if culling has successfully been setup.
      */
-    bool updateCulling( std::vector<bool> &culling_info, const Utilities::Collision::GJKShape *projection_r = nullptr ) const;
+    bool updateCulling( std::vector<float> &culling_info, const Utilities::Collision::GJKShape *projection_r = nullptr ) const;
 
     /**
      * This draws the entire map.
@@ -131,7 +131,7 @@ public:
      * @param camera This is the camera data to be passed into world.
      * @param culling_info The culling information that would affect the World.
      */
-    void draw( const Camera &camera, const std::vector<bool> *const culling_info_r = nullptr );
+    void draw( const Camera &camera, const std::vector<float> *const culling_info_r = nullptr );
 
     /**
      * @return the program that this World uses.

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -123,7 +123,7 @@ public:
      * @param projection The projection shape to make the culling info from.
      * @return true if culling has successfully been setup.
      */
-    bool updateCulling( std::vector<float> &culling_info, const Utilities::Collision::GJKShape *projection_r = nullptr ) const;
+    bool updateCulling( std::vector<float> &culling_info, const Utilities::Collision::GJKShape &projection ) const;
 
     /**
      * This draws the entire map.

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -5,6 +5,7 @@
 #include "../../../Camera.h"
 #include "../../../../Data/Mission/PTCResource.h"
 #include "../../../../Data/Mission/TilResource.h"
+#include "../../../../Utilities/Collision/GJKShape.h"
 
 namespace Graphics {
 namespace SDL2 {
@@ -111,11 +112,26 @@ public:
     void setWorld( const Data::Mission::PTCResource &pointer_tile_cluster, const std::vector<Data::Mission::TilResource*> resources_til, const std::map<uint32_t, Internal::Texture2D*>& textures );
 
     /**
+     * @return The number of drawable sections in this world.
+     */
+    uint32_t getNumberSections() const { return valid_sections; }
+
+    /**
+     * Update Culling for the camera.
+     * @note This will change the parameter culling_info.
+     * @param culling_info The boolean vector that will hold culling information for the World.
+     * @param projection The projection shape to make the culling info from.
+     * @return true if culling has successfully been setup.
+     */
+    bool updateCulling( std::vector<bool> &culling_info, const Utilities::Collision::GJKShape *projection_r = nullptr ) const;
+
+    /**
      * This draws the entire map.
      * @note Make sure setFragmentShader, loadFragmentShader, compilieProgram and setWorld in this order are called SUCCESSFULLY.
-     * @param This is the camera data to be passed into world.
+     * @param camera This is the camera data to be passed into world.
+     * @param culling_info The culling information that would affect the World.
      */
-    void draw( const Camera &camera );
+    void draw( const Camera &camera, const std::vector<bool> *const culling_info_r = nullptr );
 
     /**
      * @return the program that this World uses.

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -20,13 +20,17 @@ namespace Internal {
  */
 class World {
 public:
-    class MeshDraw {
-    public:
+    struct MeshDraw {
+        struct Section {
+            glm::i32vec2 position;
+            uint32_t camera_visable_index;
+        };
+
         Mesh *mesh_p;
         const Data::Mission::TilResource *til_resource_r;
         float change_rate;
         float current; // [ -change_rate, change_rate ]
-        std::vector<glm::i32vec2> positions;
+        std::vector<Section> sections;
     };
     static const GLchar* default_vertex_shader;
     static const GLchar* default_fragment_shader;
@@ -41,6 +45,7 @@ protected:
     GLuint glow_time_uniform_id;
     GLuint selected_tile_uniform_id;
     std::vector<MeshDraw> tiles;
+    uint32_t valid_sections;
     
     GLfloat selected_tile;
     GLfloat current_selected_tile;

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -22,12 +22,11 @@ class World {
 public:
     class MeshDraw {
     public:
-        Mesh *mesh;
-        const Data::Mission::TilResource *tilResourceR;
+        Mesh *mesh_p;
+        const Data::Mission::TilResource *til_resource_r;
         float change_rate;
         float current; // [ -change_rate, change_rate ]
-        unsigned int positions_amount;
-        glm::i32vec2 *positions;
+        std::vector<glm::i32vec2> positions;
     };
     static const GLchar* default_vertex_shader;
     static const GLchar* default_fragment_shader;

--- a/src/Tests/Utilities/Collision/GJK.cpp
+++ b/src/Tests/Utilities/Collision/GJK.cpp
@@ -161,19 +161,30 @@ void sayProblem( int width, int height, glm::vec3 position_of_camera, glm::vec2 
 int stressTest( Random::Generator &general ) {
     int status = SUCCESS;
 
-    auto camera_data = generateCubeData( glm::vec3( 1, 1, 1 ), glm::vec3( 0, 0, 0 ) );
+    std::vector<glm::vec3> camera_data(8);
 
-    GJKPolyhedron cube_shape( camera_data );
+    camera_data[0] = glm::vec3( 127.6480636596679688, 3.1758630275726318, 60.8731765747070312 );
+    camera_data[1] = glm::vec3( 127.5414276123046875, 3.1758630275726318, 60.7715873718261719 );
+    camera_data[2] = glm::vec3( 127.6340255737304688, 3.2561616897583008, 60.8879165649414062 );
+    camera_data[3] = glm::vec3( 127.5273895263671875, 3.2561612129211426, 60.7863273620605469 );
+    camera_data[4] = glm::vec3( 114.6178359985351562, -126.2063064575195312, 287.9737854003906250 );
+    camera_data[5] = glm::vec3( -98.6433944702148438, -126.2067489624023438, 84.7968063354492188 );
+    camera_data[6] = glm::vec3( 86.5334472656250000, 34.3913993835449219, 317.4512329101562500 );
+    camera_data[7] = glm::vec3( -126.7258300781250000, 34.3909606933593750, 114.2761077880859375 );
 
     int width;
     int height;
     glm::vec3 position_of_camera;
     glm::vec2 rotation;
     float distance_away;
+
+    /*
     glm::mat4 projection_matrix;
     glm::mat4 extra_matrix_0;
     glm::mat4 extra_matrix_1;
     glm::mat4 extra_matrix_2;
+
+    GJKPolyhedron cube_shape( camera_data );
 
     width = general.nextUnsignedInt() % 3520 + 320;
     height = general.nextUnsignedInt() % 1808 + 240;
@@ -194,8 +205,8 @@ int stressTest( Random::Generator &general ) {
     extra_matrix_1 = glm::translate( glm::mat4(1.0f), -position_of_camera );
     extra_matrix_2 = extra_matrix_0 * extra_matrix_1;
 
-    glm::mat4 inverse = glm::inverse( projection_matrix * extra_matrix_2 );
-    auto camera_shape = GJKPolyhedron( cube_shape, inverse );
+    glm::mat4 inverse = glm::inverse( projection_matrix * extra_matrix_2 );*/
+    auto camera_shape = GJKPolyhedron( camera_data );
 
     for( int x = 0; x < 14 && status != FAILURE; x++ ) {
         for( int y = 0; y < 16 && status != FAILURE; y++ ) {

--- a/src/Tests/Utilities/Collision/GJK.cpp
+++ b/src/Tests/Utilities/Collision/GJK.cpp
@@ -144,27 +144,40 @@ int main() {
 
     // This tests for the bug to hopefully fix.
     {
-        GJKPolyhedron camera_shape( generateCubeData( glm::vec3( 32, 32, 32 ), glm::vec3( 96, 0, 108 ) ) );
+        std::vector<glm::vec3> camera_data( 8, glm::vec3() );
+        camera_data[0] = glm::vec3( 69.21285247802734,5.121590614318848 ,155.7484283447266 );
+        camera_data[1] = glm::vec3( 69.07632446289062,5.121588706970215 ,155.8036193847656 );
+        camera_data[2] = glm::vec3( 69.22514343261719,5.197661399841309 ,155.7788391113281 );
+        camera_data[3] = glm::vec3( 69.08860778808594,5.197659492492676 ,155.8340301513672 );
+        camera_data[4] = glm::vec3( 262.2105712890625,-150.0403594970703 ,240.3976745605469 );
+        camera_data[5] = glm::vec3( -10.86629772186279,-150.0435638427734 ,350.7831726074219 );
+        camera_data[6] = glm::vec3( 286.7877197265625,2.108406543731689 ,301.203857421875 );
+        camera_data[7] = glm::vec3( 13.71085262298584,2.105211734771729 ,411.58935546875 );
+
+
+        GJKPolyhedron camera_shape( camera_data );
 
         std::vector<glm::vec3> section_data( 8, glm::vec3() );
-        glm::vec3 min(48, -16, 0);
-        glm::vec3 max(64, 16, 16);
+        {
+            glm::vec3 min( 64,  6, 144 );
+            glm::vec3 max( 80, -6, 160 );
 
-        section_data[0] = glm::vec3( min.x, min.y, min.z );
-        section_data[1] = glm::vec3( max.x, min.y, min.z );
-        section_data[2] = glm::vec3( min.x, max.y, min.z );
-        section_data[3] = glm::vec3( max.x, max.y, min.z );
-        section_data[4] = glm::vec3( min.x, min.y, max.z );
-        section_data[5] = glm::vec3( max.x, min.y, max.z );
-        section_data[6] = glm::vec3( min.x, max.y, max.z );
-        section_data[7] = glm::vec3( max.x, max.y, max.z );
-
+            section_data[0] = glm::vec3( min.x, min.y, min.z );
+            section_data[1] = glm::vec3( max.x, min.y, min.z );
+            section_data[2] = glm::vec3( min.x, max.y, min.z );
+            section_data[3] = glm::vec3( max.x, max.y, min.z );
+            section_data[4] = glm::vec3( min.x, min.y, max.z );
+            section_data[5] = glm::vec3( max.x, min.y, max.z );
+            section_data[6] = glm::vec3( min.x, max.y, max.z );
+            section_data[7] = glm::vec3( max.x, max.y, max.z );
+        }
         GJKPolyhedron section_shape( section_data );
 
         size_t limit = 2048;
 
-        if( !GJK::hasCollision(camera_shape, section_shape, limit) ) {
-            std::cout << "The problematic shape would not collide!" << std::endl;
+        if( GJK::hasCollision(camera_shape, section_shape, limit) ) {
+            std::cout << "The problematic shape should collide!" << std::endl;
+            std::cout << "Limit = " << limit << std::endl;
             status = FAILURE;
         }
 

--- a/src/Tests/Utilities/Collision/GJK.cpp
+++ b/src/Tests/Utilities/Collision/GJK.cpp
@@ -132,6 +132,55 @@ int quaderentTest( int x, int y, int z ) {
 int main() {
     int status = SUCCESS;
 
+    // This tests for the bug to hopefully fix.
+    {
+        std::vector<glm::vec3> camera_data( 8, glm::vec3() );
+        camera_data[0] = glm::vec3( 145.9847106933594,3.178083181381226 ,143.4626617431641 );
+        camera_data[1] = glm::vec3( 145.8795318603516,3.178083419799805 ,143.5657501220703 );
+        camera_data[2] = glm::vec3( 146.0030975341797,3.099510431289673 ,143.4814300537109 );
+        camera_data[3] = glm::vec3( 145.8979187011719,3.099510669708252 ,143.5845184326172 );
+        camera_data[4] = glm::vec3( 100.0131454467773,18.33088302612305 ,-113.711311340332 );
+        camera_data[5] = glm::vec3( -110.3445205688477,18.33116912841797 ,92.482666015625 );
+        camera_data[6] = glm::vec3( 136.7857360839844,-138.8161010742188 ,-76.196533203125 );
+        camera_data[7] = glm::vec3( -73.57000732421875,-138.8158111572266 ,129.9955596923828 );
+
+
+        GJKPolyhedron camera_shape( camera_data );
+
+        for( int x = 0; x < 14; x++ ) {
+            for( int y = 0; y < 16; y++ ) {
+                std::vector<glm::vec3> section_data( 8, glm::vec3() );
+
+                glm::vec3 min(     x * 16,  6,     y * 16 );
+                glm::vec3 max( min.x + 16, -6, min.y + 16 );
+
+                section_data[0] = glm::vec3( min.x, min.y, min.z );
+                section_data[1] = glm::vec3( max.x, min.y, min.z );
+                section_data[2] = glm::vec3( min.x, max.y, min.z );
+                section_data[3] = glm::vec3( max.x, max.y, min.z );
+                section_data[4] = glm::vec3( min.x, min.y, max.z );
+                section_data[5] = glm::vec3( max.x, min.y, max.z );
+                section_data[6] = glm::vec3( min.x, max.y, max.z );
+                section_data[7] = glm::vec3( max.x, max.y, max.z );
+
+                GJKPolyhedron section_shape( section_data );
+
+                size_t limit = 128;
+
+                if( !GJK::hasCollision(camera_shape, section_shape, limit) ) {
+                    std::cout << "The problematic shape should collide!" << std::endl;
+                    std::cout << "Limit = " << limit << std::endl;
+                    status = FAILURE;
+                }
+
+                if( limit == 0 ) {
+                    std::cout << "The limit is reached for extermely simple shapes who have about 16 vertices." << std::endl;
+                    status = FAILURE;
+                }
+            }
+        }
+    }
+
     // This is very slow, but it would test every quaderent.
     // As it is it will run insideTest and outsideTest about 729 times.
     for( int x = -1; x <= 1 && status == SUCCESS; x++) {
@@ -139,51 +188,6 @@ int main() {
             for( int z = -1; z <= 1 && status == SUCCESS; z++) {
                 status |= quaderentTest(x, y, z);
             }
-        }
-    }
-
-    // This tests for the bug to hopefully fix.
-    {
-        std::vector<glm::vec3> camera_data( 8, glm::vec3() );
-        camera_data[0] = glm::vec3( 69.21285247802734,5.121590614318848 ,155.7484283447266 );
-        camera_data[1] = glm::vec3( 69.07632446289062,5.121588706970215 ,155.8036193847656 );
-        camera_data[2] = glm::vec3( 69.22514343261719,5.197661399841309 ,155.7788391113281 );
-        camera_data[3] = glm::vec3( 69.08860778808594,5.197659492492676 ,155.8340301513672 );
-        camera_data[4] = glm::vec3( 262.2105712890625,-150.0403594970703 ,240.3976745605469 );
-        camera_data[5] = glm::vec3( -10.86629772186279,-150.0435638427734 ,350.7831726074219 );
-        camera_data[6] = glm::vec3( 286.7877197265625,2.108406543731689 ,301.203857421875 );
-        camera_data[7] = glm::vec3( 13.71085262298584,2.105211734771729 ,411.58935546875 );
-
-
-        GJKPolyhedron camera_shape( camera_data );
-
-        std::vector<glm::vec3> section_data( 8, glm::vec3() );
-        {
-            glm::vec3 min( 64,  6, 144 );
-            glm::vec3 max( 80, -6, 160 );
-
-            section_data[0] = glm::vec3( min.x, min.y, min.z );
-            section_data[1] = glm::vec3( max.x, min.y, min.z );
-            section_data[2] = glm::vec3( min.x, max.y, min.z );
-            section_data[3] = glm::vec3( max.x, max.y, min.z );
-            section_data[4] = glm::vec3( min.x, min.y, max.z );
-            section_data[5] = glm::vec3( max.x, min.y, max.z );
-            section_data[6] = glm::vec3( min.x, max.y, max.z );
-            section_data[7] = glm::vec3( max.x, max.y, max.z );
-        }
-        GJKPolyhedron section_shape( section_data );
-
-        size_t limit = 2048;
-
-        if( GJK::hasCollision(camera_shape, section_shape, limit) ) {
-            std::cout << "The problematic shape should collide!" << std::endl;
-            std::cout << "Limit = " << limit << std::endl;
-            status = FAILURE;
-        }
-
-        if( limit == 0 ) {
-            std::cout << "The limit is reached for extermely simple shapes who have about 16 vertices." << std::endl;
-            status = FAILURE;
         }
     }
 

--- a/src/Tests/Utilities/Collision/GJK.cpp
+++ b/src/Tests/Utilities/Collision/GJK.cpp
@@ -67,23 +67,22 @@ int outsideTest( int x, int y, int z, const GJKShape &shape, std::string name, g
     GJKPolyhedron tetrahedron_outside( generateTetrahedronData( position + displacement ) );
     GJKPolyhedron triangle_outside( generateTriangleData( position + displacement ) );
 
-    if( GJK::hasCollision(shape, cube_outside) ) {
+    if( GJK::hasCollision(shape, cube_outside) == GJK::COLLISION ) {
         std::cout << "Cube did collide outside " << name << std::endl;
-        displayVec3( "v", position, std::cout );
-        displayVec3( "d", displacement, std::cout );
         status = FAILURE;
     }
-    if( GJK::hasCollision(shape, tetrahedron_outside) ) {
+    if( GJK::hasCollision(shape, tetrahedron_outside) == GJK::COLLISION ) {
         std::cout << "Tetrahedron did collide outside " << name << std::endl;
-        displayVec3( "v", position, std::cout );
-        displayVec3( "d", displacement, std::cout );
         status = FAILURE;
     }
-    if( GJK::hasCollision(shape, triangle_outside) ) {
+    if( GJK::hasCollision(shape, triangle_outside) == GJK::COLLISION ) {
         std::cout << "Triangle did collide outside " << name << std::endl;
+        status = FAILURE;
+    }
+
+    if( status == FAILURE ) {
         displayVec3( "v", position, std::cout );
         displayVec3( "d", displacement, std::cout );
-        status = FAILURE;
     }
 
     return status;
@@ -97,25 +96,24 @@ int insideTest( int x, int y, int z, const GJKShape &shape, std::string name, gl
     GJKPolyhedron tetrahedron_inside( generateTetrahedronData( position + displacement ) );
     GJKPolyhedron triangle_inside( generateTriangleData( position + displacement ) );
 
-    if( !GJK::hasCollision(shape, cube_inside) ) {
+    if( GJK::hasCollision(shape, cube_inside) == GJK::NO_COLLISION ) {
         std::cout << "Cube did not collide inside " << name << std::endl;
-        displayVec3( "v", position, std::cout );
-        displayVec3( "d", displacement, std::cout );
         status = FAILURE;
     }
 
-    if( !GJK::hasCollision(shape, tetrahedron_inside) ) {
+    if( GJK::hasCollision(shape, tetrahedron_inside) == GJK::NO_COLLISION ) {
         std::cout << "Tetrahedron did not collide inside " << name << std::endl;
-        displayVec3( "v", position, std::cout );
-        displayVec3( "d", displacement, std::cout );
         status = FAILURE;
     }
 
-    if( !GJK::hasCollision(shape, triangle_inside) ) {
+    if( GJK::hasCollision(shape, triangle_inside) == GJK::NO_COLLISION ) {
         std::cout << "Triangle did not collide inside " << name << std::endl;
+        status = FAILURE;
+    }
+
+    if( status == FAILURE ) {
         displayVec3( "v", position, std::cout );
         displayVec3( "d", displacement, std::cout );
-        status = FAILURE;
     }
 
     return status;
@@ -226,12 +224,8 @@ int stressTest( Random::Generator &general ) {
 
             GJKPolyhedron section_shape( section_data );
 
-            size_t limit = 128;
-
             // Its status is not important. Just detect if it got stuck.
-            GJK::hasCollision(camera_shape, section_shape, limit);
-
-            if( limit == 0 ) {
+            if( GJK::hasCollision(camera_shape, section_shape, 128) == GJK::NOT_DETERMINED ) {
                 sayProblem( width, height, position_of_camera, rotation, distance_away );
                 status = FAILURE;
             }

--- a/src/Tests/Utilities/Collision/GJK.cpp
+++ b/src/Tests/Utilities/Collision/GJK.cpp
@@ -96,18 +96,21 @@ int insideTest( int x, int y, int z, const GJKShape &shape, std::string name, gl
     if( !GJK::hasCollision(shape, cube_inside) ) {
         std::cout << "Cube did not collide inside " << name << std::endl;
         displayVec3( "v", position, std::cout );
+        displayVec3( "d", displacement, std::cout );
         status = FAILURE;
     }
 
     if( !GJK::hasCollision(shape, tetrahedron_inside) ) {
         std::cout << "Tetrahedron did not collide inside " << name << std::endl;
         displayVec3( "v", position, std::cout );
+        displayVec3( "d", displacement, std::cout );
         status = FAILURE;
     }
 
     if( !GJK::hasCollision(shape, triangle_inside) ) {
         std::cout << "Triangle did not collide inside " << name << std::endl;
         displayVec3( "v", position, std::cout );
+        displayVec3( "d", displacement, std::cout );
         status = FAILURE;
     }
 

--- a/src/Tests/Utilities/Collision/GJK.cpp
+++ b/src/Tests/Utilities/Collision/GJK.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <random> // Used in the stress test using the Random device.
 #include <thread> // Definitely used in this stress test.
+#include <ctime>
 
 #include "Helper.h"
 
@@ -302,6 +303,7 @@ int main( int argc, char* argv[] ) {
 
         std::cout << "How Many threads do you want for this stress test. Enter 0 for all that is available in the system." << std::endl;
 
+        std::cout << "Threads: ";
         std::cin >> number_of_threads;
 
         if( number_of_threads == 0 )
@@ -312,13 +314,15 @@ int main( int argc, char* argv[] ) {
 
         int tminutes = 2;
 
-        std::cout << "How many minutes do you want this test to run on your computer. Note: The worst cause for speed is that GJK never halts." << std::endl;
+        std::cout << "\nHow many minutes do you want this test to run on your computer. Note: The worst cause for speed is that GJK never halts. Warning: If you do not want to run this stress test then you can simply enter 0 in the minutes and this program will exit." << std::endl;
 
-        std::cout << "\nWarning: If you do not want to run this stress test then you can simply enter 0 in the minutes and this program will exit." << std::endl;
-
+        std::cout << "Minutes: ";
         std::cin >> tminutes;
 
         const auto starting_time = high_resolution_clock::now();
+
+        const auto system_time = std::chrono::system_clock::to_time_t(starting_time);
+        std::cout << "Started test at " << std::ctime(&system_time) << std::endl;
 
         if( tminutes == 0 ) {
             return 0; // Exit the program.
@@ -331,14 +335,32 @@ int main( int argc, char* argv[] ) {
                 }
             ) );
         }
+
+        uint64_t total_times_on_threads = 0;
+
         for( size_t i = 0; i < number_of_threads; i++ ) {
             threads[i].join();
             std::cout << "Times run on thread " << i << " is " << map_views[ i ] << std::endl;
+            total_times_on_threads += map_views[ i ];
         }
 
-        auto current_time = high_resolution_clock::now();
+        std::cout << "Total Times Run on Thread = " << total_times_on_threads << std::endl;
 
-        std::cout << "Minutes run = " << duration_cast<minutes>(current_time - starting_time).count() << std::endl;
+        const auto current_time = high_resolution_clock::now();
+        const auto min_ran = duration_cast<minutes>(current_time - starting_time).count();
+
+        std::cout << "Minutes run = " << min_ran << std::endl;
+
+        const auto runs_per_minute = total_times_on_threads / min_ran;
+
+        std::cout << "Runs per minute = " << runs_per_minute << std::endl;
+
+        const double runs_per_second = static_cast<double>(runs_per_minute) / 60.0;
+
+        std::cout << "Runs per second = " << runs_per_second << std::endl;
+
+        const auto end_system_time = std::chrono::system_clock::to_time_t(current_time);
+        std::cout << "Ended test at " << std::ctime(&end_system_time) << std::endl;
     }
 
     // This is very slow, but it would test every quaderent.

--- a/src/Tests/Utilities/Collision/GJK.cpp
+++ b/src/Tests/Utilities/Collision/GJK.cpp
@@ -157,13 +157,19 @@ int stressTest( Random::Generator &general ) {
 
     GJKPolyhedron cube_shape( camera_data );
 
+
+    int width;
+    int height;
     glm::vec3 position_of_camera;
     glm::vec2 rotation;
     float distance_away;
+    glm::mat4 projection_matrix;
     glm::mat4 extra_matrix_0;
     glm::mat4 extra_matrix_1;
-    glm::mat4 PV3D;
+    glm::mat4 extra_matrix_2;
 
+    width = general.nextUnsignedInt() % 3520 + 320;
+    height = general.nextUnsignedInt() % 1808 + 240;
     position_of_camera.x = general.nextFloat( 14 * 16, 0 );
     position_of_camera.y = 0;
     position_of_camera.z = general.nextFloat( 16 * 16, 0 );
@@ -171,15 +177,17 @@ int stressTest( Random::Generator &general ) {
     rotation.y = general.nextFloat( 7, 0 );
     distance_away = general.nextFloat( 100, -100 );
 
+    projection_matrix = glm::perspective( glm::pi<float>() / 4.0f, static_cast<float>(width) / static_cast<float>(height), 0.1f, 200.0f );
+
     extra_matrix_0 = glm::translate( glm::mat4(1.0f), glm::vec3( 0, 0, distance_away ) );
     extra_matrix_1 = glm::rotate( glm::mat4(1.0f), rotation.y, glm::vec3( 1.0, 0.0, 0.0 ) ); // rotate up and down.
-    PV3D           = extra_matrix_0 * extra_matrix_1;
+    extra_matrix_2 = extra_matrix_0 * extra_matrix_1;
     extra_matrix_1 = glm::rotate( glm::mat4(1.0f), rotation.x, glm::vec3( 0.0, 1.0, 0.0 ) ); // rotate left and right.
-    extra_matrix_0 = PV3D * extra_matrix_1;
+    extra_matrix_0 = extra_matrix_2 * extra_matrix_1;
     extra_matrix_1 = glm::translate( glm::mat4(1.0f), -position_of_camera );
-    PV3D           = extra_matrix_0 * extra_matrix_1;
+    extra_matrix_2 = extra_matrix_0 * extra_matrix_1;
 
-    glm::mat4 inverse = glm::inverse( PV3D );
+    glm::mat4 inverse = glm::inverse( projection_matrix * extra_matrix_2 );
     auto camera_shape = GJKPolyhedron( cube_shape, inverse );
 
     for( int x = 0; x < 14 && status != FAILURE; x++ ) {

--- a/src/Tests/Utilities/Collision/GJK.cpp
+++ b/src/Tests/Utilities/Collision/GJK.cpp
@@ -163,7 +163,7 @@ int main() {
 
         size_t limit = 2048;
 
-        if( GJK::hasCollision(camera_shape, section_shape, limit) ) {
+        if( !GJK::hasCollision(camera_shape, section_shape, limit) ) {
             std::cout << "The problematic shape would not collide!" << std::endl;
             status = FAILURE;
         }

--- a/src/Tests/Utilities/Collision/GJK.cpp
+++ b/src/Tests/Utilities/Collision/GJK.cpp
@@ -138,11 +138,12 @@ std::mutex say_guard;
 std::random_device random_device;
 std::mutex random_device_guard;
 
-void sayProblem( glm::vec3 position_of_camera, glm::vec2 rotation, float distance_away ) {
-
+void sayProblem( int width, int height, glm::vec3 position_of_camera, glm::vec2 rotation, float distance_away ) {
     say_guard.lock();
 
     std::cout << "This GJK algorithm broke at\n";
+    std::cout << "  width = " << width << "\n";
+    std::cout << "  height = " << height << "\n";
     std::cout << "  position = ( " << position_of_camera.x << ", " << position_of_camera.y << ", " << position_of_camera.z << " );\n";
     std::cout << "  rotation = ( " << rotation.x << ", " << rotation.y << " );\n";
     std::cout << "  distance_away = " << distance_away << std::endl;
@@ -156,7 +157,6 @@ int stressTest( Random::Generator &general ) {
     auto camera_data = generateCubeData( glm::vec3( 1, 1, 1 ), glm::vec3( 0, 0, 0 ) );
 
     GJKPolyhedron cube_shape( camera_data );
-
 
     int width;
     int height;
@@ -214,7 +214,7 @@ int stressTest( Random::Generator &general ) {
             GJK::hasCollision(camera_shape, section_shape, limit);
 
             if( limit == 0 ) {
-                sayProblem( position_of_camera, rotation, distance_away );
+                sayProblem( width, height, position_of_camera, rotation, distance_away );
                 status = FAILURE;
             }
         }

--- a/src/Utilities/Collision/GJK.cpp
+++ b/src/Utilities/Collision/GJK.cpp
@@ -192,13 +192,24 @@ bool GJK::hasCollision() {
     // Reset simplex.
     simplex_length = 0;
     SimplexStatus result = INCOMPLETE;
-    size_t limit_cycles = 0;
+
+    while( result == SimplexStatus::INCOMPLETE ) {
+        result = evolveSimplex();
+    }
+
+    return result == SimplexStatus::VALID;
+}
+
+bool GJK::hasCollision( size_t &limit ) {
+    // Reset simplex.
+    simplex_length = 0;
+    SimplexStatus result = INCOMPLETE;
 
     // TODO In certain situations this will get stuck.
     // Cell (3, 0) min(48, -16, 0) max(64, 16, 16) of ConFt if limit_cycles did not exist.
-    while( result == SimplexStatus::INCOMPLETE && limit_cycles < 32 ) {
+    while( result == SimplexStatus::INCOMPLETE && limit != 0 ) {
         result = evolveSimplex();
-        limit_cycles++;
+        limit--;
     }
 
     return result == SimplexStatus::VALID;
@@ -207,6 +218,11 @@ bool GJK::hasCollision() {
 bool GJK::hasCollision( const GJKShape &shape_0, const GJKShape &shape_1 ) {
     GJK collider( &shape_0, &shape_1 );
     return collider.hasCollision();
+}
+
+bool GJK::hasCollision( const GJKShape &shape_0, const GJKShape &shape_1,  size_t &limit ) {
+    GJK collider( &shape_0, &shape_1 );
+    return collider.hasCollision( limit );
 }
 
 // Thank you Winterdev.

--- a/src/Utilities/Collision/GJK.cpp
+++ b/src/Utilities/Collision/GJK.cpp
@@ -192,9 +192,13 @@ bool GJK::hasCollision() {
     // Reset simplex.
     simplex_length = 0;
     SimplexStatus result = INCOMPLETE;
+    size_t limit_cycles = 0;
 
-    while( result == SimplexStatus::INCOMPLETE ) {
+    // TODO In certain situations this will get stuck.
+    // Cell (3, 0) min(48, -16, 0) max(64, 16, 16) of ConFt if limit_cycles did not exist.
+    while( result == SimplexStatus::INCOMPLETE && limit_cycles < 32 ) {
         result = evolveSimplex();
+        limit_cycles++;
     }
 
     return result == SimplexStatus::VALID;

--- a/src/Utilities/Collision/GJK.cpp
+++ b/src/Utilities/Collision/GJK.cpp
@@ -64,9 +64,9 @@ bool GJK::line()
 
 bool GJK::triangle()
 {
-    const glm::vec3 &a = simplex[0];
-    const glm::vec3 &b = simplex[1];
-    const glm::vec3 &c = simplex[2];
+    const glm::vec3 a = simplex[0];
+    const glm::vec3 b = simplex[1];
+    const glm::vec3 c = simplex[2];
 
     const glm::vec3 ab = b - a;
     const glm::vec3 ac = c - a;

--- a/src/Utilities/Collision/GJK.cpp
+++ b/src/Utilities/Collision/GJK.cpp
@@ -213,7 +213,7 @@ GJK::GJKState GJK::hasCollision() {
     // Reset simplex.
     simplex_length = 0;
 
-    glm::vec3 support = getSupport( glm::vec3(0,0,1) );
+    glm::vec3 support = getSupport( glm::vec3(0,1,0) );
 
     simplex[0] = support;
     simplex_length++;
@@ -250,7 +250,7 @@ GJK::GJKState GJK::hasCollision() {
     return GJKState::NOT_DETERMINED;
 }
 
-bool GJK::hasCollision( const GJKShape &shape_0, const GJKShape &shape_1, unsigned limit ) {
+GJK::GJKState GJK::hasCollision( const GJKShape &shape_0, const GJKShape &shape_1, unsigned limit ) {
     GJK collider( &shape_0, &shape_1, limit );
     return collider.hasCollision();
 }
@@ -329,7 +329,7 @@ void addUniqueEdge(std::vector<Edge> &edges, const std::vector<uint_fast16_t> &f
 // reduce the number of allocations this makes.
 GJK::Depth GJK::getDepth( const GJKShape &shape_1, const GJKShape &shape_0, unsigned limit ) {
     Depth depth;
-    GJK gjk( &shape_0, &shape_1 );
+    GJK gjk( &shape_0, &shape_1, limit );
 
     depth.normal = glm::vec3( 0, 0, 0 );
     depth.depth  = 0.0;

--- a/src/Utilities/Collision/GJK.cpp
+++ b/src/Utilities/Collision/GJK.cpp
@@ -64,9 +64,9 @@ bool GJK::line()
 
 bool GJK::triangle()
 {
-    const glm::vec3 a = simplex[0];
-    const glm::vec3 b = simplex[1];
-    const glm::vec3 c = simplex[2];
+    const glm::vec3 &a = simplex[0];
+    const glm::vec3 &b = simplex[1];
+    const glm::vec3 c = simplex[2]; // This is not a reference for a reason.
 
     const glm::vec3 ab = b - a;
     const glm::vec3 ac = c - a;

--- a/src/Utilities/Collision/GJK.cpp
+++ b/src/Utilities/Collision/GJK.cpp
@@ -83,7 +83,7 @@ GJK::GJK( const GJKShape *const param_shape_0_r, const GJKShape *const param_sha
 GJK::~GJK() {}
 
 bool GJK::addSupport( glm::vec3 direction ) {
-    assert( SIMPLEX_LENGTH >= simplex_length );
+    assert( SIMPLEX_LENGTH > simplex_length );
 
     simplex[ simplex_length ] = shape_0_r->getSupport( direction ) - shape_1_r->getSupport( -direction );
     simplex_length++;
@@ -135,12 +135,12 @@ GJK::SimplexStatus GJK::evolveSimplex() {
         case 4:
         {
             // Calculate the three edges.
-            const glm::vec3 da = simplex[3] - simplex[0];
-            const glm::vec3 db = simplex[3] - simplex[1];
-            const glm::vec3 dc = simplex[3] - simplex[2];
+            const glm::vec3 da = simplex[1] - simplex[0];
+            const glm::vec3 db = simplex[2] - simplex[0];
+            const glm::vec3 dc = simplex[3] - simplex[0];
 
             // Make the direction to the origin.
-            const glm::vec3 d0 = -simplex[3];
+            const glm::vec3 d0 = -simplex[0];
 
             const glm::vec3 abd = glm::cross(da, db);
             const glm::vec3 bcd = glm::cross(db, dc);
@@ -205,8 +205,6 @@ bool GJK::hasCollision( size_t &limit ) {
     simplex_length = 0;
     SimplexStatus result = INCOMPLETE;
 
-    // TODO In certain situations this will get stuck.
-    // Cell (3, 0) min(48, -16, 0) max(64, 16, 16) of ConFt if limit_cycles did not exist.
     while( result == SimplexStatus::INCOMPLETE && limit != 0 ) {
         result = evolveSimplex();
         limit--;

--- a/src/Utilities/Collision/GJK.h
+++ b/src/Utilities/Collision/GJK.h
@@ -1,6 +1,7 @@
 #ifndef UTILITIES_COLLISON_GJK_H
 #define UTILITIES_COLLISON_GJK_H
 
+#include <array>
 #include "GJKShape.h"
 
 namespace Utilities {
@@ -8,7 +9,8 @@ namespace Collision {
 
 /**
  *
- * Thank You Hamaluik for the GJK tutorial. However, there are differences between this and Hamaluik's tutorial.
+ * Thank You Hamaluik and WinterDev for the GJK tutorials.
+ *
  */
 class GJK {
 public:
@@ -31,16 +33,20 @@ protected:
     const GJKShape *const shape_1_r;
     unsigned simplex_length;
     glm::vec3 direction;
-    glm::vec3 simplex[SIMPLEX_LENGTH];
+    std::array<glm::vec3, 4> simplex;
 
     SimplexStatus evolveSimplex();
 
+    static bool line( std::array<glm::vec3, 4> &simplex, unsigned &simplex_length, glm::vec3 &direction );
+    static bool triangle( std::array<glm::vec3, 4> &simplex, unsigned &simplex_length, glm::vec3 &direction );
+    static bool tetrahedron( std::array<glm::vec3, 4> &simplex, unsigned &simplex_length, glm::vec3 &direction );
+    bool nextSimplex();
+
+    glm::vec3 getSupport( glm::vec3 direction ) const;
     bool addSupport( glm::vec3 direction );
 public:
     GJK( const GJKShape *const shape_0_r, const GJKShape *const shape_1_r );
     virtual ~GJK();
-
-    static glm::vec3 tripleProduct( glm::vec3 a, glm::vec3 b, glm::vec3 c );
 
     bool hasCollision();
     bool hasCollision( size_t &limit ); // NOTE This is provisional

--- a/src/Utilities/Collision/GJK.h
+++ b/src/Utilities/Collision/GJK.h
@@ -43,8 +43,10 @@ public:
     static glm::vec3 tripleProduct( glm::vec3 a, glm::vec3 b, glm::vec3 c );
 
     bool hasCollision();
+    bool hasCollision( size_t &limit ); // NOTE This is provisional
 
     static bool hasCollision( const GJKShape &shape_0, const GJKShape &shape_1 );
+    static bool hasCollision( const GJKShape &shape_0, const GJKShape &shape_1,  size_t &limit ); // NOTE This is provisional
     static Depth getDepth( const GJKShape &shape_0, const GJKShape &shape_1 );
 };
 

--- a/src/Utilities/Collision/GJK.h
+++ b/src/Utilities/Collision/GJK.h
@@ -15,16 +15,23 @@ class GJK {
 public:
     // A 3D Simplex would only take up to 4 vertices.
     static constexpr size_t SIMPLEX_LENGTH = 4;
+    static constexpr unsigned DEFAULT_LIMIT = 32;
 
     struct Depth {
         glm::vec3 normal;
         float     depth;
         bool      has_collision;
     };
+    enum GJKState {
+        COLLISION      =  1,
+        NOT_DETERMINED =  0, // Timed out of limit.
+        NO_COLLISION   = -1,
+    };
 protected:
     const GJKShape *const shape_0_r;
     const GJKShape *const shape_1_r;
     unsigned simplex_length;
+    unsigned limit;
     glm::vec3 direction;
     glm::vec3 simplex[4];
 
@@ -37,15 +44,15 @@ protected:
     glm::vec3 getSupport( glm::vec3 direction ) const;
     bool addSupport( glm::vec3 direction );
 public:
-    GJK( const GJKShape *const shape_0_r, const GJKShape *const shape_1_r );
+    GJK( const GJKShape *const shape_0_r, const GJKShape *const shape_1_r, unsigned limit = DEFAULT_LIMIT );
     virtual ~GJK();
 
-    bool hasCollision();
-    bool hasCollision( size_t &limit ); // NOTE This is provisional
+    GJKState hasCollision();
 
-    static bool hasCollision( const GJKShape &shape_0, const GJKShape &shape_1 );
-    static bool hasCollision( const GJKShape &shape_0, const GJKShape &shape_1,  size_t &limit ); // NOTE This is provisional
-    static Depth getDepth( const GJKShape &shape_0, const GJKShape &shape_1 );
+    unsigned getLimit() const { return limit; }
+
+    static bool hasCollision( const GJKShape &shape_0, const GJKShape &shape_1, unsigned limit = DEFAULT_LIMIT );
+    static Depth getDepth( const GJKShape &shape_0, const GJKShape &shape_1, unsigned limit = DEFAULT_LIMIT );
 };
 
 }

--- a/src/Utilities/Collision/GJK.h
+++ b/src/Utilities/Collision/GJK.h
@@ -1,7 +1,6 @@
 #ifndef UTILITIES_COLLISON_GJK_H
 #define UTILITIES_COLLISON_GJK_H
 
-#include <array>
 #include "GJKShape.h"
 
 namespace Utilities {
@@ -27,11 +26,12 @@ protected:
     const GJKShape *const shape_1_r;
     unsigned simplex_length;
     glm::vec3 direction;
-    std::array<glm::vec3, 4> simplex;
+    glm::vec3 simplex[4];
 
-    static bool line( std::array<glm::vec3, 4> &simplex, unsigned &simplex_length, glm::vec3 &direction );
-    static bool triangle( std::array<glm::vec3, 4> &simplex, unsigned &simplex_length, glm::vec3 &direction );
-    static bool tetrahedron( std::array<glm::vec3, 4> &simplex, unsigned &simplex_length, glm::vec3 &direction );
+    inline bool line();
+    inline bool triangle();
+    inline bool tetrahedron();
+
     bool nextSimplex();
 
     glm::vec3 getSupport( glm::vec3 direction ) const;

--- a/src/Utilities/Collision/GJK.h
+++ b/src/Utilities/Collision/GJK.h
@@ -23,19 +23,11 @@ public:
         bool      has_collision;
     };
 protected:
-    enum SimplexStatus {
-        INVALID,
-        INCOMPLETE,
-        VALID
-    };
-
     const GJKShape *const shape_0_r;
     const GJKShape *const shape_1_r;
     unsigned simplex_length;
     glm::vec3 direction;
     std::array<glm::vec3, 4> simplex;
-
-    SimplexStatus evolveSimplex();
 
     static bool line( std::array<glm::vec3, 4> &simplex, unsigned &simplex_length, glm::vec3 &direction );
     static bool triangle( std::array<glm::vec3, 4> &simplex, unsigned &simplex_length, glm::vec3 &direction );

--- a/src/Utilities/Collision/GJK.h
+++ b/src/Utilities/Collision/GJK.h
@@ -51,7 +51,7 @@ public:
 
     unsigned getLimit() const { return limit; }
 
-    static bool hasCollision( const GJKShape &shape_0, const GJKShape &shape_1, unsigned limit = DEFAULT_LIMIT );
+    static GJKState hasCollision( const GJKShape &shape_0, const GJKShape &shape_1, unsigned limit = DEFAULT_LIMIT );
     static Depth getDepth( const GJKShape &shape_0, const GJKShape &shape_1, unsigned limit = DEFAULT_LIMIT );
 };
 

--- a/src/Utilities/Collision/GJKPolyhedron.cpp
+++ b/src/Utilities/Collision/GJKPolyhedron.cpp
@@ -1,5 +1,6 @@
 #include "GJKPolyhedron.h"
 
+#include <sstream>
 #include <stdexcept>
 
 namespace Utilities {
@@ -52,6 +53,18 @@ glm::vec3 GJKPolyhedron::getSupport( glm::vec3 direction ) const {
 
     // O(n) Complexity.
     return furthest_point;
+}
+
+std::string GJKPolyhedron::toString() const {
+    std::ostringstream out;
+    out.precision(16);
+    out << std::fixed;
+
+    for( auto i = array.begin(); i != array.end(); i++ ) {
+        out << "camera_data[" << (array.begin() - i) << "] = glm::vec3( " << (*i).x << "," << (*i).y << " ," << (*i).z << " );\n";
+    }
+
+    return out.str();
 }
 
 }

--- a/src/Utilities/Collision/GJKPolyhedron.cpp
+++ b/src/Utilities/Collision/GJKPolyhedron.cpp
@@ -17,7 +17,7 @@ GJKPolyhedron::GJKPolyhedron( const std::vector<glm::vec3> &param_array ) : arra
     center *= 1.0 / static_cast<float>( array.size() );
 }
 
-GJKPolyhedron::GJKPolyhedron( const GJKPolyhedron &gjk_polygon, const glm::mat4 &matrix ) : array(), center( glm::vec3(0, 0, 0) ) {
+GJKPolyhedron::GJKPolyhedron( const GJKPolyhedron &gjk_polygon, const glm::mat4 &matrix ) : array(gjk_polygon.array), center( glm::vec3(0, 0, 0) ) {
     for( auto element : gjk_polygon.array ) {
         glm::vec4 transformed = glm::vec4( element, 1) * matrix;
 

--- a/src/Utilities/Collision/GJKPolyhedron.cpp
+++ b/src/Utilities/Collision/GJKPolyhedron.cpp
@@ -61,7 +61,7 @@ std::string GJKPolyhedron::toString() const {
     out << std::fixed;
 
     for( auto i = array.begin(); i != array.end(); i++ ) {
-        out << "camera_data[" << (array.begin() - i) << "] = glm::vec3( " << (*i).x << "," << (*i).y << " ," << (*i).z << " );\n";
+        out << "camera_data[" << (i - array.begin()) << "] = glm::vec3( " << (*i).x << ", " << (*i).y << ", " << (*i).z << " );\n";
     }
 
     return out.str();

--- a/src/Utilities/Collision/GJKPolyhedron.cpp
+++ b/src/Utilities/Collision/GJKPolyhedron.cpp
@@ -38,11 +38,11 @@ glm::vec3 GJKPolyhedron::getCenter() const {
 glm::vec3 GJKPolyhedron::getSupport( glm::vec3 direction ) const {
     // Grab the first element in the array.
     glm::vec3 furthest_point = array[0];
-    float furthest_distance = glm::dot( array[0], direction );
+    float furthest_distance = glm::dot( array[0] - center, direction );
 
     // Then iterate through the rest of the points.
     for( auto i = array.begin() + 1; i < array.end(); i++ ) {
-        float new_distance = glm::dot( (*i), direction );
+        float new_distance = glm::dot( (*i) - center, direction );
 
         if( furthest_distance < new_distance ) {
             furthest_distance = new_distance;

--- a/src/Utilities/Collision/GJKPolyhedron.cpp
+++ b/src/Utilities/Collision/GJKPolyhedron.cpp
@@ -39,11 +39,11 @@ glm::vec3 GJKPolyhedron::getCenter() const {
 glm::vec3 GJKPolyhedron::getSupport( glm::vec3 direction ) const {
     // Grab the first element in the array.
     glm::vec3 furthest_point = array[0];
-    float furthest_distance = glm::dot( array[0] - center, direction );
+    float furthest_distance = glm::dot( array[0], direction );
 
     // Then iterate through the rest of the points.
     for( auto i = array.begin() + 1; i < array.end(); i++ ) {
-        float new_distance = glm::dot( (*i) - center, direction );
+        float new_distance = glm::dot( (*i), direction );
 
         if( furthest_distance < new_distance ) {
             furthest_distance = new_distance;

--- a/src/Utilities/Collision/GJKPolyhedron.h
+++ b/src/Utilities/Collision/GJKPolyhedron.h
@@ -22,6 +22,8 @@ public:
 
     virtual glm::vec3 getCenter() const;
     virtual glm::vec3 getSupport( glm::vec3 direction ) const;
+
+    std::string toString() const;
 };
 
 }

--- a/src/Utilities/Collision/GJKShape.h
+++ b/src/Utilities/Collision/GJKShape.h
@@ -1,6 +1,7 @@
 #ifndef UTILITIES_COLLISON_GJK_SHAPE_H
 #define UTILITIES_COLLISON_GJK_SHAPE_H
 
+#include <string>
 #include <glm/vec3.hpp>
 
 namespace Utilities {
@@ -13,6 +14,7 @@ public:
 
     virtual glm::vec3 getCenter() const = 0;
     virtual glm::vec3 getSupport( glm::vec3 direction ) const = 0;
+    virtual std::string toString() const = 0;
 };
 
 }


### PR DESCRIPTION
While I had not worked on the transparency yet, I made vast improvements to my engine. GJK got battle tested through my occlusion culling algorithm. I realize that turning each cell in a map into a cube then comparing it against a camera again and again might not be the most optimal solution.

- GJK got revised and is deemed to be "Stable"
- Occlusion Culling is implemented. However, only map sections are culled, so object models are still rendered. (This is very important to reduce the number of semi transparent triangles to sort.)
- Added a hidden feature to gjk_test which is compiled with the unit tests. It is a stress test for gjk complete with multithreading support.
- EPA is broken, but it is not used so it is not an issue yet.
- Minor fixes to the map's polygons.
- Fixed Long Beach Cobj crashing bug.