### PR TITLE
Logging for data

### DIFF
--- a/src/Data/Mission/ACT/Aircraft.cpp
+++ b/src/Data/Mission/ACT/Aircraft.cpp
@@ -54,7 +54,9 @@ Json::Value Data::Mission::ACT::Aircraft::makeJson() const {
 
 bool Data::Mission::ACT::Aircraft::readACTType( uint_fast8_t act_type, Utilities::Buffer::Reader &data_reader, Utilities::Buffer::Endian endian ) {
     assert(act_type == this->getTypeID());
-    assert(data_reader.totalSize() == this->getSize());
+
+    if( data_reader.totalSize() != this->getSize() )
+        return false;
     
     // TODO See if this is acurate information.
     internal.rotation = data_reader.readU32( endian );

--- a/src/Data/Mission/ACT/BaseTurret.cpp
+++ b/src/Data/Mission/ACT/BaseTurret.cpp
@@ -46,7 +46,9 @@ Json::Value Data::Mission::ACT::BaseTurret::makeJson() const {
 
 bool Data::Mission::ACT::BaseTurret::readACTType( uint_fast8_t act_type, Utilities::Buffer::Reader &data_reader, Utilities::Buffer::Endian endian ) {
     assert(act_type == this->getTypeID());
-    assert(data_reader.totalSize() == this->getSize());
+
+    if(data_reader.totalSize() != this->getSize())
+        return false;
     
     internal.rotation = data_reader.readU32( endian );
     internal.uint16_0 = data_reader.readU16( endian );

--- a/src/Data/Mission/ACT/Internal/Hash.cpp
+++ b/src/Data/Mission/ACT/Internal/Hash.cpp
@@ -6,8 +6,6 @@
 #include "../Skycaptin.h"
 #include "../Prop.h"
 
-#include <iostream>
-
 namespace {
 
 class Declaration {

--- a/src/Data/Mission/ACT/Prop.cpp
+++ b/src/Data/Mission/ACT/Prop.cpp
@@ -25,7 +25,9 @@ Json::Value Data::Mission::ACT::Prop::makeJson() const {
 
 bool Data::Mission::ACT::Prop::readACTType( uint_fast8_t act_type, Utilities::Buffer::Reader &data_reader, Utilities::Buffer::Endian endian ) {
     assert(act_type == this->getTypeID());
-    assert(data_reader.totalSize() == this->getSize());
+
+    if( data_reader.totalSize() != this->getSize() )
+        return false;
 
     internal.uint16_0 = data_reader.readU16( endian );
     internal.uint16_1 = data_reader.readU16( endian );

--- a/src/Data/Mission/ACT/Skycaptin.cpp
+++ b/src/Data/Mission/ACT/Skycaptin.cpp
@@ -64,7 +64,9 @@ Json::Value Data::Mission::ACT::Skycaptin::makeJson() const {
 
 bool Data::Mission::ACT::Skycaptin::readACTType( uint_fast8_t act_type, Utilities::Buffer::Reader &data_reader, Utilities::Buffer::Endian endian ) {
     assert(act_type == this->getTypeID());
-    assert(data_reader.totalSize() == this->getSize());
+
+    if(data_reader.totalSize() != this->getSize())
+        return false;
     
     internal.uint32_0 = data_reader.readU32( endian );
     internal.uint16_0 = data_reader.readU16( endian );

--- a/src/Data/Mission/ACT/Unknown.cpp
+++ b/src/Data/Mission/ACT/Unknown.cpp
@@ -2,8 +2,6 @@
 
 #include "Internal/Hash.h"
 
-#include <cassert>
-
 uint_fast16_t Data::Mission::ACT::Unknown::TYPE_ID = 0; // Zero is not used by any ACT types that future cop uses.
 
 bool Data::Mission::ACT::Unknown::readACTType( uint_fast8_t act_type, Utilities::Buffer::Reader &data_reader, Utilities::Buffer::Endian endian ) {

--- a/src/Data/Mission/ACT/X1Alpha.cpp
+++ b/src/Data/Mission/ACT/X1Alpha.cpp
@@ -27,7 +27,9 @@ Json::Value Data::Mission::ACT::X1Alpha::makeJson() const {
 
 bool Data::Mission::ACT::X1Alpha::readACTType( uint_fast8_t act_type, Utilities::Buffer::Reader &data_reader, Utilities::Buffer::Endian endian ) {
     assert(act_type == this->getTypeID());
-    assert(data_reader.totalSize() == this->getSize());
+
+    if(data_reader.totalSize() != this->getSize())
+        return false;
     
     internal.rotation_value = data_reader.readU32( endian );
     internal.uint16_0 = data_reader.readU16( endian );

--- a/src/Data/Mission/ACTManager.cpp
+++ b/src/Data/Mission/ACTManager.cpp
@@ -1,19 +1,20 @@
 #include "ACTManager.h"
 
-#include <cassert>
-
 Data::Mission::ACTManager::ACTManager() {}
 
 Data::Mission::ACTManager::~ACTManager() {}
 
-void Data::Mission::ACTManager::addACT( Data::Mission::ACTResource *act_r ) {
-    assert( act_r != nullptr );
+bool Data::Mission::ACTManager::addACT( Data::Mission::ACTResource *act_r ) {
+    if( act_r == nullptr )
+        return false;
+    if( act_type_map.find( act_r->getID() ) != act_type_map.end() )
+        return false;
 
     act_type_map[ act_r->getTypeID() ].push_back( act_r );
 
-    assert( act_type_map.find( act_r->getID() ) == act_type_map.end() );
-
     act_id_map[ act_r->getID() ] = act_r;
+
+    return true;
 }
 
 std::vector<Data::Mission::ACTResource*> Data::Mission::ACTManager::getACTs( uint_fast8_t type ) {

--- a/src/Data/Mission/ACTManager.h
+++ b/src/Data/Mission/ACTManager.h
@@ -22,7 +22,7 @@ public:
     ACTManager();
     virtual ~ACTManager();
 
-    void addACT( ACTResource *act_r );
+    bool addACT( ACTResource *act_r );
 
     std::vector<ACTResource*> getACTs( uint_fast8_t type );
     const std::vector<ACTResource*> getACTs( uint_fast8_t type ) const;

--- a/src/Data/Mission/ACTResource.cpp
+++ b/src/Data/Mission/ACTResource.cpp
@@ -79,7 +79,7 @@ Json::Value Data::Mission::ACTResource::makeJson() const {
 
 uint32_t Data::Mission::ACTResource::readACTChunk( Utilities::Buffer::Reader &data_reader, Utilities::Buffer::Endian endian, const ParseSettings &settings ) {
     auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
-    debug_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    debug_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     // std::cout << std::hex;
 
     // std::cout << "ACT_CHUNK_ID = " << ACT_CHUNK_ID << std::endl;

--- a/src/Data/Mission/ACTResource.cpp
+++ b/src/Data/Mission/ACTResource.cpp
@@ -80,24 +80,21 @@ Json::Value Data::Mission::ACTResource::makeJson() const {
 uint32_t Data::Mission::ACTResource::readACTChunk( Utilities::Buffer::Reader &data_reader, Utilities::Buffer::Endian endian, const ParseSettings &settings ) {
     auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
     debug_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
-    // std::cout << std::hex;
 
-    // std::cout << "ACT_CHUNK_ID = " << ACT_CHUNK_ID << std::endl;
+    debug_log.output << "ACT_CHUNK_ID = 0x" << ACT_CHUNK_ID << std::endl;
 
     if( !data_reader.empty() && ACT_CHUNK_ID == data_reader.readU32( endian ) ) // 0
     {
         uint32_t chunk_size = data_reader.readU32( endian ); // 4
 
-        // std::cout << "chunk_size = " << chunk_size << std::endl;
+        debug_log.output << "chunk_size = " << chunk_size << std::endl;
 
         this->matching_number = data_reader.readU32( endian );  // 8
 
-        // std::cout << "matching_number = " << matching_number << std::endl;
+        debug_log.output << "matching_number = " << matching_number << std::endl;
 
         const uint32_t ACT_SIZE = chunk_size - sizeof( uint32_t ) * 7;
         const uint_fast8_t act_type = data_reader.readU8(); // 12
-        
-        // std::cout << std::dec;
 
         //data_reader.setPosition( 3, Utilities::Buffer::Reader::CURRENT );
         data_reader.readU8(); // 13

--- a/src/Data/Mission/ACTResource.cpp
+++ b/src/Data/Mission/ACTResource.cpp
@@ -4,7 +4,6 @@
 #include "ACT/Unknown.h"
 
 #include <fstream>
-#include <cassert>
 
 #include <json/json.h>
 
@@ -79,6 +78,8 @@ Json::Value Data::Mission::ACTResource::makeJson() const {
 }
 
 uint32_t Data::Mission::ACTResource::readACTChunk( Utilities::Buffer::Reader &data_reader, Utilities::Buffer::Endian endian, const ParseSettings &settings ) {
+    auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
+    debug_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
     // std::cout << std::hex;
 
     // std::cout << "ACT_CHUNK_ID = " << ACT_CHUNK_ID << std::endl;
@@ -117,15 +118,15 @@ uint32_t Data::Mission::ACTResource::readACTChunk( Utilities::Buffer::Reader &da
         
         auto reader_act = data_reader.getReader( ACT_SIZE );
         
-        if( settings.output_level >= 3 && dynamic_cast<ACT::Unknown*>(this) == nullptr ) {
-            *settings.output_ref << getTypeIDName() << "; Resource ID: " << getResourceID() << "; Size: " << ACT_SIZE << std::endl;
+        if( dynamic_cast<ACT::Unknown*>(this) == nullptr ) {
+            debug_log.output << getTypeIDName() << "; Size: " << ACT_SIZE << "\n.";
         }
         
         bool processed = readACTType( act_type, reader_act, endian );
         assert( processed == true );
         
-        if( settings.output_level >= 3 && dynamic_cast<ACT::Unknown*>(this) != nullptr ) {
-            *settings.output_ref << getTypeIDName() << "; Resource ID: " << getResourceID() << "; Size: " << ACT_SIZE << std::endl;
+        if( dynamic_cast<ACT::Unknown*>(this) != nullptr ) {
+            debug_log.output << getTypeIDName() << "; Size: " << ACT_SIZE << "\n.";
         }
         
         return chunk_size;

--- a/src/Data/Mission/ANMResource.cpp
+++ b/src/Data/Mission/ANMResource.cpp
@@ -141,9 +141,9 @@ bool Data::Mission::ANMResource::noResourceID() const {
 
 bool Data::Mission::ANMResource::parse( const ParseSettings &settings ) {
     auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
-    debug_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    debug_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
-    error_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    error_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
     if( this->data_p != nullptr )
     {

--- a/src/Data/Mission/ANMResource.cpp
+++ b/src/Data/Mission/ANMResource.cpp
@@ -140,15 +140,17 @@ bool Data::Mission::ANMResource::noResourceID() const {
 }
 
 bool Data::Mission::ANMResource::parse( const ParseSettings &settings ) {
+    auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
+    debug_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
+    error_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+
     if( this->data_p != nullptr )
     {
         auto reader = this->data_p->getReader();
 
         size_t buffer_size = 0;
         bool file_is_not_valid = false;
-
-        if( settings.output_level >= 1 )
-            *settings.output_ref << "ANM: " << getIndexNumber() << std::endl;
 
         const auto FRAMES = reader.readU32( settings.endian );
 
@@ -182,22 +184,20 @@ bool Data::Mission::ANMResource::parse( const ParseSettings &settings ) {
                     }
                     else
                     {
-                        *settings.output_ref << "Failed to allocate for ANM data!" << std::endl;
+                        error_log.output << " ANM Failed to allocate for data!";
                         return false;
                     }
                 }
                 else
                 {
-                    if( settings.output_level >= 1 )
-                        *settings.output_ref << "Unexpected error: Image data not big enough!" << std::endl;
+                    error_log.output << " ANM Image data not big enough!";
                     return false;
                 }
             }
         }
         else
         {
-            if( settings.output_level >= 1 )
-                *settings.output_ref << "This file is not valid!" << std::endl;
+            error_log.output << " This ANM resource file is not valid!";
             return false;
         }
 

--- a/src/Data/Mission/DCSResource.cpp
+++ b/src/Data/Mission/DCSResource.cpp
@@ -1,5 +1,4 @@
 #include "DCSResource.h"
-#include <cassert>
 
 const std::string Data::Mission::DCSResource::FILE_EXTENSION = "dcs";
 const uint32_t    Data::Mission::DCSResource::IDENTIFIER_TAG = 0x43646373; // which is { 0x43, 0x64, 0x63, 0x73 } or { 'C', 'd', 'c', 's' } or "Cdcs"
@@ -19,6 +18,9 @@ uint32_t Data::Mission::DCSResource::getResourceTagID() const {
 }
 
 bool Data::Mission::DCSResource::parse( const ParseSettings &settings ) {
+    auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
+    warning_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
+
     const size_t  TAG_HEADER_SIZE = 2 * sizeof(uint32_t);
     const size_t NUM_ENTRIES_SIZE = sizeof(uint32_t);
     const size_t       ENTRY_SIZE = 8 * sizeof(uint8_t);
@@ -46,11 +48,15 @@ bool Data::Mission::DCSResource::parse( const ParseSettings &settings ) {
 
                     auto pad0 = reader.readU8();
                     auto pad1 = reader.readU8();
+
                     element.back().unk_5 = reader.readU8();
                     
-                    assert( pad0 == 0 );
-                    assert( pad1 == 0 );
-                    //assert( element.back().unk_5 == i + 1 );
+                    if( pad0 != 0 )
+                        warning_log.output << i << " pad0 is not zero, but " << std::dec << (unsigned)pad0 << ".\n";
+                    if( pad1 != 0 )
+                        warning_log.output << i << " pad1 is not zero, but " << std::dec << (unsigned)pad1 << ".\n";
+                    if( element.back().unk_5 != i + 1 )
+                        warning_log.output << i << " element.back().unk_5 is not " << std::dec << (i + 1) << ", but " << (unsigned)element.back().unk_5 << ".\n";
                 }
 
                 return true;

--- a/src/Data/Mission/FUNResource.cpp
+++ b/src/Data/Mission/FUNResource.cpp
@@ -28,8 +28,6 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
     const uint32_t TAG_tEXT = 0x74455854;
     // which is { 0x74, 0x45, 0x58, 0x54 } or { 't', 'E', 'X', 'T' } or "tEXT"
 
-    auto  info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
-    info_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
     debug_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
     
@@ -103,26 +101,26 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                         auto parameters = getFunctionParameters( i );
                         auto code = getFunctionCode( i );
                         
-                        info_log.output << "i[" << std::dec << i  << "], ";
-                        info_log.output << "f[" << functions.at( i ).faction << "], ";
-                        info_log.output << "id[" << functions.at( i ).identifier << "], ";
-                        info_log.output << "offset = " << functions.at( i ).start_parameter_offset << "\n" << std::endl;
+                        debug_log.output << "i[" << std::dec << i  << "], ";
+                        debug_log.output << "f[" << functions.at( i ).faction << "], ";
+                        debug_log.output << "id[" << functions.at( i ).identifier << "], ";
+                        debug_log.output << "offset = " << functions.at( i ).start_parameter_offset << "\n" << std::endl;
 
-                        info_log.output << std::hex << "Parameters = ";
+                        debug_log.output << std::hex << "Parameters = ";
                         for( auto f = parameters.begin(); f < parameters.end(); f++ ) {
-                            info_log.output << "0x" << static_cast<unsigned>( (*f) ) << ", ";
+                            debug_log.output << "0x" << static_cast<unsigned>( (*f) ) << ", ";
                         }
                         for( auto f = parameters.begin(); f < parameters.end() - 1; f++ ) {
                             if( (*f) == 0 ) {
                                 debug_log.output << "Difference: (*f) == 0.\n";
                             }
                         }
-                        info_log.output << std::endl;
-                        info_log.output << std::hex << "Code = ";
+                        debug_log.output << std::endl;
+                        debug_log.output << std::hex << "Code = ";
                         for( auto f = code.begin(); f < code.end(); f++ ) {
-                            info_log.output << "0x" << static_cast<unsigned>( (*f) ) << ", ";
+                            debug_log.output << "0x" << static_cast<unsigned>( (*f) ) << ", ";
                         }
-                        info_log.output << std::dec << "\n";
+                        debug_log.output << std::dec << "\n";
                         
                         // faction = 1, identifier = 5 Probably means initialization!
                         // FORCE_ACTOR_SPAWN = NUMBER, { 0xC7, 0x80, 0x3C }

--- a/src/Data/Mission/FUNResource.cpp
+++ b/src/Data/Mission/FUNResource.cpp
@@ -1,6 +1,5 @@
 #include "FUNResource.h"
 #include <limits>
-#include <cassert>
 
 const std::string Data::Mission::FUNResource::FILE_EXTENSION = "fun";
 // which is { 0x43, 0x66, 0x75, 0x6E } or { 'C', 'f', 'u', 'n' } or "Cfun"
@@ -28,6 +27,11 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
     // which is { 0x74, 0x46, 0x55, 0x4e } or { 't', 'F', 'U', 'N' } or "tFUN"
     const uint32_t TAG_tEXT = 0x74455854;
     // which is { 0x74, 0x45, 0x58, 0x54 } or { 't', 'E', 'X', 'T' } or "tEXT"
+
+    auto  info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
+    info_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
+    debug_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
     
     uint32_t data_id;
     Function fun_struct;
@@ -46,7 +50,8 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                 auto reader_tfun = reader.getReader( size - TAG_HEADER_SIZE );
                 
                 data_id = reader_tfun.readU32( settings.endian );
-                assert( data_id == 1 );
+                if( data_id != 1 )
+                    debug_log.output << "Difference: data_id is " << data_id << ".\n";
                 
                 while( !reader_tfun.ended() ) {
                     fun_struct.faction    = reader_tfun.readI32( settings.endian );
@@ -55,14 +60,22 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                     fun_struct.start_parameter_offset = reader_tfun.readU32( settings.endian );
                     fun_struct.start_code_offset      = reader_tfun.readU32( settings.endian );
                     
-                    assert( ( fun_struct.faction == 1 ) | ( fun_struct.faction == -1 ) | (fun_struct.faction == 0 ) | ( fun_struct.faction == 25 ) | ( fun_struct.faction == 9999 ) );
-                    assert( fun_struct.zero == 0 );
-                    assert( fun_struct.start_parameter_offset < fun_struct.start_code_offset );
+                    if( !(( fun_struct.faction == 1 ) | ( fun_struct.faction == -1 ) | (fun_struct.faction == 0 ) | ( fun_struct.faction == 25 ) | ( fun_struct.faction == 9999 )) ) {
+                        debug_log.output << "Difference: fun_struct.fraction is " << fun_struct.faction << ".\n";
+                    }
+                    if( fun_struct.zero != 0 ) {
+                        debug_log.output << "Difference: fun_struct.zero is " << fun_struct.zero << " not zero.\n";
+                    }
+                    if( fun_struct.start_parameter_offset >= fun_struct.start_code_offset ) {
+                        debug_log.output << "Difference: fun_struct.start_parameter_offset (" << fun_struct.start_parameter_offset << ") < fun_struct.start_code_offset (" << fun_struct.start_code_offset << ").\n";
+                    }
                     
                     functions.push_back( fun_struct );
                 }
                 
-                assert( functions.size() != 0 );
+                if( functions.size() == 0 ) {
+                    debug_log.output << "Difference: functions.size() is " << functions.size() << ".\n";
+                }
                 
                 auto header    = reader.readU32( settings.endian );
                 auto size      = reader.readU32( settings.endian );
@@ -71,13 +84,17 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                     auto reader_ext = reader.getReader( size - TAG_HEADER_SIZE );
                     
                     data_id = reader_ext.readU32( settings.endian );
-                    assert( data_id == 1 );
+                    if( data_id != 1 )
+                        debug_log.output << "Difference: data_id is " << data_id << ".\n";
                     
                     ext_bytes = reader_ext.getBytes();
                     
-                    assert( ext_bytes.size() != 0 );
-                    assert( ext_bytes.size() > functions.back().start_code_offset );
-                    assert( reader.ended() );
+                    if( ext_bytes.size() == 0 )
+                        debug_log.output << "Difference: ext_bytes.size() is " << ext_bytes.size() << ".\n";
+                    if( ext_bytes.size() <= functions.back().start_code_offset )
+                        debug_log.output << "Difference: ext_bytes.size() (" << ext_bytes.size() << ") <= functions.back().start_code_offset (" << functions.back().start_code_offset << ").\n";
+                    if( !reader.ended() );
+                        debug_log.output << "Difference: Reader is not done.\n";
                     
                     while( ext_bytes.back() != 0 ){
                         last_ext.insert( last_ext.begin(), ext_bytes.back() );
@@ -88,26 +105,26 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                         auto parameters = getFunctionParameters( i );
                         auto code = getFunctionCode( i );
                         
-                        if( settings.output_level >= 3 ) {
-                            *settings.output_ref << "i[" << std::dec << i  << "], ";
-                            *settings.output_ref << "f[" << functions.at( i ).faction << "], ";
-                            *settings.output_ref << "id[" << functions.at( i ).identifier << "], ";
-                            *settings.output_ref << "offset = " << functions.at( i ).start_parameter_offset << "\n" << std::endl;
-                            
-                            *settings.output_ref << std::hex << "Parameters = ";
-                            for( auto f = parameters.begin(); f < parameters.end(); f++ ) {
-                                *settings.output_ref << "0x" << static_cast<unsigned>( (*f) ) << ", ";
-                            }
-                            for( auto f = parameters.begin(); f < parameters.end() - 1; f++ ) {
-                                assert( (*f) != 0 );
-                            }
-                            *settings.output_ref << std::endl;
-                            *settings.output_ref << std::hex << "Code = ";
-                            for( auto f = code.begin(); f < code.end(); f++ ) {
-                                *settings.output_ref<< "0x" << static_cast<unsigned>( (*f) ) << ", ";
-                            }
-                            *settings.output_ref << std::dec << "\n" << std::endl;
+                        info_log.output << "i[" << std::dec << i  << "], ";
+                        info_log.output << "f[" << functions.at( i ).faction << "], ";
+                        info_log.output << "id[" << functions.at( i ).identifier << "], ";
+                        info_log.output << "offset = " << functions.at( i ).start_parameter_offset << "\n" << std::endl;
+
+                        info_log.output << std::hex << "Parameters = ";
+                        for( auto f = parameters.begin(); f < parameters.end(); f++ ) {
+                            info_log.output << "0x" << static_cast<unsigned>( (*f) ) << ", ";
                         }
+                        for( auto f = parameters.begin(); f < parameters.end() - 1; f++ ) {
+                            if( (*f) == 0 ) {
+                                debug_log.output << "Difference: (*f) == 0.\n";
+                            }
+                        }
+                        info_log.output << std::endl;
+                        info_log.output << std::hex << "Code = ";
+                        for( auto f = code.begin(); f < code.end(); f++ ) {
+                            info_log.output << "0x" << static_cast<unsigned>( (*f) ) << ", ";
+                        }
+                        info_log.output << std::dec << "\n";
                         
                         // faction = 1, identifier = 5 Probably means initialization!
                         // FORCE_ACTOR_SPAWN = NUMBER, { 0xC7, 0x80, 0x3C }
@@ -116,10 +133,18 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                         // JOKE/SLIM has faction 1 and identifier 5, and it appears to be something else. I can deduce no pattern in this sequence.
                         // However, I have enough knowedge to write an inaccurate parser.
                         
-                        assert( parameters.size() > 1 );
-                        assert( code.size() > 1 );
-                        assert( parameters.back() == 0 );
-                        assert( code.back() == 0 );
+                        if( parameters.size() <= 1 ) {
+                            debug_log.output << "Difference: parameters.size() > 1 false. parameters.size() = " << parameters.size() << "\n";
+                        }
+                        if( code.size() <= 1 ) {
+                            debug_log.output << "Difference: code.size() > 1 false. code.size() = " << code.size() << "\n";
+                        }
+                        if( parameters.back() != 0 ) {
+                            debug_log.output << "Difference: parameters.back() = " << parameters.back() << ". It is not zero.\n";
+                        }
+                        if( code.back() != 0 ) {
+                            debug_log.output << "Difference: code.back() = " << code.back() << ". It is not zero.\n";
+                        }
                     }
                     /* std::cout << std::hex << "Last tEXT = ";
                     for( auto f = last_ext.begin(); f < last_ext.end(); f++ ){
@@ -133,7 +158,8 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
         }
     }
     
-    assert( 0 );
+    debug_log.output << "parsing had failed.\n";
+
     return false;
 }
 

--- a/src/Data/Mission/FUNResource.cpp
+++ b/src/Data/Mission/FUNResource.cpp
@@ -89,7 +89,7 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                         debug_log.output << "Difference: ext_bytes.size() is " << ext_bytes.size() << ".\n";
                     if( ext_bytes.size() <= functions.back().start_code_offset )
                         debug_log.output << "Difference: ext_bytes.size() (" << ext_bytes.size() << ") <= functions.back().start_code_offset (" << functions.back().start_code_offset << ").\n";
-                    if( !reader.ended() );
+                    if( !reader.ended() )
                         debug_log.output << "Difference: Reader is not done.\n";
                     
                     while( ext_bytes.back() != 0 ){

--- a/src/Data/Mission/FUNResource.cpp
+++ b/src/Data/Mission/FUNResource.cpp
@@ -36,8 +36,6 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
     uint32_t data_id;
     Function fun_struct;
     
-    // std::cout << "FUNResource 0x" << std::hex << getOffset() << std::endl;
-    
     if( this->data_p != nullptr )
     {
         auto reader = this->data_p->getReader();
@@ -146,11 +144,11 @@ bool Data::Mission::FUNResource::parse( const ParseSettings &settings ) {
                             debug_log.output << "Difference: code.back() = " << code.back() << ". It is not zero.\n";
                         }
                     }
-                    /* std::cout << std::hex << "Last tEXT = ";
+                    debug_log.output << std::hex << "Last tEXT = ";
                     for( auto f = last_ext.begin(); f < last_ext.end(); f++ ){
-                        std::cout << "0x" << static_cast<unsigned>( (*f) ) << ", ";
+                        debug_log.output << "0x" << static_cast<unsigned>( (*f) ) << ", ";
                     }
-                    std::cout << std::dec << "\n" << std::endl; */
+                    debug_log.output << "\n";
                     
                     return true;
                 }

--- a/src/Data/Mission/FontResource.cpp
+++ b/src/Data/Mission/FontResource.cpp
@@ -116,8 +116,6 @@ Data::Mission::FontResource::FilterStatus Data::Mission::FontResource::filterTex
 }
 
 bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
-    auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
-    info_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
     debug_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
@@ -137,7 +135,7 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                 throw std::runtime_error( message );
             }
 
-            info_log.output << "Loading FNT " << getResourceID() << "!";
+            debug_log.output << "Loading FNT " << getResourceID() << "!";
 
             // Get the data first
             auto header   = reader.readU32( settings.endian );
@@ -153,14 +151,14 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
             auto u32_0 = reader.readU32( settings.endian );
             auto offset_to_image_header = reader.readU32( settings.endian );
 
-            info_log.output << "  Header = 0x" << std::hex << header << std::dec << "\n";
-            info_log.output << "  Tag Size = 0x" << std::hex << tag_size << std::dec << "\n";
-            info_log.output << "  u16_100 = " << u16_100 << "\n";
-            info_log.output << "  number_of_glyphs = " << number_of_glyphs << "\n";
-            info_log.output << "  platform = " << platform << "\n";
-            info_log.output << "  unk_u8 height? = " << static_cast<uint32_t>( unk_u8 ) << "\n";
-            info_log.output << "  offset_to_glyphs = 0x" << std::hex << offset_to_glyphs << std::dec << "\n";
-            info_log.output << "  offset_to_image_header = 0x" << std::hex << offset_to_image_header << std::dec << "\n";
+            debug_log.output << "  Header = 0x" << std::hex << header << std::dec << "\n";
+            debug_log.output << "  Tag Size = 0x" << std::hex << tag_size << std::dec << "\n";
+            debug_log.output << "  u16_100 = " << u16_100 << "\n";
+            debug_log.output << "  number_of_glyphs = " << number_of_glyphs << "\n";
+            debug_log.output << "  platform = " << platform << "\n";
+            debug_log.output << "  unk_u8 height? = " << static_cast<uint32_t>( unk_u8 ) << "\n";
+            debug_log.output << "  offset_to_glyphs = 0x" << std::hex << offset_to_glyphs << std::dec << "\n";
+            debug_log.output << "  offset_to_image_header = 0x" << std::hex << offset_to_image_header << std::dec << "\n";
 
             // assert( platform == 9 ); // This statement will not crash on Playstation 1 files.
             // assert( platform == 8 ); // This statement will not crash on Mac or Windows files.
@@ -173,7 +171,7 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
 
             if( !file_is_not_valid )
             {
-                info_log.output << "FNT Header is valid!" << "\n";
+                debug_log.output << "FNT Header is valid!" << "\n";
 
                 reader.setPosition( offset_to_glyphs, Utilities::Buffer::BEGIN );
 
@@ -191,7 +189,7 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                 for( auto i = this->glyphs.cbegin(); i < this->glyphs.cend(); i++ ) {
                     const uint32_t wrapped_character = (*i).glyphID % MAX_GLYPHS;
 
-                    info_log.output << "  glyphs[" << (i - this->glyphs.cbegin()) << "] = " << wrapped_character << "\n";
+                    debug_log.output << "  glyphs[" << (i - this->glyphs.cbegin()) << "] = " << wrapped_character << "\n";
 
                     font_glyphs_r[ wrapped_character ] = this->glyphs.data() + (i - this->glyphs.cbegin());
                 }
@@ -208,7 +206,7 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                 auto width  = readerImageHeader.readU16( settings.endian );
                 auto height = readerImageHeader.readU16( settings.endian );
 
-                info_log.output << "width = " << width << ", height = " << height << "\n";
+                debug_log.output << "width = " << width << ", height = " << height << "\n";
 
 
                 // The pixels are compressed with 4 bit color palettes.
@@ -230,7 +228,7 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                 file_is_not_valid |= ( (IMAGE_HEADER_SIZE + offset_to_image_header + (image_palette.getWidth() / 2) * image_palette.getHeight()) > reader.totalSize() );
 
                 if( !file_is_not_valid ) {
-                    info_log.output << "FNT image is valid.\n";
+                    debug_log.output << "FNT image is valid.\n";
 
                     auto reader_image = reader.getReader( reader.totalSize() - (IMAGE_HEADER_SIZE + offset_to_image_header) );
                     
@@ -246,7 +244,7 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                     image_p = new Utilities::Image2D( backup );
 
                     if( image_p == nullptr ) {
-                        info_log.output << "  FNT image failed\n" << std::endl;
+                        debug_log.output << "  FNT image failed\n" << std::endl;
                     }
 
 
@@ -255,7 +253,7 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                 }
                 else
                 {
-                    info_log.output << "  FNT image is invalid\n" << std::endl;
+                    debug_log.output << "  FNT image is invalid\n" << std::endl;
                     return false;
                 }
             }

--- a/src/Data/Mission/FontResource.cpp
+++ b/src/Data/Mission/FontResource.cpp
@@ -116,6 +116,11 @@ Data::Mission::FontResource::FilterStatus Data::Mission::FontResource::filterTex
 }
 
 bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
+    auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
+    info_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
+    debug_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+
     if( this->data_p != nullptr )
     {
         auto reader = this->data_p->getReader();
@@ -124,12 +129,16 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
 
         if( reader.totalSize() > HEADER_SIZE )
         {
-            if( getResourceID() == 0 )
-                throw std::runtime_error( "Error: Resource ID of zero for FontResource is reserved only for use inside this program. Never in the IFF files." );
+            if( getResourceID() == 0 ) {
+                std::string message = "Error Resource ID of zero for FontResource is reserved only for use inside this program. Never in the IFF files.";
 
-            if( settings.output_level >= 1 ) {
-                *settings.output_ref << "Loading FNT " << getResourceID() << "!" << std::endl;
+                auto critical_log = settings.logger_r->getLog( Utilities::Logger::CRITICAL );
+                critical_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n" << message;
+                throw std::runtime_error( message );
             }
+
+            info_log.output << "Loading FNT " << getResourceID() << "!";
+
             // Get the data first
             auto header   = reader.readU32( settings.endian );
             auto tag_size = reader.readU32( settings.endian );
@@ -144,16 +153,14 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
             auto u32_0 = reader.readU32( settings.endian );
             auto offset_to_image_header = reader.readU32( settings.endian );
 
-            if( settings.output_level >= 2 ) {
-                *settings.output_ref << "  Header = 0x" << std::hex << header << std::dec << "\n";
-                *settings.output_ref << "  Tag Size = 0x" << std::hex << tag_size << std::dec << "\n";
-                *settings.output_ref << "  u16_100 = " << u16_100 << "\n";
-                *settings.output_ref << "  number_of_glyphs = " << number_of_glyphs << "\n";
-                *settings.output_ref << "  platform = " << platform << "\n";
-                *settings.output_ref << "  unk_u8 height? = " << static_cast<uint32_t>( unk_u8 ) << "\n";
-                *settings.output_ref << "  offset_to_glyphs = 0x" << std::hex << offset_to_glyphs << std::dec << "\n";
-                *settings.output_ref << "  offset_to_image_header = 0x" << std::hex << offset_to_image_header << std::dec << "\n" << std::endl;
-            }
+            info_log.output << "  Header = 0x" << std::hex << header << std::dec << "\n";
+            info_log.output << "  Tag Size = 0x" << std::hex << tag_size << std::dec << "\n";
+            info_log.output << "  u16_100 = " << u16_100 << "\n";
+            info_log.output << "  number_of_glyphs = " << number_of_glyphs << "\n";
+            info_log.output << "  platform = " << platform << "\n";
+            info_log.output << "  unk_u8 height? = " << static_cast<uint32_t>( unk_u8 ) << "\n";
+            info_log.output << "  offset_to_glyphs = 0x" << std::hex << offset_to_glyphs << std::dec << "\n";
+            info_log.output << "  offset_to_image_header = 0x" << std::hex << offset_to_image_header << std::dec << "\n";
 
             // assert( platform == 9 ); // This statement will not crash on Playstation 1 files.
             // assert( platform == 8 ); // This statement will not crash on Mac or Windows files.
@@ -166,9 +173,8 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
 
             if( !file_is_not_valid )
             {
-                if( settings.output_level >= 2 ) {
-                    *settings.output_ref << "  FNT Header is valid!" << std::endl;
-                }
+                info_log.output << "FNT Header is valid!" << "\n";
+
                 reader.setPosition( offset_to_glyphs, Utilities::Buffer::BEGIN );
 
                 auto readerGlyphs = reader.getReader( number_of_glyphs * GLYPH_SIZE );
@@ -185,9 +191,8 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                 for( auto i = this->glyphs.cbegin(); i < this->glyphs.cend(); i++ ) {
                     const uint32_t wrapped_character = (*i).glyphID % MAX_GLYPHS;
 
-                    if( settings.output_level >= 3 ) {
-                        *settings.output_ref << "  glyphs[" << (i - this->glyphs.cbegin()) << "] = " << wrapped_character << std::endl;
-                    }
+                    info_log.output << "  glyphs[" << (i - this->glyphs.cbegin()) << "] = " << wrapped_character << "\n";
+
                     font_glyphs_r[ wrapped_character ] = this->glyphs.data() + (i - this->glyphs.cbegin());
                 }
 
@@ -203,10 +208,8 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                 auto width  = readerImageHeader.readU16( settings.endian );
                 auto height = readerImageHeader.readU16( settings.endian );
 
-                if( settings.output_level >= 2 ) {
-                    *settings.output_ref << "  width = " << width << "\n";
-                    *settings.output_ref << "  height = " << height << "\n" << std::endl;
-                }
+                info_log.output << "width = " << width << ", height = " << height << "\n";
+
 
                 // The pixels are compressed with 4 bit color palettes.
                 // Playstation did not support 1 bit, so their best option is 4 bit.
@@ -227,9 +230,7 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                 file_is_not_valid |= ( (IMAGE_HEADER_SIZE + offset_to_image_header + (image_palette.getWidth() / 2) * image_palette.getHeight()) > reader.totalSize() );
 
                 if( !file_is_not_valid ) {
-                    if( settings.output_level >= 1 ) {
-                        *settings.output_ref << "  FNT image is valid\n" << std::endl;
-                    }
+                    info_log.output << "FNT image is valid.\n";
 
                     auto reader_image = reader.getReader( reader.totalSize() - (IMAGE_HEADER_SIZE + offset_to_image_header) );
                     
@@ -244,8 +245,8 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                     
                     image_p = new Utilities::Image2D( backup );
 
-                    if( image_p == nullptr && settings.output_level >= 1 ) {
-                        *settings.output_ref << "  FNT image failed\n" << std::endl;
+                    if( image_p == nullptr ) {
+                        info_log.output << "  FNT image failed\n" << std::endl;
                     }
 
 
@@ -254,9 +255,7 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                 }
                 else
                 {
-                    if( settings.output_level >= 1 ) {
-                        *settings.output_ref << "  FNT image is invalid\n" << std::endl;
-                    }
+                    info_log.output << "  FNT image is invalid\n" << std::endl;
                     return false;
                 }
             }
@@ -346,7 +345,7 @@ const std::vector<Data::Mission::FontResource*> Data::Mission::FontResource::get
     return Data::Mission::FontResource::getVector( const_cast< Data::Mission::IFF& >( mission_file ) );
 }
 
-Data::Mission::FontResource* Data::Mission::FontResource::getWindows( std::ostream *stream, int output_level ) {
+Data::Mission::FontResource* Data::Mission::FontResource::getWindows( Utilities::Logger &logger ) {
     Data::Mission::FontResource* windows_font_p = new Data::Mission::FontResource;
 
     windows_font_p->setIndexNumber( 0 );
@@ -360,8 +359,7 @@ Data::Mission::FontResource* Data::Mission::FontResource::getWindows( std::ostre
     Data::Mission::Resource::ParseSettings parse_settings;
     parse_settings.type = Data::Mission::Resource::ParseSettings::Windows;
     parse_settings.endian = Utilities::Buffer::LITTLE;
-    parse_settings.output_level = output_level;
-    parse_settings.output_ref = stream;
+    parse_settings.logger_r = &logger;
 
     if( !windows_font_p->parse( parse_settings ) )
         throw std::logic_error( "Internal Error: The internal Windows font has failed to parse!");
@@ -373,7 +371,7 @@ Data::Mission::FontResource* Data::Mission::FontResource::getWindows( std::ostre
     return windows_font_p;
 }
 
-Data::Mission::FontResource* Data::Mission::FontResource::getPlaystation( std::ostream *stream, int output_level ) {
+Data::Mission::FontResource* Data::Mission::FontResource::getPlaystation( Utilities::Logger &logger ) {
     Data::Mission::FontResource* playstation_font_p = new Data::Mission::FontResource;
 
     playstation_font_p->setIndexNumber( 0 );
@@ -387,8 +385,7 @@ Data::Mission::FontResource* Data::Mission::FontResource::getPlaystation( std::o
     Data::Mission::Resource::ParseSettings parse_settings;
     parse_settings.type = Data::Mission::Resource::ParseSettings::Playstation;
     parse_settings.endian = Utilities::Buffer::LITTLE;
-    parse_settings.output_level = output_level;
-    parse_settings.output_ref = stream;
+    parse_settings.logger_r = &logger;
 
     if( !playstation_font_p->parse( parse_settings ) )
         throw std::logic_error( "Internal Error: The internal Playstation font has failed to parse!");

--- a/src/Data/Mission/FontResource.cpp
+++ b/src/Data/Mission/FontResource.cpp
@@ -4,7 +4,6 @@
 #include "../../Utilities/ImagePalette2D.h"
 #include <string.h>
 #include <fstream>
-#include <cassert>
 #include <stdexcept>
 
 namespace {
@@ -117,7 +116,9 @@ Data::Mission::FontResource::FilterStatus Data::Mission::FontResource::filterTex
 
 bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
     auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
-    debug_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    debug_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
+    warning_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
     if( this->data_p != nullptr )
     {
@@ -135,7 +136,7 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
                 throw std::runtime_error( message );
             }
 
-            debug_log.output << "Loading FNT " << getResourceID() << "!";
+            debug_log.output << "Loading FNT " << getResourceID() << "!\n";
 
             // Get the data first
             auto header   = reader.readU32( settings.endian );
@@ -151,14 +152,14 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
             auto u32_0 = reader.readU32( settings.endian );
             auto offset_to_image_header = reader.readU32( settings.endian );
 
-            debug_log.output << "  Header = 0x" << std::hex << header << std::dec << "\n";
-            debug_log.output << "  Tag Size = 0x" << std::hex << tag_size << std::dec << "\n";
-            debug_log.output << "  u16_100 = " << u16_100 << "\n";
-            debug_log.output << "  number_of_glyphs = " << number_of_glyphs << "\n";
-            debug_log.output << "  platform = " << platform << "\n";
-            debug_log.output << "  unk_u8 height? = " << static_cast<uint32_t>( unk_u8 ) << "\n";
-            debug_log.output << "  offset_to_glyphs = 0x" << std::hex << offset_to_glyphs << std::dec << "\n";
-            debug_log.output << "  offset_to_image_header = 0x" << std::hex << offset_to_image_header << std::dec << "\n";
+            debug_log.output << "  Header = 0x" << std::hex << header << std::dec << "\n"
+                << "  Tag Size = 0x" << std::hex << tag_size << std::dec << "\n"
+                << "  u16_100 = " << u16_100 << "\n"
+                << "  number_of_glyphs = " << number_of_glyphs << "\n"
+                << "  platform = " << platform << "\n"
+                << "  unk_u8 height? = " << static_cast<uint32_t>( unk_u8 ) << "\n"
+                << "  offset_to_glyphs = 0x" << std::hex << offset_to_glyphs << std::dec << "\n"
+                << "  offset_to_image_header = 0x" << std::hex << offset_to_image_header << std::dec << "\n";
 
             // assert( platform == 9 ); // This statement will not crash on Playstation 1 files.
             // assert( platform == 8 ); // This statement will not crash on Mac or Windows files.
@@ -200,7 +201,8 @@ bool Data::Mission::FontResource::parse( const ParseSettings &settings ) {
 
                 const auto font_image_identifier = readerImageHeader.readU8();
 
-                assert( font_image_identifier == '@' );
+                if( font_image_identifier != '@' )
+                    warning_log.output << "font_image_identifier is not @.\n";
 
                 readerImageHeader.setPosition( 0x4, Utilities::Buffer::BEGIN );
                 auto width  = readerImageHeader.readU16( settings.endian );

--- a/src/Data/Mission/FontResource.h
+++ b/src/Data/Mission/FontResource.h
@@ -93,8 +93,8 @@ public:
     static std::vector<FontResource*> getVector( Data::Mission::IFF &mission_file );
     static const std::vector<FontResource*> getVector( const Data::Mission::IFF &mission_file );
 
-    static FontResource* getWindows( std::ostream *stream = nullptr, int output_level = 0 );
-    static FontResource* getPlaystation( std::ostream *stream = nullptr, int output_level = 0 );
+    static FontResource* getWindows( Utilities::Logger &logger = Utilities::logger );
+    static FontResource* getPlaystation( Utilities::Logger &logger = Utilities::logger );
 };
 
 }

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -23,8 +23,8 @@
 
 #include <fstream>
 #include <algorithm>
-#include <cstring> // std::strerror
-#include <cassert> // std::strerror
+#include <cstring>
+#include <cassert>
 #include <iostream>
 #include <unordered_set>
 
@@ -158,8 +158,17 @@ namespace {
 
 int Data::Mission::IFF::open( const std::string &file_path ) {
     std::unordered_set<std::string> filenames; // Check for potential conflicts.
-    
+    Utilities::Logger &logger = Utilities::logger;
     std::fstream file;
+
+    auto info_log = logger.getLog( Utilities::Logger::INFO );
+    info_log.info << "IFF: " << file_path << "\n";
+    auto debug_log = logger.getLog( Utilities::Logger::DEBUG );
+    debug_log.info << "IFF: " << file_path << "\n";
+    auto warning_log = logger.getLog( Utilities::Logger::WARNING );
+    warning_log.info << "IFF: " << file_path << "\n";
+    auto error_log = logger.getLog( Utilities::Logger::ERROR );
+    error_log.info << "IFF: " << file_path << "\n";
 
     this->setName( file_path );
 
@@ -204,14 +213,14 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                 // This determines if the file is big endian or little endian.
                 if( WIN_CTRL_TAG[ 0 ] == reinterpret_cast<const char*>(&TYPE_ID)[ 0 ] ) {
                     this->type = FILE_IS_LITTLE_ENDIAN;
-                    std::cout << "\"" << file_path << "\" is a little endian mission file" << std::endl;
+                    info_log.output << "\"" << file_path << "\" is a little endian mission file" << std::endl;
                     default_settings.type = Resource::ParseSettings::Windows; // Might be Playstation file as well.
                     default_settings.endian = Utilities::Buffer::Endian::LITTLE;
                 }
                 else
                 if( MAC_CTRL_TAG[ 0 ] == reinterpret_cast<const char*>(&TYPE_ID)[ 0 ] ) {
                     this->type = FILE_IS_BIG_ENDIAN;
-                    std::cout << "\"" << file_path << "\" is a big endian mission file" << std::endl;
+                    info_log.output << "\"" << file_path << "\" is a big endian mission file" << std::endl;
                     default_settings.type = Resource::ParseSettings::Macintosh;
                     default_settings.endian = Utilities::Buffer::Endian::BIG;
                 }
@@ -246,7 +255,7 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                 const uint32_t DATA_SIZE = chunkToDataSize( CHUNK_SIZE );
 
                 if( TYPE_ID == FILL_TAG ) {
-                    //std::cout << "TYPE_ID: " << "FILL" << " CHUNK_SIZE: " << CHUNK_SIZE << std::endl;
+                    debug_log.output << "TYPE_ID: " << "FILL" << " CHUNK_SIZE: " << CHUNK_SIZE << std::endl;
 
                     // This tag does not have any useable information. This might have been used to demiout certain files.
 
@@ -261,7 +270,7 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                     // Check if the buffer is too high.
                     if( DATA_SIZE > data_reader.totalSize() ) {
                         // data_buffer.allocate( DATA_SIZE - data_reader.totalSize() );
-                        std::cout << std::hex << " Error: The limit of 0x" << data_reader.totalSize() << std::dec  << " for this reader has been reached" << std::endl;
+                        error_log.output << std::hex << " The limit of 0x" << data_reader.totalSize() << " for this reader has been reached" << std::endl;
                         error_in_read = true;
                     }
 
@@ -312,13 +321,13 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                             resource_pool.back().data_p->add( reinterpret_cast<uint8_t*>(data_buffer.dangerousPointer() + 12), DATA_SIZE - 12 );
                         }
                         else
-                            std::cout << "This SHOC chunk is either too small or has an invalid tag." << std::endl;
+                            error_log.output << "This SHOC chunk is either too small or has an invalid tag." << std::endl;
 
-                        // std::cout << "TYPE_ID: " << "SHOC" << " CHUNK_SIZE: " << CHUNK_SIZE << std::endl;
+                        debug_log.output << "TYPE_ID: " << "SHOC" << " CHUNK_SIZE: " << CHUNK_SIZE << std::endl;
                     }
                     else
                     if( TYPE_ID == MSIC_TAG ) {
-                        //std::cout << "TYPE_ID: " << "MISC" << " CHUNK_SIZE: " << CHUNK_SIZE << std::endl;
+                        debug_log.output << "TYPE_ID: " << "MISC" << " CHUNK_SIZE: " << CHUNK_SIZE << std::endl;
                         if( msic_p == nullptr ) {
                             msic_p = new MSICResource();
                             msic_p->setIndexNumber( 0 );
@@ -372,9 +381,9 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                             const std::string expecting = std::string(".stream").substr( 0, ending.length() );
                             
                             if( ending.compare(expecting) != 0 ) {
-                                std::cout << "Offset = 0x" << std::hex << file_offset << std::dec << ".\n";
-                                std::cout << "  \"" << name_swvr << "\" is the name of the SWVR chunk.\n";
-                                std::cout << "  Invalid line ending at IFF! This could mean that this IFF file might not work with Future Cop." << std::endl;
+                                warning_log.output << "Offset = 0x" << std::hex << file_offset << ".\n"
+                                    << "  \"" << name_swvr << "\" is the name of the SWVR chunk.\n"
+                                    << "  Invalid line ending at IFF! This could mean that this IFF file might not work with Future Cop.\n";
                             }
                             else {
                                 name_swvr = name_swvr.substr( 0, dot_position );
@@ -383,8 +392,8 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                         else
                         {
                             if( name_swvr.length() != STRING_LIMIT - 1 ) {
-                                std::cout << "Offset = 0x" << std::hex << file_offset << std::dec << ".\n";
-                                std::cout << "  SWVR name \"" << name_swvr << "\" probably invalid." << std::endl;
+                                warning_log.output << "Offset = 0x" << std::hex << file_offset << ".\n"
+                                    << "  SWVR name \"" << name_swvr << "\" probably invalid.\n";
                             }
                         }
                     }
@@ -401,7 +410,7 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                         // TODO Read in this case.
                     }
                     else
-                        std::cout << "TYPE_ID: " << static_cast<char>((TYPE_ID >> 24) & 0xFF) << static_cast<char>((TYPE_ID >> 16) & 0xFF) << static_cast<char>((TYPE_ID >> 8) & 0xFF) << static_cast<char>(TYPE_ID & 0xFF) << " CHUNK_SIZE: " << CHUNK_SIZE << std::endl;
+                        warning_log.output << "TYPE_ID: " << static_cast<char>((TYPE_ID >> 24) & 0xFF) << static_cast<char>((TYPE_ID >> 16) & 0xFF) << static_cast<char>((TYPE_ID >> 8) & 0xFF) << static_cast<char>(TYPE_ID & 0xFF) << " CHUNK_SIZE: " << CHUNK_SIZE << ".\n";
                 }
                 else
                     error_in_read = true;
@@ -414,20 +423,16 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
         if( errno != 0 )
         {
             if( ( readstate & std::ifstream::failbit ) != 0 ) {
-                std::cout << "There is a logical error detected with the reading of the IFF or Mission File. Please report this to the developer!" << std::endl;
-                std::cout << "Error: " << std::strerror(errno) << std::endl;
+                error_log.output << "There is a logical error detected with the reading of the IFF or Mission File. Please report this to the developer!\n"
+                    << "Error: " << std::strerror(errno) << "\n";
             }
             if( ( readstate & std::ifstream::badbit ) != 0 ) {
-                std::cout << "There is a input error detected with the reading of the IFF or Mission File." << std::endl;
+                error_log.output << "There is a input error detected with the reading of the IFF or Mission File.\n";
             }
         }
 
         // We are done reading the IFF file.
         file.close();
-
-        //if( !is_confirmend_iff_file ) {
-        //    std::cout << "This file is not a little endian iff file or big endian iff file." << std::endl;
-        //}
 
         // Now, every resource can be parsed.
         for( auto &i : resource_pool ) {
@@ -461,7 +466,7 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
             // Check for naming conflicts
             const std::string file_name = new_resource_p->getFullName( new_resource_p->getResourceID() );
             
-            // std::cout << "Resource Name = " << file_name << std::endl;
+            info_log.output << "Resource Name = \"" << file_name << "\".\n";
             assert( filenames.find( file_name ) == filenames.end() );
             filenames.emplace( file_name );
 
@@ -484,12 +489,12 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
         if( pyr_pointer_r.size() != 0 ) {
             if( !pyr_pointer_r[0]->makeTiles( Data::Mission::TilResource::getVector( *this ) ) )
             {
-                std::cerr << "Error: PYR resource is found, but there are no Til resources." << std::endl;
+                error_log.output << "PYR resource is found, but there are no Til resources.\n";
             }
         }
         else
         if( getResource( Data::Mission::TilResource::IDENTIFIER_TAG ) != nullptr )
-            std::cerr << "Error: PYR resource is not found, but the Til resources are in the file." << std::endl;
+            error_log.output << "PYR resource is not found, but the Til resources are in the file.\n";
 
         if( getResource( Data::Mission::ObjResource::IDENTIFIER_TAG ) != nullptr ) {
             std::vector<Data::Mission::BMPResource*> textures_from_prime = Data::Mission::BMPResource::getVector( *this );

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -202,6 +202,9 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
         Utilities::Buffer *msic_data_p;
 
         {
+            auto info_log = logger.getLog( Utilities::Logger::INFO );
+            info_log.info << "IFF: " << file_path << "\n";
+
             type_writer.write( file, type_reader.totalSize() );
 
             const uint32_t TYPE_ID = type_reader.readU32( Utilities::Buffer::Endian::NO_SWAP );
@@ -213,14 +216,14 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                 // This determines if the file is big endian or little endian.
                 if( WIN_CTRL_TAG[ 0 ] == reinterpret_cast<const char*>(&TYPE_ID)[ 0 ] ) {
                     this->type = FILE_IS_LITTLE_ENDIAN;
-                    info_log.output << "\"" << file_path << "\" is a little endian mission file" << std::endl;
+                    info_log.output << "This IFF file is little endian (Windows/Playstation) formated.\n";
                     default_settings.type = Resource::ParseSettings::Windows; // Might be Playstation file as well.
                     default_settings.endian = Utilities::Buffer::Endian::LITTLE;
                 }
                 else
                 if( MAC_CTRL_TAG[ 0 ] == reinterpret_cast<const char*>(&TYPE_ID)[ 0 ] ) {
                     this->type = FILE_IS_BIG_ENDIAN;
-                    info_log.output << "\"" << file_path << "\" is a big endian mission file" << std::endl;
+                    info_log.output << "This IFF file is big endian (Macintosh) formated.\n";
                     default_settings.type = Resource::ParseSettings::Macintosh;
                     default_settings.endian = Utilities::Buffer::Endian::BIG;
                 }

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -466,7 +466,7 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
             // Check for naming conflicts
             const std::string file_name = new_resource_p->getFullName( new_resource_p->getResourceID() );
             
-            info_log.output << "Resource Name = \"" << file_name << "\".\n";
+            debug_log.output << "Resource Name = \"" << file_name << "\".\n";
             assert( filenames.find( file_name ) == filenames.end() );
             filenames.emplace( file_name );
 

--- a/src/Data/Mission/MSICResource.cpp
+++ b/src/Data/Mission/MSICResource.cpp
@@ -56,18 +56,18 @@ bool Data::Mission::MSICResource::parse( const ParseSettings &settings ) {
 
             // Mac and Windows files both the folling facts.
             // Playstation was not tested because of its different audio system.
-            assert( zero0 == 0 ); // 8 bytes of zeros.
-            assert( zero1 == 0 );
-            assert( Data::Mission::MSICResource::IDENTIFIER_TAG == header );
-            assert( (what == 0x4e) || (what == 0x50) || (what == 0x51) || (what == 0x55) || (what == 0x58) || (what == 0x59) || (what == 0x60) || (what == 0x62) || (what == 0x65) || (what == 0x66) || (what == 0x70) || (what == 0x110) );
-            assert( predict_index == index ); // 16 bit number telling the header offset.
+            // assert( zero0 == 0 ); // 8 bytes of zeros.
+            // assert( zero1 == 0 );
+            // assert( Data::Mission::MSICResource::IDENTIFIER_TAG == header );
+            // assert( (what == 0x4e) || (what == 0x50) || (what == 0x51) || (what == 0x55) || (what == 0x58) || (what == 0x59) || (what == 0x60) || (what == 0x62) || (what == 0x65) || (what == 0x66) || (what == 0x70) || (what == 0x110) );
+            // assert( predict_index == index ); // 16 bit number telling the header offset.
             predict_index++;
-            assert( zero3 == 0 ); // 2 bytes of zeros.
+            // assert( zero3 == 0 ); // 2 bytes of zeros.
             
             // next_offset is multiplied by two.
-            auto dataReader = reader.getReader( 2 * static_cast<size_t>( next_offset ));
+            auto data_reader = reader.getReader( 2 * static_cast<size_t>( next_offset ));
 
-            sound.addAudioStream( dataReader );
+            sound.addAudioStream( data_reader );
         }
         while( !reader.ended() );
 

--- a/src/Data/Mission/MSICResource.cpp
+++ b/src/Data/Mission/MSICResource.cpp
@@ -1,7 +1,5 @@
 #include "MSICResource.h"
 
-#include <cassert>
-
 namespace {
     const size_t SIZE_OF_HEADERS = 0x0014;
     const size_t SIZE_OF_DATA    = 0x5FC0;
@@ -32,6 +30,9 @@ bool Data::Mission::MSICResource::noResourceID() const {
 }
 
 bool Data::Mission::MSICResource::parse( const ParseSettings &settings ) {
+    auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
+    warning_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
+
     bool file_is_not_valid = false;
 
     if( this->data_p != nullptr )
@@ -56,13 +57,19 @@ bool Data::Mission::MSICResource::parse( const ParseSettings &settings ) {
 
             // Mac and Windows files both the folling facts.
             // Playstation was not tested because of its different audio system.
-            // assert( zero0 == 0 ); // 8 bytes of zeros.
-            // assert( zero1 == 0 );
-            // assert( Data::Mission::MSICResource::IDENTIFIER_TAG == header );
-            // assert( (what == 0x4e) || (what == 0x50) || (what == 0x51) || (what == 0x55) || (what == 0x58) || (what == 0x59) || (what == 0x60) || (what == 0x62) || (what == 0x65) || (what == 0x66) || (what == 0x70) || (what == 0x110) );
-            // assert( predict_index == index ); // 16 bit number telling the header offset.
+            if( zero0 != 0 ) // 8 bytes of zeros.
+                warning_log.output << "zero0 is actually " << std::dec << zero0 << ".\n";
+            if( zero1 != 0 )
+                warning_log.output << "zero1 is actually " << std::dec << zero1 << ".\n";
+            if( Data::Mission::MSICResource::IDENTIFIER_TAG != header )
+                warning_log.output << "header is actually 0x" << std::hex << header << ".\n";
+            if( !((what == 0x4e) || (what == 0x50) || (what == 0x51) || (what == 0x55) || (what == 0x58) || (what == 0x59) || (what == 0x60) || (what == 0x62) || (what == 0x65) || (what == 0x66) || (what == 0x70) || (what == 0x110)) )
+                warning_log.output << "what is actually 0x" << std::hex << what << ".\n";
+            if( predict_index != index ) // 16 bit number telling the header offset.
+                warning_log.output << "index is actually 0x" << std::hex << index << " not what is predicted " << predict_index << ".\n";
             predict_index++;
-            // assert( zero3 == 0 ); // 2 bytes of zeros.
+            if( zero3 != 0 )
+                warning_log.output << "zero3 is actually " << std::dec << zero3 << ".\n";
             
             // next_offset is multiplied by two.
             auto data_reader = reader.getReader( 2 * static_cast<size_t>( next_offset ));

--- a/src/Data/Mission/NetResource.cpp
+++ b/src/Data/Mission/NetResource.cpp
@@ -1,7 +1,6 @@
 #include "NetResource.h"
 
 #include <fstream>
-#include <cassert>
 
 #include <json/json.h>
 
@@ -82,6 +81,9 @@ uint32_t Data::Mission::NetResource::getResourceTagID() const {
 }
 
 bool Data::Mission::NetResource::parse( const ParseSettings &settings ) {
+    auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
+    error_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
+
     if( this->data_p != nullptr )
     {
         auto reader = this->data_p->getReader();
@@ -105,7 +107,7 @@ bool Data::Mission::NetResource::parse( const ParseSettings &settings ) {
             return true;
         }
         else {
-            assert( false );
+            error_log.output << "The NET resource did not parse!.\n";
             return false;
         }
     }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -221,11 +221,11 @@ uint32_t Data::Mission::ObjResource::getResourceTagID() const {
 
 bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
     auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
-    info_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    info_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
-    warning_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    warning_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
-    error_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    error_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
     if( this->data_p != nullptr )
     {
@@ -537,7 +537,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 
                 frames_gen_3DHS = data_size / ( BONE_SIZE * bone_depth_number );
 
-                warning_log.output << std::dec << "3DHS has " << read_3D_positions << " 3D vectors, and contains about " << frames_gen_3DHS << " frames.\n";
+                info_log.output << std::dec << "3DHS has " << read_3D_positions << " 3D vectors, and contains about " << frames_gen_3DHS << " frames.\n";
                 
                 for( int d = 0; d < frames_gen_3DHS; d++ )
                 {
@@ -680,7 +680,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 if( bounding_box_per_frame >= 1 )
                 {
                     // Numbers 1, 2, 3, 4, 5, 6, 7 appears throughout the English version of Future Cop on the ps1, Mac, and Windows.
-                    if( bounding_box_per_frame <= 7 )
+                    if( bounding_box_per_frame > 7 && bounding_box_per_frame == 0 )
                         warning_log.output << "bounding_box_per_frame = " << std::dec << bounding_box_per_frame << "\n";
                     
                     const auto bounding_box_amount = reader3DBB.readU32( settings.endian );

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -7,7 +7,6 @@
 #include <glm/ext/matrix_transform.hpp>
 #include <algorithm>
 #include <cmath>
-#include <iostream>
 #include <fstream>
 #include <cassert>
 
@@ -342,11 +341,6 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
 
                 for( size_t i = 0; i < texture_ref_amount; i++ )
                 {
-                    /*if( DataHandler::read_u8( start_data ) != 2 )
-                        std::cout << "expected 2 at uv not " << std::dec
-                                  << (static_cast<uint32_t>(DataHandler::read_u8( start_data )) & 0xFF)
-                                  << std::hex << std::endl;*/
-                    
                     reader3DTL.readU32( settings.endian ); // Skip unknown bytes
 
                     texture_quads.push_back( TextureQuad() );
@@ -441,16 +435,16 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
             }
             else
             if( identifier == TAG_3DRF ) {
-                // std::cout << "3DRF" << std::endl;
+                info_log.output << "3DRF" << std::endl;
                 auto reader3DRF = reader.getReader( data_tag_size );
                 
-                // std::cout << "Index " << getIndexNumber() << std::endl;
-                // std::cout << "reader3DRF.totalSize() = " << reader3DRF.totalSize() << std::endl;
+                info_log.output << "Index " << getIndexNumber() << std::endl;
+                info_log.output << "reader3DRF.totalSize() = " << reader3DRF.totalSize() << std::endl;
                 // assert( reader3DRF.totalSize() == 0x10 );
             }
             else
             if( identifier == TAG_3DRL ) {
-                // std::cout << "3DRL" << std::endl;
+                info_log.output << "3DRL" << std::endl;
                 auto reader3DRL = reader.getReader( data_tag_size );
             }
             else

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -219,8 +219,8 @@ uint32_t Data::Mission::ObjResource::getResourceTagID() const {
 }
 
 bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
-    auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
-    info_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
+    debug_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
     warning_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
@@ -256,7 +256,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 }
                 else
                 {
-                    info_log.output << "4DGI at location 0x" << std::hex << this->getOffset() << "\n";
+                    debug_log.output << "4DGI at location 0x" << std::hex << this->getOffset() << "\n";
 
                     auto un1 = reader4DGI.readU32( settings.endian );
                     if( un1 != 1 ) // Always 1 for Mac, Playstation, and Windows
@@ -337,7 +337,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 }
 
                 size_t texture_ref_amount = (reader3DTL.totalSize() - reader3DTL.getPosition()) / 0x10;
-                info_log.output << "triangle amount " << std::dec << texture_ref_amount << "\n";
+                debug_log.output << "triangle amount " << std::dec << texture_ref_amount << "\n";
 
                 for( size_t i = 0; i < texture_ref_amount; i++ )
                 {
@@ -379,7 +379,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 if( number_of_faces == 0 ) // Each model has one or more faces.
                     warning_log.output << "3DQL the number of faces is missing.\n";
 
-                info_log.output << "3DQL has 0x" << std::hex << number_of_faces << " faces\n";
+                debug_log.output << "3DQL has 0x" << std::hex << number_of_faces << " faces\n";
 
                 for( unsigned int i = 0; i < number_of_faces; i++ )
                 {
@@ -435,16 +435,16 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
             }
             else
             if( identifier == TAG_3DRF ) {
-                info_log.output << "3DRF" << std::endl;
+                debug_log.output << "3DRF" << std::endl;
                 auto reader3DRF = reader.getReader( data_tag_size );
                 
-                info_log.output << "Index " << getIndexNumber() << std::endl;
-                info_log.output << "reader3DRF.totalSize() = " << reader3DRF.totalSize() << std::endl;
+                debug_log.output << "Index " << getIndexNumber() << std::endl;
+                debug_log.output << "reader3DRF.totalSize() = " << reader3DRF.totalSize() << std::endl;
                 // assert( reader3DRF.totalSize() == 0x10 );
             }
             else
             if( identifier == TAG_3DRL ) {
-                info_log.output << "3DRL" << std::endl;
+                debug_log.output << "3DRL" << std::endl;
                 auto reader3DRL = reader.getReader( data_tag_size );
             }
             else
@@ -461,7 +461,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 const auto bones_space = reader3DHY.totalSize() - reader3DHY.getPosition();
                 const auto amount_of_bones = bones_space / 0x14;
 
-                info_log.output << "3DHY: size = " << std::dec << amount_of_bones << "\n";
+                debug_log.output << "3DHY: size = " << std::dec << amount_of_bones << "\n";
 
                 if( (bones_space % 0x14) != 0 )
                     warning_log.output << "3DHY bones are not right!\n";
@@ -504,9 +504,9 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                     
                     this->max_bone_childern = std::max( bones.at(i).parent_amount, this->max_bone_childern );
                     
-                    info_log.output << "bone: ";
+                    debug_log.output << "bone: ";
 
-                    info_log.output
+                    debug_log.output
                         << "parent index: 0x" << std::hex << bones.at(i).parent_amount << ", "
                         << "0x" <<    bones.at(i).normal_start << " with 0x" <<  bones.at(i).normal_stride << " normals, "
                         << "0x" <<    bones.at(i).vertex_start << " with 0x" <<  bones.at(i).vertex_stride << " vertices, "
@@ -517,7 +517,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 
                 // The bytes_per_frame_3DMI might not actually hold true.
                 // I found out that the position and the rotation contains the index to 3DMI.
-                info_log.output << "bytes_per_frame_3DMI = 0x" << std::hex << bytes_per_frame_3DMI << "\n";
+                debug_log.output << "bytes_per_frame_3DMI = 0x" << std::hex << bytes_per_frame_3DMI << "\n";
             }
             else
             if( identifier == TAG_3DHS ) {
@@ -531,7 +531,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 
                 frames_gen_3DHS = data_size / ( BONE_SIZE * bone_depth_number );
 
-                info_log.output << std::dec << "3DHS has " << read_3D_positions << " 3D vectors, and contains about " << frames_gen_3DHS << " frames.\n";
+                debug_log.output << std::dec << "3DHS has " << read_3D_positions << " 3D vectors, and contains about " << frames_gen_3DHS << " frames.\n";
                 
                 for( int d = 0; d < frames_gen_3DHS; d++ )
                 {
@@ -550,7 +550,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 auto reader3DMI = reader.getReader( data_tag_size );
                 
                 if( reader3DMI.readU32( settings.endian ) != 1 )
-                    warning_log.output << "3DMI unexpected number at beginning!\n";
+                    debug_log.output << "3DMI unexpected number at beginning!\n";
                 
                 this->bone_animation_data_size = (reader3DMI.totalSize() - reader3DMI.getPosition()) / sizeof( uint16_t );
                 
@@ -566,13 +566,13 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
             if( identifier == TAG_3DTA ) {
                 auto reader3DTA = reader.getReader( data_tag_size );
                 
-                info_log.output << "3DTA is not handled yet.\n";
+                debug_log.output << "3DTA is not handled yet.\n";
             }
             else
             if( identifier == TAG_3DAL ) {
                 auto reader3DAL = reader.getReader( data_tag_size );
                 
-                info_log.output << "3DAL is not handled yet.\n";
+                debug_log.output << "3DAL is not handled yet.\n";
             }
             else
             if( identifier == TAG_4DVL ) {
@@ -581,7 +581,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 auto start_number = reader4DVL.readU32( settings.endian );
                 auto amount_of_vertices = reader4DVL.readU32( settings.endian );
                 
-                info_log.output << "4DVL has 0x" << std::hex << amount_of_vertices << " vertices.\n";
+                debug_log.output << "4DVL has 0x" << std::hex << amount_of_vertices << " vertices.\n";
 
                 auto positions_pointer = &vertex_positions;
 
@@ -608,7 +608,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 auto start_number = reader4DNL.readU32( settings.endian );
                 auto amount_of_normals = reader4DNL.readU32( settings.endian );
 
-                info_log.output << "4DNL has 0x" << std::hex << amount_of_normals << " normals.\n";
+                debug_log.output << "4DNL has 0x" << std::hex << amount_of_normals << " normals.\n";
 
                 auto normals_pointer = &vertex_normals;
 
@@ -638,7 +638,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 auto data_size = readerAnmD.totalSize() - readerAnmD.getPosition();
                 const auto TRACK_AMOUNT = data_size / 0x10;
 
-                info_log.output << std::dec << "AnmD has " << TRACK_AMOUNT << " tracks\n";
+                debug_log.output << std::dec << "AnmD has " << TRACK_AMOUNT << " tracks\n";
 
                 unsigned int start = 0xFFFF, end = 0x0;
                 
@@ -660,7 +660,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                     end = std::max( end, static_cast<unsigned int>( from_frame ) );
                     end = std::max( end, static_cast<unsigned int>( to_frame ) );
 
-                    info_log.output << std::dec << "f: " << from_frame << " t: " << to_frame << " f.d: " << frame_duration << ".\n";
+                    debug_log.output << std::dec << "f: " << from_frame << " t: " << to_frame << " f.d: " << frame_duration << ".\n";
                 }
                 
                 frames_gen_AnmD = end - start + 1;

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -435,12 +435,14 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
             }
             else
             if( identifier == TAG_3DRF ) {
-                debug_log.output << "3DRF" << std::endl;
                 auto reader3DRF = reader.getReader( data_tag_size );
                 
-                debug_log.output << "Index " << getIndexNumber() << std::endl;
-                debug_log.output << "reader3DRF.totalSize() = " << reader3DRF.totalSize() << std::endl;
-                // assert( reader3DRF.totalSize() == 0x10 );
+                debug_log.output << "3DRF" << std::hex << "\n"
+                    << "Index " << getIndexNumber() << "\n"
+                    << "reader3DRF.totalSize() = " << reader3DRF.totalSize() << "\n";
+
+                if( reader3DRF.totalSize() != 0x10 )
+                    warning_log.output << "reader3DRF.totalSize() is not 0x10, but 0x" << std::hex << reader3DRF.totalSize() << ".\n";
             }
             else
             if( identifier == TAG_3DRL ) {
@@ -746,8 +748,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
             }
         }
         
-        // This assertion statement tells that there are only two options for
-        // Animation either morphing or bone animation.
+        // This warning tells that there are only two options for animations either morphing or bone animation.
         if( !( !(( bytes_per_frame_3DMI > 0 ) & ( vertex_anm_positions.size() > 0 )) ) )
             warning_log.output << "Both animation systems are used. This might be a problem because normal Future Cop models do not have both bone and morph animations.\n";
         

--- a/src/Data/Mission/PTCResource.cpp
+++ b/src/Data/Mission/PTCResource.cpp
@@ -4,7 +4,6 @@
 #include "../../Utilities/ModelBuilder.h"
 #include <string>
 #include <algorithm>
-#include <iostream>
 
 namespace {
     const uint32_t GRDB_TAG = 0x47524442; // which is { 0x47, 0x52, 0x44, 0x42 } or { 'G', 'R', 'D', 'B' } or "GRDB"

--- a/src/Data/Mission/PYRResource.cpp
+++ b/src/Data/Mission/PYRResource.cpp
@@ -121,8 +121,10 @@ uint32_t Data::Mission::PYRResource::getResourceTagID() const {
 }
 
 bool Data::Mission::PYRResource::parse( const ParseSettings &settings ) {
+    auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
+    info_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
-    error_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    error_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
     if( this->data_p != nullptr )
         {
@@ -234,7 +236,7 @@ bool Data::Mission::PYRResource::parse( const ParseSettings &settings ) {
                     uint16_t first_zero = readerPYPL.readU16( settings.endian );
                     uint16_t id = readerPYPL.readU16( settings.endian );
 
-                    error_log.output << "PYPL ID: " << std::dec << id << "\n";
+                    info_log.output << "PYPL ID: " << std::dec << id << "\n";
 
                     if( id == particles.at( i ).getID() )
                     {

--- a/src/Data/Mission/PYRResource.cpp
+++ b/src/Data/Mission/PYRResource.cpp
@@ -121,8 +121,8 @@ uint32_t Data::Mission::PYRResource::getResourceTagID() const {
 }
 
 bool Data::Mission::PYRResource::parse( const ParseSettings &settings ) {
-    auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
-    info_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
+    debug_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
     error_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
@@ -236,7 +236,7 @@ bool Data::Mission::PYRResource::parse( const ParseSettings &settings ) {
                     uint16_t first_zero = readerPYPL.readU16( settings.endian );
                     uint16_t id = readerPYPL.readU16( settings.endian );
 
-                    info_log.output << "PYPL ID: " << std::dec << id << "\n";
+                    debug_log.output << "PYPL ID: " << std::dec << id << "\n";
 
                     if( id == particles.at( i ).getID() )
                     {

--- a/src/Data/Mission/PYRResource.cpp
+++ b/src/Data/Mission/PYRResource.cpp
@@ -3,7 +3,6 @@
 #include "../../Utilities/ImageFormat/Chooser.h"
 #include <string.h>
 #include <fstream>
-#include <cassert>
 
 namespace {
     const uint32_t TAG_PYDT = 0x50594454; // which is { 0x50, 0x59, 0x44, 0x54 } or { 'P', 'Y', 'D', 'T' } or "PYDT"
@@ -19,9 +18,9 @@ Data::Mission::PYRResource::Particle::Particle( Utilities::Buffer::Reader &reade
     this->num_sprites = reader.readU8();
     this->sprite_size = reader.readU8(); // Power of two size
 
-    assert( this->num_sprites != 0 ); // This should not crash at all.
+    // assert( this->num_sprites != 0 ); // This should not crash at all.
     // This should not crash at all.
-    assert( (sprite_size == 0x80) | (sprite_size == 0x40) | (sprite_size == 0x20) | (sprite_size == 0x10) );
+    // assert( (sprite_size == 0x80) | (sprite_size == 0x40) | (sprite_size == 0x20) | (sprite_size == 0x10) );
 
     this->textures.reserve( this->num_sprites );
 
@@ -70,9 +69,9 @@ Data::Mission::PYRResource::Particle::Texture::Texture( Utilities::Buffer::Reade
     if( u4 == 1 )
         this->location.y = this->location.y | 256;
 
-    //assert( u4 == 0 ); // This will crash on PS1 not PC
-    assert( (u4 == 0) | (u4 == 1) ); // This will not crash on any platform.
-    assert( u5 == 0 ); // This will crash on PS1 not PC
+    // assert( u4 == 0 ); // This will crash on PS1 not PC
+    // assert( (u4 == 0) | (u4 == 1) ); // This will not crash on any platform.
+    // assert( u5 == 0 ); // This will crash on PS1 not PC
 }
 
 glm::u16vec2 Data::Mission::PYRResource::Particle::Texture::getLocation() const {

--- a/src/Data/Mission/PYRResource.cpp
+++ b/src/Data/Mission/PYRResource.cpp
@@ -121,6 +121,9 @@ uint32_t Data::Mission::PYRResource::getResourceTagID() const {
 }
 
 bool Data::Mission::PYRResource::parse( const ParseSettings &settings ) {
+    auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
+    error_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+
     if( this->data_p != nullptr )
         {
         auto reader = this->data_p->getReader();
@@ -213,8 +216,7 @@ bool Data::Mission::PYRResource::parse( const ParseSettings &settings ) {
             }
             else
             {
-                if( settings.output_level >= 1 )
-                    *settings.output_ref << "PYR Tag Error, 0x" << std::hex << identifier << std::dec << std::endl;
+                error_log.output << "PYR Tag Error, 0x" << std::hex << identifier << "\n";
                 reader.setPosition( tag_data_size, Utilities::Buffer::CURRENT );
             }
         }
@@ -232,8 +234,7 @@ bool Data::Mission::PYRResource::parse( const ParseSettings &settings ) {
                     uint16_t first_zero = readerPYPL.readU16( settings.endian );
                     uint16_t id = readerPYPL.readU16( settings.endian );
 
-                    if( settings.output_level >= 2 )
-                        *settings.output_ref << "PYPL ID: " << id << std::endl;
+                    error_log.output << "PYPL ID: " << std::dec << id << "\n";
 
                     if( id == particles.at( i ).getID() )
                     {
@@ -247,8 +248,7 @@ bool Data::Mission::PYRResource::parse( const ParseSettings &settings ) {
                     }
                     else
                     {
-                        if( settings.output_level >= 1 )
-                            *settings.output_ref << "PYPL Error: id, " << id << ", != " << particles.at( i ).getID() << std::endl;
+                        error_log.output << "PYPL Error: ID, " << std::hex << id << ", != " << particles.at( i ).getID() << "\n";
                         i = amount_of_tiles; // Cancel the reading.
                     }
                 }

--- a/src/Data/Mission/RPNSResource.cpp
+++ b/src/Data/Mission/RPNSResource.cpp
@@ -2,8 +2,6 @@
 #include <limits>
 #include <cassert>
 
-#include <iostream>
-
 const std::string Data::Mission::RPNSResource::FILE_EXTENSION = "rpns";
 // which is { 0x52, 0x50, 0x4E, 0x53 } or { 'R', 'P', 'N', 'S' } or "RPNS"
 const uint32_t Data::Mission::RPNSResource::IDENTIFIER_TAG = 0x52504E53;

--- a/src/Data/Mission/RPNSResource.cpp
+++ b/src/Data/Mission/RPNSResource.cpp
@@ -1,6 +1,5 @@
 #include "RPNSResource.h"
 #include <limits>
-#include <cassert>
 
 const std::string Data::Mission::RPNSResource::FILE_EXTENSION = "rpns";
 // which is { 0x52, 0x50, 0x4E, 0x53 } or { 'R', 'P', 'N', 'S' } or "RPNS"

--- a/src/Data/Mission/Resource.cpp
+++ b/src/Data/Mission/Resource.cpp
@@ -1,7 +1,6 @@
 #include "Resource.h"
 
 #include <fstream>
-#include <iostream>
 #include <cassert>
 
 const Data::Mission::Resource::ParseSettings Data::Mission::Resource::DEFAULT_PARSE_SETTINGS = Data::Mission::Resource::ParseSettings();

--- a/src/Data/Mission/Resource.cpp
+++ b/src/Data/Mission/Resource.cpp
@@ -1,7 +1,6 @@
 #include "Resource.h"
 
 #include <fstream>
-#include <cassert>
 
 const Data::Mission::Resource::ParseSettings Data::Mission::Resource::DEFAULT_PARSE_SETTINGS = Data::Mission::Resource::ParseSettings();
 
@@ -98,6 +97,9 @@ Data::Mission::Resource* Data::Mission::Resource::genResourceByType( const Utili
 }
 
 void Data::Mission::Resource::processHeader( const ParseSettings &settings ) {
+    auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
+    warning_log.info << getFileExtension() << ": " << getResourceID() << " process header.\n";
+
     auto reader = header_p->getReader();
     
     auto unk_0  = reader.readU32( settings.endian ); // 0x00
@@ -106,12 +108,15 @@ void Data::Mission::Resource::processHeader( const ParseSettings &settings ) {
     auto unk_3  = reader.readU32( settings.endian ); // 0x0C
     auto unk_4  = reader.readU32( settings.endian ); // 0x10
     // For Mac and Windows these are the values.
-    // assert( (unk_4 ==  1) || (unk_4 ==  2) || (unk_4 ==  3) || (unk_4 ==  4) || (unk_4 ==  5) || (unk_4 ==  6) || (unk_4 ==  7) ||
-    //         (unk_4 == 10) || (unk_4 == 11) || (unk_4 == 12) || (unk_4 == 13) || (unk_4 == 15) || (unk_4 == 19) || (unk_4 == 20) ||
-    //         (unk_4 == 21) || (unk_4 == 22) || (unk_4 == 23) || (unk_4 == 25) || (unk_4 == 31) || (unk_4 == 39) || (unk_4 == 43) ||
-    //         (unk_4 == 55) );
+    if( !((unk_4 ==  1) || (unk_4 ==  2) || (unk_4 ==  3) || (unk_4 ==  4) || (unk_4 ==  5) || (unk_4 ==  6) || (unk_4 ==  7) ||
+          (unk_4 == 10) || (unk_4 == 11) || (unk_4 == 12) || (unk_4 == 13) || (unk_4 == 15) || (unk_4 == 19) || (unk_4 == 20) ||
+          (unk_4 == 21) || (unk_4 == 22) || (unk_4 == 23) || (unk_4 == 25) || (unk_4 == 31) || (unk_4 == 39) || (unk_4 == 43) ||
+          (unk_4 == 55)) )
+        warning_log.output << std::dec << "unk_4 is " << unk_4 << ".\n";
     auto unk_5 = reader.readU8(); // 0x14
-    assert( (unk_5 == 0) || (unk_5 == 0x81) || (unk_5 == 0x82) || (unk_5 == 0x83) || (unk_5 == 0x89) || (unk_5 == 0x8a) || (unk_5 == 0x8b) || (unk_5 == 0x8c) );
+    if( !((unk_5 == 0) || (unk_5 == 0x81) || (unk_5 == 0x82) || (unk_5 == 0x83) || (unk_5 == 0x89) || (unk_5 == 0x8a) ||
+          (unk_5 == 0x8b) || (unk_5 == 0x8c)) )
+        warning_log.output << std::dec << "unk_5 is " << unk_5 << ".\n";
     auto unk_6 = reader.readU8(); // 0x16
     // I gave up on unk_6 for this assertion test run.
     // assert( (unk_6 == 0) || (unk_6 == 2) || (unk_6 == 16) || (unk_6 == 129) || (unk_6 == 130) || (unk_6 == 135) || (unk_6 == 151) || (unk_6 == 170) || (unk_6 == 207) );
@@ -159,7 +164,7 @@ int Data::Mission::Resource::read( const char *const file_path ) {
         
         data_p = new Utilities::Buffer();
 
-        // To make these operations faster expand the raw_data, so it does not have to reallocate data.
+        // TODO make these operations faster expand the raw_data, so it does not have to reallocate data.
         data_p->reserve( size );
 
         // This will store the byte.

--- a/src/Data/Mission/Resource.cpp
+++ b/src/Data/Mission/Resource.cpp
@@ -6,10 +6,10 @@
 
 const Data::Mission::Resource::ParseSettings Data::Mission::Resource::DEFAULT_PARSE_SETTINGS = Data::Mission::Resource::ParseSettings();
 
-Data::Mission::Resource::ParseSettings::ParseSettings() {
-    type = Unidentified; // We do not know what is being loaded.
-    output_level = 0;
-    output_ref = &std::cout; // The console is the default output.
+Data::Mission::Resource::ParseSettings::ParseSettings() :
+    type( OperatingSystem::Unidentified ),
+    endian( Utilities::Buffer::Endian::NO_SWAP ),
+    logger_r( &Utilities::logger ) {
 }
 
 Data::Mission::Resource::Resource() : header_p( nullptr ), data_p( nullptr ), mis_index_number( -1 ), index_number( -1 ), offset( 0 ) {

--- a/src/Data/Mission/Resource.cpp
+++ b/src/Data/Mission/Resource.cpp
@@ -72,8 +72,6 @@ uint32_t Data::Mission::Resource::getResourceID() const {
     if( !noResourceID() )
         return resource_id;
     
-    assert( resource_id == 1 );
-    
     return resource_id + getIndexNumber();
 }
 

--- a/src/Data/Mission/Resource.h
+++ b/src/Data/Mission/Resource.h
@@ -4,6 +4,7 @@
 #include "IFF.h"
 #include "IFFOptions.h"
 #include "../../Utilities/Buffer.h"
+#include "../../Utilities/Logger.h"
 
 #include <ostream>
 #include <vector>
@@ -20,8 +21,7 @@ public:
         enum OperatingSystem { Macintosh, Windows, Playstation, Unidentified };
         OperatingSystem type; // What type of operating system file type is this loader loading.
         Utilities::Buffer::Endian endian;
-        int output_level; // 0 means no output, 1 means only error, 2 means expressive, 3 maxinum output.
-        std::ostream *output_ref;
+        Utilities::Logger *logger_r;
         
         ParseSettings();
     };

--- a/src/Data/Mission/SNDSResource.cpp
+++ b/src/Data/Mission/SNDSResource.cpp
@@ -1,7 +1,5 @@
 #include "SNDSResource.h"
 
-#include <iostream>
-
 const std::string Data::Mission::SNDSResource::FILE_EXTENSION = "snds";
 const uint32_t Data::Mission::SNDSResource::IDENTIFIER_TAG = 0x736E6473; // which is { 0x73, 0x6E, 0x64, 0x73 } or { 's', 'n', 'd', 's' } or "snds"
 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -284,10 +284,8 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 if( skipped_space )
                 {
                     warning_log.output << "\n"
-                        << "The resource number " << std::dec << this->getResourceID() << " has " << skipped_space << " skipped.\n"
-                        << "mesh_library_size is 0x" << std::hex << this->mesh_library_size
-                        << " or 0x" << (this->mesh_library_size >> 4)
-                        << " or " << std::dec << PREDICTED_POLYGON_TILE_AMOUNT << "\n";
+                        << "This resource has " << skipped_space << " skipped.\n"
+                        << "mesh_library_size is 0x" << std::hex << this->mesh_library_size << "\n";
                 }
 
                 // Read the UV's

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -153,6 +153,11 @@ void Data::Mission::TilResource::makeEmpty() {
 }
 
 bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
+    auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
+    info_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
+    warning_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+
     if( this->data_p != nullptr ) {
         auto reader = this->data_p->getReader();
         
@@ -172,13 +177,9 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 auto color_amount = reader_sect.readU16( settings.endian );
                 auto texture_cordinates_amount = reader_sect.readU16( settings.endian );
                 
-                if( settings.output_level >= 1 )
-                {
-                    *settings.output_ref << "Mission::TilResource::load() id = " << getIndexNumber() << std::endl;
-                    *settings.output_ref << "Mission::TilResource::load() loc = 0x" << std::hex << getOffset() << std::dec << std::endl;
-                    *settings.output_ref << "Color amount = " << color_amount << std::endl;
-                    *settings.output_ref << "texture_cordinates_amount = " << texture_cordinates_amount << std::endl;
-                }
+                info_log.output << "loc = 0x" << std::hex << getOffset() << std::dec << "\n";
+                info_log.output << "Color amount = " << color_amount << "\n";
+                info_log.output << "texture_cordinates_amount = " << texture_cordinates_amount << "\n";
                 
                 // setup the point_cloud_3_channel.
                 point_cloud_3_channel.setDimensions( AMOUNT_OF_TILES + 1, AMOUNT_OF_TILES + 1 );
@@ -223,8 +224,8 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 auto what1 = reader_sect.readU16( settings.endian );
                 
                 // Modifiying this to be other than what it is will cause an error?
-                if( what1 != 0 && settings.output_level >= 1 )
-                    *settings.output_ref << "Error expected zero in the Til resource." << (unsigned)what1 << std::endl;
+                if( what1 != 0 )
+                    warning_log.output << "Expected zero in the Til resource." << (unsigned)what1 << "\n";
                 
                 this->texture_reference = reader_sect.readU16( settings.endian );
                 
@@ -262,12 +263,12 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                     actual_polygon_tile_amount++;
                 }
 
-                if( actual_polygon_tile_amount != PREDICTED_POLYGON_TILE_AMOUNT && settings.output_level >= 1  ) {
-                    *settings.output_ref << "\n"
-                    << "The resource id " << this->getResourceID() << " has mispredicted the polygon tile amount." << "\n"
+                if( actual_polygon_tile_amount != PREDICTED_POLYGON_TILE_AMOUNT ) {
+                    warning_log.output << "\n"
+                    << "This resource has mispredicted the polygon tile amount.\n"
                     << " mesh_library_size is 0x" << std::hex << this->mesh_library_size << std::dec << "\n"
                     << " The predicted polygons to be there are " << PREDICTED_POLYGON_TILE_AMOUNT << "\n"
-                    << " The amount of polygons that exist are  " << actual_polygon_tile_amount << std::endl;
+                    << " The amount of polygons that exist are  " << actual_polygon_tile_amount << "\n";
                 }
                 
                 bool skipped_space = false;
@@ -279,13 +280,13 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 // Undo the read after the bytes are skipped.
                 reader_sect.setPosition( -static_cast<int>(sizeof( uint32_t )), Utilities::Buffer::CURRENT );
 
-                if( skipped_space && settings.output_level >= 3 )
+                if( skipped_space )
                 {
-                    *settings.output_ref << std::endl
-                    << "The resource number " << this->getResourceID() << " has " << skipped_space << " skipped." << std::endl
+                    warning_log.output << "\n"
+                    << "The resource number " << std::dec << this->getResourceID() << " has " << skipped_space << " skipped.\n"
                     << "mesh_library_size is 0x" << std::hex << this->mesh_library_size
-                    << " or 0x" << (this->mesh_library_size >> 4)
-                    << " or " << std::dec << PREDICTED_POLYGON_TILE_AMOUNT << std::endl;
+                    << " or 0x" << std::hex << (this->mesh_library_size >> 4)
+                    << " or " << std::dec << PREDICTED_POLYGON_TILE_AMOUNT << "\n";
                 }
 
                 // Read the UV's
@@ -345,13 +346,9 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
             }
             else
             {
-                if( settings.output_level >= 0 ) {
-                    *settings.output_ref << "Mission::TilResource::load() " << identifier << " not recognized" << std::endl;
-                }
+                warning_log.output << "Identifier 0x" << std::hex << identifier << " not recognized.\n";
                 
                 reader.setPosition( data_size, Utilities::Buffer::CURRENT );
-                
-                assert( false );
             }
         }
         

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -7,7 +7,6 @@
 #include "../../Utilities/ImageFormat/Chooser.h"
 #include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <cassert>
 #include <set>
 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -154,9 +154,9 @@ void Data::Mission::TilResource::makeEmpty() {
 
 bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
     auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
-    info_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    info_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
-    warning_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    warning_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
     if( this->data_p != nullptr ) {
         auto reader = this->data_p->getReader();
@@ -225,7 +225,7 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 
                 // Modifiying this to be other than what it is will cause an error?
                 if( what1 != 0 )
-                    warning_log.output << "Expected zero in the Til resource." << (unsigned)what1 << "\n";
+                    warning_log.output << "Expected zero in the Til resource rather than " << (unsigned)what1 << "\n";
                 
                 this->texture_reference = reader_sect.readU16( settings.endian );
                 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -155,6 +155,8 @@ void Data::Mission::TilResource::makeEmpty() {
 bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
     auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
     info_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
+    debug_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
     warning_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
@@ -227,9 +229,9 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 
                 // Modifiying this to be other than what it is will cause an error?
                 if( unk_byte_0 != 0 )
-                    warning_log.output << "Expected zero in unk_byte_0 the Til resource rather than " << (unsigned)unk_byte_0 << "\n";
+                    debug_log.output << "Expected zero in unk_byte_0 rather than " << (unsigned)unk_byte_0 << ".\n";
                 if( unk_byte_1 != 0 )
-                    warning_log.output << "Expected zero in unk_byte_1 the Til resource rather than " << (unsigned)unk_byte_1 << "\n";
+                    debug_log.output << "Expected zero in unk_byte_1 rather than " << (unsigned)unk_byte_1 << ".\n";
                 
                 this->texture_reference = reader_sect.readU16( settings.endian );
                 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -433,7 +433,6 @@ int Data::Mission::TilResource::write( const std::string& file_path, const Data:
 
         if( iff_options.til.enable_til_backface_culling ) {
             model_output_p = createCulledModel();
-            assert( model_output_p != nullptr );
         }
 
         if( model_output_p == nullptr )

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -153,8 +153,6 @@ void Data::Mission::TilResource::makeEmpty() {
 }
 
 bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
-    auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
-    info_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
     debug_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
@@ -180,7 +178,7 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 auto color_amount = reader_sect.readU16( settings.endian );
                 auto texture_cordinates_amount = reader_sect.readU16( settings.endian );
 
-                info_log.output << "loc = 0x" << std::hex << getOffset() << std::dec << "\n"
+                debug_log.output << "loc = 0x" << std::hex << getOffset() << std::dec << "\n"
                     << "Color amount = " << color_amount << "\n"
                     << "texture_cordinates_amount = " << texture_cordinates_amount << "\n";
                 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -221,11 +221,15 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 readCullingTile( culling_bottom_left,  reader_sect, settings.endian );
                 readCullingTile( culling_bottom_right, reader_sect, settings.endian );
                 
-                auto what1 = reader_sect.readU16( settings.endian );
+                // These are most likely bytes.
+                auto unk_byte_0 = reader_sect.readU8();
+                auto unk_byte_1 = reader_sect.readU8();
                 
                 // Modifiying this to be other than what it is will cause an error?
-                if( what1 != 0 )
-                    warning_log.output << "Expected zero in the Til resource rather than " << (unsigned)what1 << "\n";
+                if( unk_byte_0 != 0 )
+                    warning_log.output << "Expected zero in unk_byte_0 the Til resource rather than " << (unsigned)unk_byte_0 << "\n";
+                if( unk_byte_1 != 0 )
+                    warning_log.output << "Expected zero in unk_byte_1 the Til resource rather than " << (unsigned)unk_byte_1 << "\n";
                 
                 this->texture_reference = reader_sect.readU16( settings.endian );
                 

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -190,9 +190,9 @@ public:
     virtual Utilities::ModelBuilder * createModel() const { return createModel( false ); }
     virtual Utilities::ModelBuilder * createCulledModel() const { return createModel( true ); }
 
-    virtual Utilities::ModelBuilder * createModel( bool is_culled ) const;
+    virtual Utilities::ModelBuilder * createModel( bool is_culled, Utilities::Logger &logger = Utilities::logger ) const;
     
-    Utilities::ModelBuilder * createPartial( unsigned int texture_index, bool is_culled = false, float x_offset = 0.0f, float z_offset = 0.0f ) const;
+    Utilities::ModelBuilder * createPartial( unsigned int texture_index, bool is_culled = false, float x_offset = 0.0f, float z_offset = 0.0f, Utilities::Logger &logger = Utilities::logger ) const;
     
     void createPhysicsCell( unsigned int x, unsigned int z );
     

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -104,7 +104,8 @@ public:
     struct TileGraphics {
         uint16_t shading : 8; // Lighting information, but they do change meaning depending type bitfield
         uint16_t texture_index : 3; // Holds the index of the texture the tile references.
-        uint16_t unknown_0 : 2;
+        uint16_t animated : 1;
+        uint16_t semi_transparent : 1;
         uint16_t rectangle : 1; // Indicates rectangle/square?
         uint16_t type : 2; // Tells how the tile will be drawn.
         
@@ -114,17 +115,19 @@ public:
         }
         
         void set( const uint16_t bitfield ) {
-            shading        = (bitfield >>  0) & ((1 << 8) - 1);
-            texture_index  = (bitfield >>  8) & ((1 << 3) - 1);
-            unknown_0      = (bitfield >> 11) & ((1 << 2) - 1);
-            rectangle      = (bitfield >> 13) & ((1 << 1) - 1);
-            type           = (bitfield >> 14) & ((1 << 2) - 1);
+            shading          = (bitfield >>  0) & ((1 << 8) - 1);
+            texture_index    = (bitfield >>  8) & ((1 << 3) - 1);
+            animated         = (bitfield >> 11) & ((1 << 1) - 1);
+            semi_transparent = (bitfield >> 12) & ((1 << 1) - 1);
+            rectangle        = (bitfield >> 13) & ((1 << 1) - 1);
+            type             = (bitfield >> 14) & ((1 << 2) - 1);
         }
         
         uint16_t get() const {
             return ((uint16_t)shading << 0) |
                 ((uint16_t)texture_index << 8) |
-                ((uint16_t)unknown_0 << 11) |
+                ((uint16_t)animated << 11) |
+                ((uint16_t)semi_transparent << 12) |
                 ((uint16_t)rectangle << 13) |
                 ((uint16_t)type << 14);
         }
@@ -144,10 +147,10 @@ private:
     CullingTile culling_bottom_left;
     CullingTile culling_bottom_right;
 
-    uint16_t texture_reference; // This is an unknown number, but it affects all the textures in the file. One change might mess up the tiles.
+    uint16_t texture_reference; // This is an unknown number, but it affects all the textures in the resource. One change will mess up the tiles.
     Floor mesh_reference_grid[ AMOUNT_OF_TILES ][ AMOUNT_OF_TILES ];
 
-    uint16_t mesh_library_size; // This is the number of unknown numbers but 4 times bigger for some reason.
+    uint16_t mesh_library_size;
     std::vector<Tile> mesh_tiles; // These are descriptions of tiles that are used to make up the map format. The 32 bit numbers are packed with information
 
     std::vector<glm::u8vec2> texture_cords; // They contain the UV's for the tiles, they are often read as quads
@@ -158,9 +161,8 @@ private:
     
     struct TextureInfo {
         std::string name;
-        std::vector<bool> is_semi_transparent;
     };
-    TextureInfo texture_info[8]; // There can only be 2*2*2 or 8 texture names;
+    TextureInfo texture_info[8]; // There can only be 2*2*2 or 8 texture resource IDs.
     
     std::vector<Utilities::Collision::Triangle> all_triangles; // This stores all the triangles in the Til Resource.
 public:

--- a/src/Data/Mission/WAVResource.cpp
+++ b/src/Data/Mission/WAVResource.cpp
@@ -2,7 +2,6 @@
 
 #include <string.h>
 #include <fstream>
-#include <iostream>
 
 namespace {
     uint32_t TAG_CHUNK_ID = 0x52494646; // which is { 0x52, 0x49, 0x46, 0x46 } or { 'R', 'I', 'F', 'F' } or "RIFF"

--- a/src/Data/Mission/WAVResource.cpp
+++ b/src/Data/Mission/WAVResource.cpp
@@ -12,8 +12,8 @@ namespace {
 }
 
 bool Data::Mission::WAVResource::parse( const ParseSettings &settings ) {
-    auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
-    info_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
+    debug_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
     error_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
@@ -67,7 +67,7 @@ bool Data::Mission::WAVResource::parse( const ParseSettings &settings ) {
                     
                     setAudioStream( reader );
 
-                    info_log.output << "This is a wav file." << std::endl;
+                    debug_log.output << "This is a wav file." << std::endl;
                     
                     return true;
                 }

--- a/src/Data/Mission/WAVResource.cpp
+++ b/src/Data/Mission/WAVResource.cpp
@@ -14,9 +14,9 @@ namespace {
 
 bool Data::Mission::WAVResource::parse( const ParseSettings &settings ) {
     auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
-    info_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    info_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
-    error_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    error_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
     if( this->data_p != nullptr ) {
         auto reader = this->data_p->getReader();

--- a/src/Data/Mission/WAVResource.cpp
+++ b/src/Data/Mission/WAVResource.cpp
@@ -13,6 +13,11 @@ namespace {
 }
 
 bool Data::Mission::WAVResource::parse( const ParseSettings &settings ) {
+    auto info_log = settings.logger_r->getLog( Utilities::Logger::INFO );
+    info_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
+    error_log.output << FILE_EXTENSION << ": " << getResourceID() << "\n";
+
     if( this->data_p != nullptr ) {
         auto reader = this->data_p->getReader();
         
@@ -63,26 +68,21 @@ bool Data::Mission::WAVResource::parse( const ParseSettings &settings ) {
                     
                     setAudioStream( reader );
 
-                    if( settings.output_level >= 3 )
-                        *settings.output_ref << "This is a wav file." << std::endl;
+                    info_log.output << "This is a wav file." << std::endl;
                     
                     return true;
                 }
                 else {
-                    if( settings.output_level >= 1 )
-                        *settings.output_ref << "Potential buffer overflow attempt detected. Please at least scan it for viruses if you got this one from the internet!" << std::endl;
+                    error_log.output << "Potential buffer overflow attempt detected. Please at least scan it for viruses if you got this one from the internet!\n";
                     return false;
                 }
             }
             else
             {
-                if( settings.output_level >= 1 )
-                {
-                    if( size_of_chunk_1 == 16 )
-                        *settings.output_ref << "This is not a wav file." << std::endl;
-                    else
-                        *settings.output_ref << "This pariticalar wav file's format is not supported." << std::endl;
-                }
+                if( size_of_chunk_1 == 16 )
+                    error_log.output << "This is not a wav file.\n";
+                else
+                    error_log.output << "This pariticalar wav file's format is not supported.\n" ;
                 return false;
             }
         }

--- a/src/FCMapViewer.cpp
+++ b/src/FCMapViewer.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
         }
     }
 
-    Utilities::logger.setOutputLog( &std::cout, 0, Utilities::Logger::WARNING );
+    Utilities::logger.setOutputLog( &std::cout, 0, Utilities::Logger::INFO );
 
     {
         auto initialize_log = Utilities::logger.getLog( Utilities::Logger::ALL );

--- a/src/FCMapViewer.cpp
+++ b/src/FCMapViewer.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
         }
     }
 
-    Utilities::logger.setOutputLog( &std::cout, 0, Utilities::Logger::ERROR );
+    Utilities::logger.setOutputLog( &std::cout, 0, Utilities::Logger::WARNING );
 
     {
         auto initialize_log = Utilities::logger.getLog( Utilities::Logger::ALL );

--- a/src/FCMapViewer.cpp
+++ b/src/FCMapViewer.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
         }
     }
 
-    Utilities::logger.setOutputLog( &std::cout, 0, Utilities::Logger::WARNING );
+    Utilities::logger.setOutputLog( &std::cout, 0, Utilities::Logger::ERROR );
 
     {
         auto initialize_log = Utilities::logger.getLog( Utilities::Logger::ALL );

--- a/src/FCMapViewer.cpp
+++ b/src/FCMapViewer.cpp
@@ -20,6 +20,7 @@
 #include "Controls/System.h"
 #include "Controls/StandardInputSet.h"
 
+#include "Utilities/Logger.h"
 #include "Utilities/ImageFormat/Chooser.h"
 
 #include "ConfigureInput.h"
@@ -133,6 +134,14 @@ int main(int argc, char** argv)
             variable_name = "";
         }
     }
+
+    Utilities::logger.setOutputLog( &std::cout, 0, Utilities::Logger::WARNING );
+
+    {
+        auto initialize_log = Utilities::logger.getLog( Utilities::Logger::ALL );
+        initialize_log.output << "FCMapViewer started at ";
+    }
+    Utilities::logger.setTimeStampMode( true );
     
     if( width <= 0 )
         width = 640;
@@ -141,41 +150,54 @@ int main(int argc, char** argv)
 
     auto graphics_identifiers = Graphics::Environment::getAvailableIdentifiers();
     
-    if( graphics_identifiers.size() == 0 )
-        return -37;
+    if( graphics_identifiers.size() == 0 ) {
+
+        auto log = Utilities::logger.getLog( Utilities::Logger::CRITICAL );
+        log.output << "Graphics has no available identifiers.";
+        return -1;
+    }
     
-    if( !Graphics::Environment::isIdentifier( graphics_identifiers[0] ) )
-        return -38;
+    if( !Graphics::Environment::isIdentifier( graphics_identifiers[0] ) ) {
+        auto log = Utilities::logger.getLog( Utilities::Logger::CRITICAL );
+        log.output << "The graphics identifier \"" << graphics_identifiers[0] << "\" is not an identifer.";
+        return -2;
+    }
 
     Graphics::Environment::initSystem( graphics_identifiers[0] );
     
     Graphics::Environment *environment_p = Graphics::Environment::alloc( graphics_identifiers[0] );
-    if( environment_p == nullptr )
-        return -39;
-    
+    if( environment_p == nullptr ) {
+        auto log = Utilities::logger.getLog( Utilities::Logger::CRITICAL );
+        log.output << "The graphics environment has failed to allocate.";
+        return -3;
+    }
     
     // Declare a pointer
-    Graphics::Window *window_p = nullptr;
-    
-    {
-        window_p = Graphics::Window::alloc( *environment_p );
+    Graphics::Window *window_r = Graphics::Window::alloc( *environment_p );
         
-        if( window_p == nullptr ) {
-            delete environment_p;
-            return -40;
-        }
+    if( window_r == nullptr ) {
+        auto log = Utilities::logger.getLog( Utilities::Logger::CRITICAL );
+        log.output << "The graphics window has failed to allocate.";
+        delete environment_p;
+        return -4;
     }
+
     std::string title = "Future Cop Map Viewer";
 
-    window_p->setWindowTitle( title );
-    if( window_p->center() != 1 )
-        std::cout << "The window had failed to center! " << window_p->center() << std::endl;
-    window_p->setDimensions( glm::u32vec2( width, height ) );
-    window_p->setFullScreen( true );
+    window_r->setWindowTitle( title );
+    if( window_r->center() != 1 ) {
+        auto log = Utilities::logger.getLog( Utilities::Logger::WARNING );
+        log.output << "The graphics window has failed to center.";
+    }
+    window_r->setDimensions( glm::u32vec2( width, height ) );
+    window_r->setFullScreen( false );
     
-    if( window_p->attach() != 1 ) {
+    if( window_r->attach() != 1 ) {
+        auto log = Utilities::logger.getLog( Utilities::Logger::CRITICAL );
+        log.output << "The graphics window has failed to attach.";
+
         delete environment_p;
-        return -40;
+        return -5;
     }
     
     Data::Manager manager;
@@ -203,17 +225,23 @@ int main(int argc, char** argv)
     }
 
     if( !manager.hasEntry( iff_mission_id ) ) {
+
+        // Cout is fine for this case because it always needs to be shown in a terminal.
         Data::Manager::listIDs( std::cout );
+
         delete environment_p;
-        return -1;
+        return -6;
     }
 
     auto entry = manager.getIFFEntry( iff_mission_id );
     entry.importance = Data::Manager::Importance::NEEDED;
 
     if( !manager.setIFFEntry( iff_mission_id, entry ) ) {
+        auto log = Utilities::logger.getLog( Utilities::Logger::CRITICAL );
+        log.output << "Set IFF Entry has failed for \"" << iff_mission_id << "\".";
+
         delete environment_p;
-        return -2;
+        return -7;
     }
     
     manager.togglePlatform( platform, true );
@@ -224,9 +252,11 @@ int main(int argc, char** argv)
     auto number_of_iffs = manager.setLoad( load_all );
 
     if( number_of_iffs < 2 ) {
-        std::cout << "The number IFF " << number_of_iffs << " is not enough." << std::endl;
+        auto log = Utilities::logger.getLog( Utilities::Logger::CRITICAL );
+        log.output << "The number IFF " << number_of_iffs << " is not enough.";
+
         delete environment_p;
-        return -3;
+        return -8;
     }
     
     std::vector<Data::Mission::IFF*> loaded_IFFs;
@@ -234,14 +264,18 @@ int main(int argc, char** argv)
     Data::Mission::IFF *global_r = manager.getIFFEntry( global_id ).getIFF( platform );
     if( global_r != nullptr )
         loaded_IFFs.push_back( global_r );
-    else
-        std::cout << "The global IFF " << global_id << " did not load." << std::endl;
+    else {
+        auto log = Utilities::logger.getLog( Utilities::Logger::ERROR );
+        log.output << "The global IFF " << global_id << " did not load.";
+    }
 
     Data::Mission::IFF *resource_r = manager.getIFFEntry( iff_mission_id ).getIFF( platform );
     if( resource_r != nullptr )
         loaded_IFFs.push_back( resource_r );
-    else
-        std::cout << "The mission IFF " << iff_mission_id << " did not load." << std::endl;
+    else {
+        auto log = Utilities::logger.getLog( Utilities::Logger::ERROR );
+        log.output << "The mission IFF " << iff_mission_id << " did not load.";
+    }
 
     // First get the model textures from the resource file.
     if( resource_r != nullptr ) {
@@ -249,8 +283,10 @@ int main(int argc, char** argv)
 
         int status = environment_p->setupTextures( cbmp_resources );
 
-        if( status < 0 )
-            std::cout << (-status) << " general textures had failed to load out of " << cbmp_resources.size() << std::endl;
+        if( status < 0 ) {
+            auto log = Utilities::logger.getLog( Utilities::Logger::ERROR );
+            log.output << (-status) << " general textures had failed to load out of " << cbmp_resources.size();
+        }
     }
 
     // Load all the 3D meshes from the resource as well.
@@ -259,13 +295,16 @@ int main(int argc, char** argv)
 
         int status = environment_p->setModelTypes( cobj_resources );
 
-        if( status < 0 )
-            std::cout << (-status) << " 3d meshes had failed to load out of " << cobj_resources.size() << std::endl;
+        if( status < 0 ) {
+            auto log = Utilities::logger.getLog( Utilities::Logger::ERROR );
+            log.output << (-status) << " 3d meshes had failed to load out of " << cobj_resources.size();
+        }
     }
     
     // Get the font from the resource file.
     if( Graphics::Text2DBuffer::loadFonts( *environment_p, loaded_IFFs ) == 0 ) {
-        std::cout << "Fonts missing!" << std::endl;
+        auto log = Utilities::logger.getLog( Utilities::Logger::ERROR );
+        log.output << "Fonts are missing.";
     }
 
     std::vector<Data::Mission::TilResource*> til_resources;
@@ -282,7 +321,7 @@ int main(int argc, char** argv)
     // Setup the camera
     Graphics::Camera *first_person_r = Graphics::Camera::alloc( *environment_p );
     first_person_r->attachText2DBuffer( *text_2d_buffer_r );
-    window_p->attachCamera( *first_person_r );
+    window_r->attachCamera( *first_person_r );
     first_person_r->setViewportOrigin( glm::u32vec2( 0, 0 ) );
     first_person_r->setViewportDimensions( glm::u32vec2( width, height ) );
     glm::mat4 extra_matrix_0;
@@ -312,8 +351,10 @@ int main(int argc, char** argv)
     double distance_away = -10;
     bool is_camera_moving = false;
 
-    if( window_p->center() != 1 )
-        std::cout << "The window had failed to center! " << window_p->center() << std::endl;
+    if( window_r->center() != 1 ) {
+        auto log = Utilities::logger.getLog( Utilities::Logger::ERROR );
+        log.output << "The window had failed to center.";
+    }
 
     // Setup the controls
     auto control_system_p = Controls::System::getSingleton(); // create the new system for controls

--- a/src/FCMissionReader.cpp
+++ b/src/FCMissionReader.cpp
@@ -4,6 +4,7 @@
 #include "Config.h"
 #include "Data/Mission/BMPResource.h"
 #include "Data/Mission/Til/Mesh.h"
+#include "Utilities/Logger.h"
 
 namespace {
     std::string INPUT_OPERATION = "-i";
@@ -35,7 +36,13 @@ namespace {
 }
 
 int main( int argc, char *argv[] ) {
-    // Data::Mission::Til::Mesh::loadMeshScript( "./tile_set.json", nullptr );
+    Utilities::logger.setOutputLog( &std::cout, 0, Utilities::Logger::WARNING );
+
+    {
+        auto initialize_log = Utilities::logger.getLog( Utilities::Logger::ALL );
+        initialize_log.output << "FCMissionReader started at ";
+    }
+    Utilities::logger.setTimeStampMode( true );
 
     Data::Mission::IFF mission_file[2]; // Two mission files at a time for now.
     std::string output_folder_path = "./output/";
@@ -58,7 +65,8 @@ int main( int argc, char *argv[] ) {
                     mission_file[ number_of_inputs++ ].open( argv[++i] );
                 else
                 {
-                    std::cout << "Input Error: you exceeded the limit of two input Mission files." << std::endl;
+                    auto log = Utilities::logger.getLog( Utilities::Logger::CRITICAL );
+                    log.output << "You exceeded the limit of two input Mission files.";
                     i = argc;
                 }
             else
@@ -91,7 +99,8 @@ int main( int argc, char *argv[] ) {
             else
             if( COMPARE_OUTPUT_OPERATION.compare( input ) == 0 ) {
                 if( number_of_inputs < 2 ) {
-                    std::cout << "Input Error: only two inputs are allowed not three more." << std::endl;
+                    auto log = Utilities::logger.getLog( Utilities::Logger::CRITICAL );
+                    log.output << "Only two inputs are allowed not three more.";
                     i = argc;
                 }
                 else

--- a/src/FCModelViewer.cpp
+++ b/src/FCModelViewer.cpp
@@ -155,7 +155,7 @@ int main(int argc, char** argv)
         }
     }
 
-    Utilities::logger.setOutputLog( &std::cout, 0, Utilities::Logger::WARNING );
+    Utilities::logger.setOutputLog( &std::cout, 0, Utilities::Logger::INFO );
 
     {
         auto initialize_log = Utilities::logger.getLog( Utilities::Logger::ALL );

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -31,13 +31,19 @@ public:
             MeshDraw *mesh_draw_r;
             GLfloat selected_tile;
             GLfloat glow_time;
+            glm::vec2 animated_uv_destination;
 
             void addTriangles( const std::vector<DynamicTriangleDraw::Triangle> &triangles, DynamicTriangleDraw::DrawCommand &triangles_draw ) const;
         };
 
+        struct Info {
+            int_fast8_t type;
+            int_fast8_t animated;
+        };
+
         Mesh *mesh_p;
         std::vector<DynamicTriangleDraw::Triangle> transparent_triangles;
-        std::vector<int_fast8_t> transparent_triangle_info;
+        std::vector<Info> transparent_triangle_info;
         const Data::Mission::TilResource *til_resource_r;
         float change_rate;
         float current; // [ -change_rate, change_rate ]
@@ -54,12 +60,15 @@ protected:
     Shader fragment_shader;
     GLuint texture_uniform_id;
     GLuint matrix_uniform_id;
+    GLuint animated_uv_destination_id;
     GLuint glow_time_uniform_id;
     GLuint selected_tile_uniform_id;
     std::vector<MeshDraw> tiles;
     
     GLfloat selected_tile;
     GLfloat current_selected_tile;
+    glm::vec2 animated_uv_destination;
+    float     animated_uv_time;
     GLfloat scale;
     GLfloat glow_time;
 public:

--- a/src/Graphics/SDL2/GLES2/Text2DBuffer.cpp
+++ b/src/Graphics/SDL2/GLES2/Text2DBuffer.cpp
@@ -38,7 +38,6 @@ int Graphics::SDL2::GLES2::Text2DBuffer::loadFonts( Graphics::Environment &envir
     auto gl_environment_r = dynamic_cast<Graphics::SDL2::GLES2::Environment*>(&environment);
 
     assert( gl_environment_r != nullptr ); // Graphics::SDL2::GLES2::Environment is expected here!
-
     
     if( gl_environment_r->text_draw_routine_p != nullptr )
         delete gl_environment_r->text_draw_routine_p;
@@ -67,15 +66,15 @@ int Graphics::SDL2::GLES2::Text2DBuffer::loadFonts( Graphics::Environment &envir
 
     // If no fonts are found then add one.
     if( !has_resource_id_1 ) {
-        fonts_r.push_back( Data::Mission::FontResource::getPlaystation( &std::cout, 2 ) );
+        fonts_r.push_back( Data::Mission::FontResource::getPlaystation( Utilities::logger ) );
         has_del_symbol = true;
     }
     if( !has_resource_id_2 ) {
-        fonts_r.push_back( Data::Mission::FontResource::getWindows( &std::cout, 2 ) );
+        fonts_r.push_back( Data::Mission::FontResource::getWindows( Utilities::logger ) );
         has_del_symbol = true;
     }
     if( !has_del_symbol ) {
-        auto font_p = Data::Mission::FontResource::getWindows( &std::cout, 2 );
+        auto font_p = Data::Mission::FontResource::getWindows( Utilities::logger );
         font_p->setResourceID( 0 );
         fonts_r.push_back( font_p );
         has_del_symbol = true;

--- a/src/Tests/Data/Mission/FontResource.cpp
+++ b/src/Tests/Data/Mission/FontResource.cpp
@@ -6,7 +6,7 @@
 #include "Embedded/PFNT.h"
 #include "Embedded/PFNTExpected.h"
 
-Data::Mission::FontResource* getMacintosh( std::ostream *stream, int output_level ) {
+Data::Mission::FontResource* getMacintosh( Utilities::Logger &logger ) {
     Data::Mission::FontResource* macintosh_font_p = new Data::Mission::FontResource;
 
     macintosh_font_p->setIndexNumber( 0 );
@@ -20,8 +20,7 @@ Data::Mission::FontResource* getMacintosh( std::ostream *stream, int output_leve
     Data::Mission::Resource::ParseSettings parse_settings;
     parse_settings.type = Data::Mission::Resource::ParseSettings::Macintosh;
     parse_settings.endian = Utilities::Buffer::BIG;
-    parse_settings.output_level = output_level;
-    parse_settings.output_ref = stream;
+    parse_settings.logger_r = &logger;
 
     if( !macintosh_font_p->parse( parse_settings ) )
         throw std::logic_error( "Internal Error: The internal Mac font has failed to parse!");
@@ -281,7 +280,7 @@ int main() {
     const int OUTPUT_LEVEL = 0;
     
     {
-        auto windows_font_r = Data::Mission::FontResource::getWindows( &std::cout, OUTPUT_LEVEL );
+        auto windows_font_r = Data::Mission::FontResource::getWindows( Utilities::logger );
         std::string name = "Windows";
         
         if( windows_font_r == nullptr ) {
@@ -303,7 +302,7 @@ int main() {
     }
     
     {
-        auto mac_font_r = getMacintosh( &std::cout, OUTPUT_LEVEL );
+        auto mac_font_r = getMacintosh( Utilities::logger );
         std::string name = "Macintosh";
         
         if( mac_font_r == nullptr ) {
@@ -325,7 +324,7 @@ int main() {
     }
     
     {
-        auto ps1_font_r = Data::Mission::FontResource::getPlaystation( &std::cout, OUTPUT_LEVEL );
+        auto ps1_font_r = Data::Mission::FontResource::getPlaystation( Utilities::logger );
         std::string name = "Playstation";
         
         if( ps1_font_r == nullptr ) {

--- a/src/Tests/Data/Mission/TilResource.cpp
+++ b/src/Tests/Data/Mission/TilResource.cpp
@@ -138,41 +138,43 @@ int main() {
         Data::Mission::TilResource::TileGraphics tile_graphics;
         
         tile_graphics.set( 0b0000000010010111 );
-        if( tile_graphics.shading   != 0b10010111 || tile_graphics.texture_index != 0 ||
-            tile_graphics.unknown_0 != 0          || tile_graphics.rectangle     != 0 ||
-            tile_graphics.type      != 0 ) {
+        if( tile_graphics.shading   != 0b10010111 || tile_graphics.texture_index     != 0 ||
+            tile_graphics.animated  != 0          || tile_graphics.semi_transparent  != 0 || tile_graphics.rectangle != 0          || tile_graphics.type      != 0 ) {
             std::cout << "Error: the TileGraphics bitfield regarding shading is flawed!" << std::endl;
             is_not_success = true;
         }
 
         tile_graphics.set( 0b00000011100000000 );
-        if( tile_graphics.shading   != 0 || tile_graphics.texture_index != 0b111 ||
-            tile_graphics.unknown_0 != 0 || tile_graphics.rectangle     != 0 ||
-            tile_graphics.type      != 0 ) {
+        if( tile_graphics.shading   != 0 || tile_graphics.texture_index    != 0b111 ||
+            tile_graphics.animated  != 0 || tile_graphics.semi_transparent != 0     || tile_graphics.rectangle != 0 || tile_graphics.type             != 0 ) {
             std::cout << "Error: the TileGraphics bitfield regarding texture_index is flawed!" << std::endl;
             is_not_success = true;
         }
 
-        tile_graphics.set( 0b0001100000000000 );
-        if( tile_graphics.shading   != 0    || tile_graphics.texture_index != 0 ||
-            tile_graphics.unknown_0 != 0b11 || tile_graphics.rectangle     != 0 ||
-            tile_graphics.type      != 0 ) {
-            std::cout << "Error: the TileGraphics bitfield regarding unknown_0 is flawed!" << std::endl;
+        tile_graphics.set( 0b0001000000000000 );
+        if( tile_graphics.shading   != 0 || tile_graphics.texture_index    != 0 ||
+            tile_graphics.animated  != 0 || tile_graphics.semi_transparent != 1 || tile_graphics.rectangle != 0 || tile_graphics.type             != 0 ) {
+            std::cout << "Error: the TileGraphics bitfield regarding semi_transparent is flawed!" << std::endl;
+            is_not_success = true;
+        }
+
+        tile_graphics.set( 0b0000100000000000 );
+        if( tile_graphics.shading   != 0 || tile_graphics.texture_index    != 0 ||
+            tile_graphics.animated  != 1 || tile_graphics.semi_transparent != 0 || tile_graphics.rectangle != 0 || tile_graphics.type             != 0 ) {
+            std::cout << "Error: the TileGraphics bitfield regarding animated is flawed!" << std::endl;
             is_not_success = true;
         }
         
         tile_graphics.set( 0b0010000000000000 );
-        if( tile_graphics.shading   != 0 || tile_graphics.texture_index != 0 ||
-            tile_graphics.unknown_0 != 0 || tile_graphics.rectangle     != 1 ||
-            tile_graphics.type      != 0 ) {
+        if( tile_graphics.shading   != 0 || tile_graphics.texture_index    != 0 ||
+            tile_graphics.animated  != 0 || tile_graphics.semi_transparent != 0 || tile_graphics.rectangle != 1 || tile_graphics.type             != 0 ) {
             std::cout << "Error: the TileGraphics bitfield regarding rectangle is flawed!" << std::endl;
             is_not_success = true;
         }
         
         tile_graphics.set( 0b1100000000000000 );
-        if( tile_graphics.shading   != 0 || tile_graphics.texture_index != 0 ||
-            tile_graphics.unknown_0 != 0 || tile_graphics.rectangle     != 0 ||
-            tile_graphics.type      != 3 ) {
+        if( tile_graphics.shading   != 0 || tile_graphics.texture_index    != 0 ||
+            tile_graphics.animated  != 0 || tile_graphics.semi_transparent != 0 || tile_graphics.rectangle != 0 || tile_graphics.type             != 3 ) {
             std::cout << "Error: the TileGraphics bitfield regarding type is flawed!" << std::endl;
             is_not_success = true;
         }

--- a/src/Utilities/Logger.cpp
+++ b/src/Utilities/Logger.cpp
@@ -39,6 +39,9 @@ Utilities::Logger::Log::Log( const Log &copy ) :
 }
 
 Utilities::Logger::Log::~Log() {
+    if( output.str().empty() )
+        return;
+
     std::stringstream time_stream;
 
     std::lock_guard<std::mutex> guard( log_r->outputs_lock );
@@ -57,7 +60,7 @@ Utilities::Logger::Log::~Log() {
 
     for( auto i : log_r->outputs ) {
         if( level == 0 || (level >= i->lower && level <= i->upper) ) {
-            *i->getOutputPtr() << log_r->getLevelName(level) << time_stream.str() << ": " << output.str() << "\n";
+            *i->getOutputPtr() << log_r->getLevelName(level) << time_stream.str() << ": " << info.str() << output.str() << "\n";
         }
     }
 }

--- a/src/Utilities/Logger.h
+++ b/src/Utilities/Logger.h
@@ -36,6 +36,7 @@ public:
         unsigned level;
         
     public:
+        std::stringstream info;
         std::stringstream output;
 
         Log( Logger *log_r, unsigned level );


### PR DESCRIPTION
I updated IFF reading in this branch. I also increased map animation support.
* Converted the usage to logging rather than using std::cout directly for the IFF parsing.
* Upgraded Utilities Logger class.
* Map has the ability to show flawed displacement animations.
* Map reads the number of "polygons" more safely than my other approach.
* Map now directly reads semi-transparency data from Ctil resources.
* Many assertion statements removed from the code. This would prevent unnecessary crashes when the debug build reads future cop IFF files.
* Other minor differences.