### PR TITLE
Map uv animations

### DIFF
--- a/src/Data/Mission/Til/Colorizer.cpp
+++ b/src/Data/Mission/Til/Colorizer.cpp
@@ -108,9 +108,9 @@ unsigned int Data::Mission::Til::Colorizer::setSquareColors( const Input &input,
                     result_r[0].x = static_cast<double>(primary.shading) * SINGLE_SCALE;
                     result_r[0].y = result_r[0].x;
                     result_r[0].z = result_r[0].x;
-                    result_r[1] = glm::vec3(1.0, 1.0, 1.0) - result_r[0];
-                    result_r[2] = result_r[1];
-                    result_r[3] = result_r[1];
+                    result_r[1] = result_r[0];
+                    result_r[2] = result_r[0];
+                    result_r[3] = result_r[0];
                 }
                 break;
         }

--- a/src/Data/Mission/Til/Mesh.cpp
+++ b/src/Data/Mission/Til/Mesh.cpp
@@ -54,8 +54,8 @@ unsigned int Data::Mission::Til::Mesh::BuildTriangle( const Input &input, const 
                 const TilResource::InfoSCTA &info_scta = input.SCTA_info_r->at( scta_index );
 
                 if( info_scta.isMemorySafe() && info_scta.source_uv_offset / 2 <= INDEX && info_scta.source_uv_offset / 2 + 4 > INDEX) {
-                    result.stca_animation_index[ result.element_start ] = 1 + scta_index;
-                    // result.stca_animation_index[ result.element_start ] = 1 + 4 * scta_index + INDEX_TABLE[ flipped ][ i ];
+                    // result.stca_animation_index[ result.element_start ] = 1 + scta_index;
+                    result.stca_animation_index[ result.element_start ] = 1 + 4 * scta_index + INDEX_TABLE[ flipped ][ i ];
                 }
             }
 

--- a/src/Data/Mission/Til/Mesh.cpp
+++ b/src/Data/Mission/Til/Mesh.cpp
@@ -48,6 +48,11 @@ unsigned int Data::Mission::Til::Mesh::BuildTriangle( const Input &input, const 
             result.coords[ result.element_start ].x = input.coord_data[ INDEX ].x;
             result.coords[ result.element_start ].y = input.coord_data[ INDEX ].y;
 
+            const unsigned x = ((triangle.points[ i ].facing_direction & FRONT_RIGHT) != 0) + input.x;
+            const unsigned y = ((triangle.points[ i ].facing_direction & BACK_LEFT)   != 0) + input.y;
+
+            result.uv_positions[ result.element_start ] = (x % 16) + 16 * (y % 16);
+
             result.stca_animation_index[ result.element_start ] = 0;
 
             for( unsigned scta_index = 0; scta_index < input.SCTA_info_r->size(); scta_index++ ) {
@@ -190,7 +195,7 @@ bool Data::Mission::Til::Mesh::isSlope( unsigned int tile_type ) {
 }
 
 
-bool Data::Mission::Til::Mesh::isFliped( unsigned int tile_type ) {
+bool Data::Mission::Til::Mesh::isFlipped( unsigned int tile_type ) {
     // Buffer overflow check.
     if( tile_type >= sizeof( default_mesh ) / sizeof( default_mesh[0] ) ) {
         return false;

--- a/src/Data/Mission/Til/Mesh.cpp
+++ b/src/Data/Mission/Til/Mesh.cpp
@@ -48,6 +48,17 @@ unsigned int Data::Mission::Til::Mesh::BuildTriangle( const Input &input, const 
             result.coords[ result.element_start ].x = input.coord_data[ INDEX ].x;
             result.coords[ result.element_start ].y = input.coord_data[ INDEX ].y;
 
+            result.stca_animation_index[ result.element_start ] = 0;
+
+            for( unsigned scta_index = 0; scta_index < input.SCTA_info_r->size(); scta_index++ ) {
+                const TilResource::InfoSCTA &info_scta = input.SCTA_info_r->at( scta_index );
+
+                if( info_scta.isMemorySafe() && info_scta.source_uv_offset / 2 <= INDEX && info_scta.source_uv_offset / 2 + 4 > INDEX) {
+                    result.stca_animation_index[ result.element_start ] = 1 + scta_index;
+                    // result.stca_animation_index[ result.element_start ] = 1 + 4 * scta_index + INDEX_TABLE[ flipped ][ i ];
+                }
+            }
+
             result.element_start++;
         }
 

--- a/src/Data/Mission/Til/Mesh.h
+++ b/src/Data/Mission/Til/Mesh.h
@@ -11,20 +11,20 @@ namespace Til {
 
 namespace Mesh {
     // Values for the facing_direction
-    const unsigned int FRONT_LEFT  = 0b00;
-    const unsigned int FRONT_RIGHT = 0b01;
-    const unsigned int BACK_LEFT   = 0b10;
-    const unsigned int BACK_RIGHT  = 0b11;
+    const unsigned FRONT_LEFT  = 0b00;
+    const unsigned FRONT_RIGHT = 0b01;
+    const unsigned BACK_LEFT   = 0b10;
+    const unsigned BACK_RIGHT  = 0b11;
 
     // Values for the heightmap_channel
-    const unsigned int RED        = 0;
-    const unsigned int GREEN      = 1;
-    const unsigned int BLUE       = 2;
-    const unsigned int NO_ELEMENT = 3; // used to indicate that the index of the polygon is non existent. If the first point of the polygon is this value then the polygon does not exist.
+    const unsigned RED        = 0;
+    const unsigned GREEN      = 1;
+    const unsigned BLUE       = 2;
+    const unsigned NO_ELEMENT = 3; // used to indicate that the index of the polygon is non existent. If the first point of the polygon is this value then the polygon does not exist.
 
     struct Point {
-        unsigned int facing_direction;
-        unsigned int heightmap_channel; // 0 red, 1 green, 2 blue, 3 abort.
+        unsigned facing_direction;
+        unsigned heightmap_channel; // 0 red, 1 green, 2 blue, 3 abort.
     };
 
     struct Polygon {
@@ -37,15 +37,17 @@ namespace Mesh {
         glm::u8vec2 *coords;
         glm::vec3 *colors;
         unsigned *stca_animation_index; // 0 means normal, 1 and above is index - 1.
-        unsigned int element_start;
-        unsigned int element_amount; // This describes the structual limit position and coords.
+        unsigned *uv_positions;
+        unsigned element_start;
+        unsigned element_amount; // This describes the structual limit position and coords.
     };
 
     struct Input {
         const TilResource::HeightmapPixel* pixels[4]; // Almost treated like an RGB 8 bit per channel.
         glm::vec3 colors[4]; // The colors for the tiles.
-        unsigned int coord_index;
-        unsigned int coord_index_limit;
+        unsigned coord_index;
+        unsigned coord_index_limit;
+        unsigned x, y;
         const glm::u8vec2 *coord_data; // This is the data that holds the coordinates.
         const std::vector<TilResource::InfoSCTA> *SCTA_info_r;
     };
@@ -56,18 +58,18 @@ namespace Mesh {
      * @param next_amount This is the amount of times it will skip to.
      * @return A valid index to the next triangle.
      */
-    unsigned int getNeighboor( unsigned int index, int next_amount );
+    unsigned getNeighboor( unsigned index, int next_amount );
 
-    unsigned int BuildTriangle( const Input &input, const Polygon &triangle, VertexData &result, bool flipped = false );
-    unsigned int BuildQuad( const Input &input, const Polygon &quad, VertexData &result );
+    unsigned BuildTriangle( const Input &input, const Polygon &triangle, VertexData &result, bool flipped = false );
+    unsigned BuildQuad( const Input &input, const Polygon &quad, VertexData &result );
 
-    unsigned int createTile( const Input &input, VertexData &result, unsigned int tileType );
+    unsigned createTile( const Input &input, VertexData &result, unsigned tileType );
 
-    bool isWall( unsigned int tile_type );
+    bool isWall( unsigned tile_type );
 
-    bool isSlope( unsigned int tile_type );
+    bool isSlope( unsigned tile_type );
 
-    bool isFliped( unsigned int tile_type );
+    bool isFlipped( unsigned tile_type );
 }
 
 }

--- a/src/Data/Mission/Til/Mesh.h
+++ b/src/Data/Mission/Til/Mesh.h
@@ -36,6 +36,7 @@ namespace Mesh {
         glm::vec3 *position;
         glm::u8vec2 *coords;
         glm::vec3 *colors;
+        unsigned *stca_animation_index; // 0 means normal, 1 and above is index - 1.
         unsigned int element_start;
         unsigned int element_amount; // This describes the structual limit position and coords.
     };
@@ -46,6 +47,7 @@ namespace Mesh {
         unsigned int coord_index;
         unsigned int coord_index_limit;
         const glm::u8vec2 *coord_data; // This is the data that holds the coordinates.
+        const std::vector<TilResource::InfoSCTA> *SCTA_info_r;
     };
 
     /**

--- a/src/Data/Mission/Til/Mesh.h
+++ b/src/Data/Mission/Til/Mesh.h
@@ -60,7 +60,7 @@ namespace Mesh {
      */
     unsigned getNeighboor( unsigned index, int next_amount );
 
-    unsigned BuildTriangle( const Input &input, const Polygon &triangle, VertexData &result, bool flipped = false );
+    unsigned BuildTriangle( const Input &input, const Polygon &triangle, VertexData &result, unsigned offset = 0 );
     unsigned BuildQuad( const Input &input, const Polygon &quad, VertexData &result );
 
     unsigned createTile( const Input &input, VertexData &result, unsigned tileType );

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -856,7 +856,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
                                         model_output_p->setVertexData(      normal_compon_index, Utilities::DataTypes::Vec3Type( normal[p] ) );
                                         model_output_p->setVertexData(       color_compon_index, Utilities::DataTypes::Vec3Type( color[p] ) );
                                         model_output_p->setVertexData( tex_coord_0_compon_index, Utilities::DataTypes::Vec2UByteType( coord[p] ) );
-                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4( current_tile.mesh_type, tile_graphics.animated, stca_animation_index[p], tile_graphics.type == 3 ) ) );
+                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4( current_tile.mesh_type + 128 * (tile_graphics.type == 3), tile_graphics.animated, stca_animation_index[p], (x % 16) + 16 * (y % 16) ) ) );
                                     }
                                 }
 
@@ -870,7 +870,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
                                         model_output_p->setVertexData(      normal_compon_index, Utilities::DataTypes::Vec3Type( -normal[p - 1] ) );
                                         model_output_p->setVertexData(       color_compon_index, Utilities::DataTypes::Vec3Type(  color[p - 1] ) );
                                         model_output_p->setVertexData( tex_coord_0_compon_index, Utilities::DataTypes::Vec2UByteType( coord[p - 1] ) );
-                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4(  current_tile.mesh_type, tile_graphics.animated, stca_animation_index[p - 1], tile_graphics.type == 3 ) ) );
+                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4( current_tile.mesh_type + 128 * (tile_graphics.type == 3), tile_graphics.animated, stca_animation_index[p - 1], (x % 16) + 16 * (y % 16) ) ) );
                                     }
                                 }
                             }

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -172,20 +172,18 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
     }
     else if( info_slfx.activate_diagonal != 0 ) {
         float light_level = 0.5;
-
-        float start = image.getWidth() * cycle;
-        float end   = start + image.getWidth() / (1 << info_slfx.data.wave.gradient_width);
-
         float value;
 
         const float width = image.getWidth() / (1 << info_slfx.data.wave.gradient_width);
+        float start = image.getWidth() * cycle;
+        float end   = start + width;
         const float gradient_light_factor = ((0x20 >> info_slfx.data.wave.gradient_light_level) * 1. / 32.);
 
         for( unsigned x = 0; x < image.getWidth(); x++ ) {
             value = light_level;
 
             if( x < width )
-                value = std::cos( glm::pi<float>() * ((x + std::fmod(start, 1.f)) / (1. * width)) );// * gradient_light_factor;
+                value += std::cos( glm::pi<float>() * (x / (1. * width)) ) * gradient_light_factor;
 
             value = std::min(1.0f, value);
             value = std::max(0.0f, value);

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -709,7 +709,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
                                         model_output_p->setVertexData(      normal_compon_index, Utilities::DataTypes::Vec3Type( -normal[p - 1] ) );
                                         model_output_p->setVertexData(       color_compon_index, Utilities::DataTypes::Vec3Type(  color[p - 1] ) );
                                         model_output_p->setVertexData( tex_coord_0_compon_index, Utilities::DataTypes::Vec2UByteType( coord[p - 1] ) );
-                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec3UByteType( glm::u8vec3(  current_tile.mesh_type, tile_graphics.animated, stca_animation_index[p] ) ) );
+                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec3UByteType( glm::u8vec3(  current_tile.mesh_type, tile_graphics.animated, stca_animation_index[p - 1] ) ) );
                                     }
                                 }
                             }

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -337,9 +337,11 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
 
                 // Read the texture_references, and shading info.
                 while( reader_sect.getPosition( Utilities::Buffer::END ) >= sizeof(uint16_t) ) {
-                    const auto data = reader_sect.readU16( settings.endian );
+                    auto data = TileGraphics( reader_sect.readU16( settings.endian ) );
 
-                    tile_graphics_bitfield.push_back( data );
+                    data.semi_transparent = true;
+
+                    tile_graphics_bitfield.push_back( data.get() );
                 }
                 
                 // Create the physics cells for this Til.

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -131,7 +131,7 @@ void Data::Mission::TilResource::AnimationSLFX::setInfo( InfoSLFX info_slfx ) {
     this->cycle = 0.0;
 
     if( info_slfx.activate_noise )
-        this->speed = 1.0;
+        this->speed = 0.03125;
     else
         this->speed = 1.0 / 16.0;
 
@@ -154,7 +154,7 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
         bool flip = false;
 
         if( (int)(cycle + 0.5) == 1 ) {
-            flip = true;
+            flip = !flip;
         }
 
         for( unsigned y = 0; y < image.getHeight(); y++ ) {
@@ -166,6 +166,7 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
 
                 flip = !flip;
             }
+            flip = !flip;
         }
     }
     else if( info_slfx.activate_diagonal != 0 ) {
@@ -721,6 +722,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
         glm::vec3   color[6];
         glm::u8vec2 coord[6];
         unsigned stca_animation_index[6];
+        unsigned uv_positions[6];
 
         has_texture_displayed = false;
         
@@ -746,6 +748,8 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
                         input.pixels[  BACK_LEFT  ] = point_cloud_3_channel.getRef( y + 1, x + 0 );
                         input.pixels[  BACK_RIGHT ] = point_cloud_3_channel.getRef( y + 1, x + 1 );
                         input.pixels[ FRONT_RIGHT ] = point_cloud_3_channel.getRef( y + 0, x + 1 );
+                        input.x = x;
+                        input.y = y;
                         input.coord_index = current_tile.texture_cord_index;
                         input.coord_index_limit = this->texture_cords.size();
                         input.coord_data = this->texture_cords.data();
@@ -756,6 +760,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
                         vertex_data.coords = coord;
                         vertex_data.colors = color;
                         vertex_data.stca_animation_index = stca_animation_index;
+                        vertex_data.uv_positions = uv_positions;
                         vertex_data.element_amount = 6;
                         vertex_data.element_start = 0;
 
@@ -829,7 +834,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
 
                             if( is_culled ) {
                                 if( Data::Mission::Til::Mesh::isSlope( current_tile.mesh_type ) ||  Data::Mission::Til::Mesh::isWall( current_tile.mesh_type ) ) {
-                                    if( Data::Mission::Til::Mesh::isFliped( current_tile.mesh_type ) ) {
+                                    if( Data::Mission::Til::Mesh::isFlipped( current_tile.mesh_type ) ) {
                                         front = current_tile.front;
                                         back  = current_tile.back;
                                     }
@@ -856,7 +861,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
                                         model_output_p->setVertexData(      normal_compon_index, Utilities::DataTypes::Vec3Type( normal[p] ) );
                                         model_output_p->setVertexData(       color_compon_index, Utilities::DataTypes::Vec3Type( color[p] ) );
                                         model_output_p->setVertexData( tex_coord_0_compon_index, Utilities::DataTypes::Vec2UByteType( coord[p] ) );
-                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4( current_tile.mesh_type + 128 * (tile_graphics.type == 3), tile_graphics.animated, stca_animation_index[p], (x % 16) + 16 * (y % 16) ) ) );
+                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4( current_tile.mesh_type + 128 * (tile_graphics.type == 3), tile_graphics.animated, stca_animation_index[p], uv_positions[p] ) ) );
                                     }
                                 }
 
@@ -870,7 +875,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
                                         model_output_p->setVertexData(      normal_compon_index, Utilities::DataTypes::Vec3Type( -normal[p - 1] ) );
                                         model_output_p->setVertexData(       color_compon_index, Utilities::DataTypes::Vec3Type(  color[p - 1] ) );
                                         model_output_p->setVertexData( tex_coord_0_compon_index, Utilities::DataTypes::Vec2UByteType( coord[p - 1] ) );
-                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4( current_tile.mesh_type + 128 * (tile_graphics.type == 3), tile_graphics.animated, stca_animation_index[p - 1], (x % 16) + 16 * (y % 16) ) ) );
+                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4( current_tile.mesh_type + 128 * (tile_graphics.type == 3), tile_graphics.animated, stca_animation_index[p - 1], uv_positions[p - 1] ) ) );
                                     }
                                 }
                             }
@@ -903,6 +908,7 @@ void Data::Mission::TilResource::createPhysicsCell( unsigned int x, unsigned int
         glm::u8vec2 cord[6];
         glm::vec3 color[6];
         unsigned stca_animation_index[6];
+        unsigned uv_positions[6];
         Tile current_tile;
         Data::Mission::Til::Mesh::Input input;
         Data::Mission::Til::Mesh::VertexData vertex_data;
@@ -916,6 +922,7 @@ void Data::Mission::TilResource::createPhysicsCell( unsigned int x, unsigned int
         vertex_data.coords = cord;
         vertex_data.colors = color;
         vertex_data.stca_animation_index = stca_animation_index;
+        vertex_data.uv_positions = uv_positions;
         
         input.coord_index_limit = this->texture_cords.size();
         input.coord_data = this->texture_cords.data();

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -171,14 +171,13 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
         }
     }
     else if( info_slfx.activate_diagonal != 0 ) {
-        float light_level = 0.5;
         float value;
 
         const float width = image.getWidth() / (1 << info_slfx.data.wave.gradient_width);
-        float start = image.getWidth() * cycle;
-        float end   = start + width;
+        const float start = image.getWidth() * cycle;
         const float gradient_light_factor = ((0x20 >> info_slfx.data.wave.gradient_light_level) * 1. / 32.);
         const float fraction = 1.0f - std::fmod(start, 1.f);
+        const float light_level = info_slfx.data.wave.background_light_level * 1. / 256.;
 
         for( unsigned x = 0; x < image.getWidth(); x++ ) {
             value = light_level;

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -178,12 +178,13 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
         float start = image.getWidth() * cycle;
         float end   = start + width;
         const float gradient_light_factor = ((0x20 >> info_slfx.data.wave.gradient_light_level) * 1. / 32.);
+        const float fraction = 1.0f - std::fmod(start, 1.f);
 
         for( unsigned x = 0; x < image.getWidth(); x++ ) {
             value = light_level;
 
-            if( x < width )
-                value += std::cos( glm::pi<float>() * (x / (1. * width)) ) * gradient_light_factor;
+            if( (x + fraction) < width )
+                value += std::sin( glm::pi<float>() * ((x + fraction) / (0.5 * width) + 1) ) * gradient_light_factor;
 
             value = std::min(1.0f, value);
             value = std::max(0.0f, value);

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -163,14 +163,22 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
             last = this->last,
             next = this->next;
 
+        const float reduce[4] = { 1., 0.5, 0.25, 0.125 };
+        float current_value, next_value, value;
+
         for( unsigned y = 0; y < image.getHeight(); y++ ) {
             for( unsigned x = 0; x < image.getWidth(); x++ ) {
-                float current_value = last.nextFloat();
-                float next_value    = next.nextFloat();
+                current_value = last.nextFloat();
+                next_value    = next.nextFloat();
 
-                float mix = current_value * ( 1.0 - cycle ) + next_value * cycle;
+                value = current_value * ( 1.0 - cycle ) + next_value * cycle;
+                value *= reduce[ info_slfx.data.noise.reducer ];
+                value += info_slfx.data.noise.brightness * 1. / 256.;
 
-                image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( mix, mix, mix, 1.0 ) );
+                value = std::min(1.0f, value);
+                value = std::max(0.0f, value);
+
+                image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( value, value, value, 1.0 ) );
             }
         }
     }

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -50,14 +50,10 @@ std::string Data::Mission::TilResource::InfoSLFX::getString() const {
     }
     else {
         stream << "    TYPE: DIAGONAL WAVES\n";
-        stream << "    apply_level:       " << (unsigned)data.wave.apply_level       << "\n";
-        stream << "    is_forever_bright: " << (unsigned)data.wave.is_forever_bright << "\n";
-        stream << "    rate:              " << (unsigned)data.wave.rate              << "\n";
-        stream << "    default_level:     " << (unsigned)data.wave.default_level     << "\n";
-        stream << "    other_wave:        " << (unsigned)data.wave.other_wave        << "\n";
-        stream << "    speed:             " << (unsigned)data.wave.speed             << "\n";
-        stream << "    unknown_0:         " << (unsigned)data.wave.unknown_0         << "\n";
-        stream << "    unused_0:          " << (unsigned)data.wave.unused_0          << "\n";
+        stream << "    gradient_light_level:   " << (unsigned)data.wave.gradient_light_level   << "\n";
+        stream << "    gradient_width:         " << (unsigned)data.wave.gradient_width         << "\n";
+        stream << "    background_light_level: " << (unsigned)data.wave.background_light_level << "\n";
+        stream << "    speed:                  " << (unsigned)data.wave.speed                  << "\n";
     }
 
     return stream.str();
@@ -82,14 +78,10 @@ uint32_t Data::Mission::TilResource::InfoSLFX::get() const {
     }
     else {
         bitfield |=
-            ((uint32_t)data.wave.apply_level       << 20) |
-            ((uint32_t)data.wave.is_forever_bright << 19) |
-            ((uint32_t)data.wave.rate              << 16) |
-            ((uint32_t)data.wave.default_level     << 12) |
-            ((uint32_t)data.wave.other_wave        <<  8) |
-            ((uint32_t)data.wave.speed             <<  4) |
-            ((uint32_t)data.wave.unknown_0         <<  3) |
-            ((uint32_t)data.wave.unused_0          <<  0);
+            ((uint32_t)data.wave.gradient_light_level   << 20) |
+            ((uint32_t)data.wave.gradient_width         << 16) |
+            ((uint32_t)data.wave.background_light_level <<  8) |
+            ((uint32_t)data.wave.speed                  <<  0);
     }
 
     return bitfield;
@@ -110,14 +102,10 @@ void Data::Mission::TilResource::InfoSLFX::set( const uint32_t bitfield ) {
         data.noise.reducer    = (bitfield >>  0) & ((1 << 2) - 1);
     }
     else {
-        data.wave.apply_level       = (bitfield >> 20) & ((1 << 4) - 1);
-        data.wave.is_forever_bright = (bitfield >> 19) & 1;
-        data.wave.rate              = (bitfield >> 16) & ((1 << 3) - 1);
-        data.wave.default_level     = (bitfield >> 12) & ((1 << 4) - 1);
-        data.wave.other_wave        = (bitfield >>  8) & ((1 << 4) - 1);
-        data.wave.speed             = (bitfield >>  4) & ((1 << 4) - 1);
-        data.wave.unknown_0         = (bitfield >>  3) & 1;
-        data.wave.unused_0          = (bitfield >>  0) & ((1 << 3) - 1);
+        data.wave.gradient_light_level   = (bitfield >> 20) & ((1 << 4) - 1);
+        data.wave.gradient_width         = (bitfield >> 16) & ((1 << 4) - 1);
+        data.wave.background_light_level = (bitfield >>  8) & ((1 << 8) - 1);
+        data.wave.speed                  = (bitfield >>  0) & ((1 << 8) - 1);
     }
 }
 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -121,6 +121,10 @@ void Data::Mission::TilResource::InfoSLFX::set( const uint32_t bitfield ) {
     }
 }
 
+Data::Mission::TilResource::AnimationSLFX::AnimationSLFX() : info_slfx( 0 ), last( 1 ), next( 2 ) {
+    setInfo( 0 );
+}
+
 Data::Mission::TilResource::AnimationSLFX::AnimationSLFX( InfoSLFX info_slfx ) : info_slfx( 0 ), last( 1 ), next( 2 ) {
     setInfo( info_slfx );
 }
@@ -131,7 +135,7 @@ void Data::Mission::TilResource::AnimationSLFX::setInfo( InfoSLFX info_slfx ) {
     this->cycle = 0.0;
 
     if( info_slfx.activate_noise )
-        this->speed = 0.03125;
+        this->speed = 2.0;
     else
         this->speed = 1.0 / 16.0;
 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -537,8 +537,8 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 // Read this bitfield!
                 this->slfx_bitfield = reader_slfx.readU32( settings.endian );
 
-                error_log.output << "SLFX is 0x" << std::hex << this->slfx_bitfield << ".\n";
-                error_log.output << InfoSLFX( this->slfx_bitfield ).getString() << "\n";
+                debug_log.output << "SLFX is 0x" << std::hex << this->slfx_bitfield << ".\n";
+                debug_log.output << InfoSLFX( this->slfx_bitfield ).getString() << "\n";
             }
             else
             if( identifier == TAG_ScTA ) {

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -171,21 +171,25 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
         }
     }
     else if( info_slfx.activate_diagonal != 0 ) {
-        float light_level = static_cast<double>( info_slfx.data.wave.background_light_level ) * 1. / 256. * 0;
+        float light_level = static_cast<double>( info_slfx.data.wave.background_light_level ) * 1. / 256.;
 
-        for( unsigned y = 0; y < image.getHeight(); y++ ) {
+        for( unsigned x = 0; x < image.getWidth(); x++ ) {
+            image.writePixel( x, 0, Utilities::PixelFormatColor::GenericColor( light_level, light_level, light_level, 1.0 ) );
+        }
+
+        float g1 = std::fmod(image.getWidth() * cycle + (image.getHeight() - 1), image.getWidth());
+        float g2 = std::fmod(image.getWidth() * cycle + (image.getHeight() - 0), image.getWidth());
+
+        float value = std::fmod( g1, 1.0f );
+        float inv_value = 1.0f - value;
+
+        image.writePixel( g1, 0, Utilities::PixelFormatColor::GenericColor( inv_value, inv_value, inv_value, 1.0 ) );
+        image.writePixel( g2, 0, Utilities::PixelFormatColor::GenericColor( value, value, value, 1.0 ) );
+
+        for( unsigned y = 1; y < image.getHeight(); y++ ) {
             for( unsigned x = 0; x < image.getWidth(); x++ ) {
-                image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( light_level, light_level, light_level, 1.0 ) );
+                image.writePixel( x, y, image.readPixel( (x + 1) % image.getWidth(), y - 1 ) );
             }
-
-            float g1 = std::fmod(image.getWidth() * cycle + (image.getHeight() - y - 1), image.getWidth());
-            float g2 = std::fmod(image.getWidth() * cycle + (image.getHeight() - y - 0), image.getWidth());
-
-            float inv_value = std::fmod( g1, 1.0f );
-            float value = 1.0f - inv_value;
-
-            image.writePixel( g1,  y, Utilities::PixelFormatColor::GenericColor( value, value, value, 1.0 ) );
-            image.writePixel( g2, y, Utilities::PixelFormatColor::GenericColor( inv_value, inv_value, inv_value, 1.0 ) );
         }
     }
 }

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -337,11 +337,9 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
 
                 // Read the texture_references, and shading info.
                 while( reader_sect.getPosition( Utilities::Buffer::END ) >= sizeof(uint16_t) ) {
-                    auto data = TileGraphics( reader_sect.readU16( settings.endian ) );
+                    const auto data = reader_sect.readU16( settings.endian );
 
-                    data.semi_transparent = true;
-
-                    tile_graphics_bitfield.push_back( data.get() );
+                    tile_graphics_bitfield.push_back( data );
                 }
                 
                 // Create the physics cells for this Til.

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -188,7 +188,7 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
                 image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( 1.0, 1.0, 1.0, 1.0 ) );
             }
 
-            unsigned medium = static_cast<unsigned>(image.getWidth() * cycle + y) % image.getWidth();
+            unsigned medium = static_cast<unsigned>(image.getWidth() * cycle + (image.getHeight() - y - 1)) % image.getWidth();
 
             image.writePixel( medium, y, Utilities::PixelFormatColor::GenericColor( 0.0, 0.0, 0.0, 1.0 ) );
         }

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -55,6 +55,7 @@ std::string Data::Mission::TilResource::InfoSLFX::getString() const {
         stream << "    other_wave:        " << (unsigned)data.wave.other_wave        << "\n";
         stream << "    speed:             " << (unsigned)data.wave.speed             << "\n";
         stream << "    unknown_0:         " << (unsigned)data.wave.unknown_0         << "\n";
+        stream << "    unused_0:          " << (unsigned)data.wave.unused_0          << "\n";
     }
 
     return stream.str();
@@ -85,7 +86,8 @@ uint32_t Data::Mission::TilResource::InfoSLFX::get() const {
             ((uint32_t)data.wave.default_level     << 12) |
             ((uint32_t)data.wave.other_wave        <<  8) |
             ((uint32_t)data.wave.speed             <<  4) |
-            ((uint32_t)data.wave.unknown_0        <<   0);
+            ((uint32_t)data.wave.unknown_0         <<  3) |
+            ((uint32_t)data.wave.unused_0          <<  0);
     }
 
     return bitfield;
@@ -112,7 +114,8 @@ void Data::Mission::TilResource::InfoSLFX::set( const uint32_t bitfield ) {
         data.wave.default_level     = (bitfield >> 12) & ((1 << 4) - 1);
         data.wave.other_wave        = (bitfield >>  8) & ((1 << 4) - 1);
         data.wave.speed             = (bitfield >>  4) & ((1 << 4) - 1);
-        data.wave.unknown_0         = (bitfield >>  0) & ((1 << 4) - 1);
+        data.wave.unknown_0         = (bitfield >>  3) & 1;
+        data.wave.unused_0          = (bitfield >>  0) & ((1 << 3) - 1);
     }
 }
 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -187,9 +187,10 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
         image.writePixel( g2, 0, Utilities::PixelFormatColor::GenericColor( value, value, value, 1.0 ) );
 
         for( unsigned y = 1; y < image.getHeight(); y++ ) {
-            for( unsigned x = 0; x < image.getWidth(); x++ ) {
-                image.writePixel( x, y, image.readPixel( (x + 1) % image.getWidth(), y - 1 ) );
+            for( unsigned x = 0; x < image.getWidth() - 1; x++ ) {
+                image.writePixel( x, y, image.readPixel( x + 1, y - 1 ) );
             }
+            image.writePixel( image.getWidth() - 1, y, image.readPixel( 0, y - 1 ) );
         }
     }
 }

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -125,7 +125,7 @@ void Data::Mission::TilResource::AnimationSLFX::setInfo( InfoSLFX info_slfx ) {
     if( info_slfx.activate_noise )
         this->speed = 2.0;
     else
-        this->speed = 1.0 / 8.0;
+        this->speed = static_cast<double>( info_slfx.data.wave.speed ) / std::pow( 2., info_slfx.data.wave.gradient_width ) * 45. / 616.;
 
     this->random.setSeeder( 0x43A7BEAF2363 );
     this->last = this->random.getGenerator();

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -229,9 +229,9 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
 
                 // Modifiying this to be other than what it is will cause an error?
                 if( uv_animation.x != 0 )
-                    warning_log.output << "Expected zero in uv_animation.x rather than " << (unsigned)uv_animation.x << ".\n";
+                    debug_log.output << "uv_animation.x has " << (unsigned)uv_animation.x << ".\n";
                 if( uv_animation.y != 0 )
-                    warning_log.output << "Expected zero in uv_animation.y rather than " << (unsigned)uv_animation.y << ".\n";
+                    debug_log.output << "uv_animation.y has " << (unsigned)uv_animation.y << ".\n";
                 
                 this->texture_reference = reader_sect.readU16( settings.endian );
 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -213,7 +213,7 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 auto color_amount = reader_sect.readU16( settings.endian );
                 auto texture_cordinates_amount = reader_sect.readU16( settings.endian );
 
-                debug_log.output << "loc = 0x" << std::hex << getOffset() << std::dec << "\n"
+                error_log.output << "loc = 0x" << std::hex << getOffset() << std::dec << "\n"
                     << "Color amount = " << color_amount << "\n"
                     << "texture_cordinates_amount = " << texture_cordinates_amount << "\n";
                 
@@ -271,8 +271,8 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
 
                 this->mesh_library_size = 0;
                 
-                for( unsigned int x = 0; x < AMOUNT_OF_TILES; x++ ) {
-                    for( unsigned int y = 0; y < AMOUNT_OF_TILES; y++ ) {
+                for( unsigned x = 0; x < AMOUNT_OF_TILES; x++ ) {
+                    for( unsigned y = 0; y < AMOUNT_OF_TILES; y++ ) {
                         mesh_reference_grid[x][y].set( reader_sect.readU16( settings.endian ) );
 
                         this->mesh_library_size += mesh_reference_grid[x][y].tile_amount;
@@ -291,13 +291,9 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 
                 mesh_tiles.reserve( this->mesh_library_size );
                 
-                std::set<uint16_t> seen_graphics_tiles;
-                
                 for( size_t i = 0; i < this->mesh_library_size; i++ ) {
 
                     mesh_tiles.push_back( { reader_sect.readU32( settings.endian ) } );
-
-                    seen_graphics_tiles.insert( mesh_tiles.back().graphics_type_index );
                 }
 
                 if( this->mesh_library_size != PREDICTED_POLYGON_TILE_AMOUNT ) {
@@ -327,10 +323,12 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 texture_cords.reserve( texture_cordinates_amount );
                 
                 for( size_t i = 0; i < texture_cordinates_amount; i++ ) {
-                    texture_cords.push_back( glm::u8vec2() );
-                    
-                    texture_cords.back().x = reader_sect.readU8();
-                    texture_cords.back().y = reader_sect.readU8();
+                    glm::u8vec2 texture_coordinate;
+
+                    texture_coordinate.x = reader_sect.readU8();
+                    texture_coordinate.y = reader_sect.readU8();
+
+                    texture_cords.push_back( texture_coordinate );
                 }
                 
                 Til::Colorizer::setColors( colors, color_amount, reader_sect, settings.endian );

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -137,7 +137,7 @@ void Data::Mission::TilResource::AnimationSLFX::setInfo( InfoSLFX info_slfx ) {
     if( info_slfx.activate_noise )
         this->speed = 2.0;
     else
-        this->speed = 1.0 / 16.0;
+        this->speed = 1.0 / 8.0;
 
     this->random.setSeeder( 0x43A7BEAF2363 );
     this->last = this->random.getGenerator();
@@ -185,12 +185,17 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
     else if( info_slfx.activate_diagonal != 0 ) {
         for( unsigned y = 0; y < image.getHeight(); y++ ) {
             for( unsigned x = 0; x < image.getWidth(); x++ ) {
-                image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( 1.0, 1.0, 1.0, 1.0 ) );
+                image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( 0.0, 0.0, 0.0, 1.0 ) );
             }
 
-            unsigned medium = static_cast<unsigned>(image.getWidth() * cycle + (image.getHeight() - y - 1)) % image.getWidth();
+            float g1 = std::fmod(image.getWidth() * cycle + (image.getHeight() - y - 1), image.getWidth());
+            float g2 = std::fmod(image.getWidth() * cycle + (image.getHeight() - y - 0), image.getWidth());
 
-            image.writePixel( medium, y, Utilities::PixelFormatColor::GenericColor( 0.0, 0.0, 0.0, 1.0 ) );
+            float inv_value = std::fmod( g1, 1.0f );
+            float value = 1.0f - inv_value;
+
+            image.writePixel( g1,  y, Utilities::PixelFormatColor::GenericColor( value, value, value, 1.0 ) );
+            image.writePixel( g2, y, Utilities::PixelFormatColor::GenericColor( inv_value, inv_value, inv_value, 1.0 ) );
         }
     }
 }

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -171,9 +171,11 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
         }
     }
     else if( info_slfx.activate_diagonal != 0 ) {
+        float light_level = static_cast<double>( info_slfx.data.wave.background_light_level ) * 1. / 256. * 0;
+
         for( unsigned y = 0; y < image.getHeight(); y++ ) {
             for( unsigned x = 0; x < image.getWidth(); x++ ) {
-                image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( 0.0, 0.0, 0.0, 1.0 ) );
+                image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( light_level, light_level, light_level, 1.0 ) );
             }
 
             float g1 = std::fmod(image.getWidth() * cycle + (image.getHeight() - y - 1), image.getWidth());

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -227,7 +227,9 @@ const uint32_t Data::Mission::TilResource::IDENTIFIER_TAG = 0x4374696C; // which
 const std::string Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME = "_TILE_TYPE";
 
 Data::Mission::TilResource::TilResource() {
-
+    InfoSLFX info_slfx( 0 );
+    info_slfx.is_disabled = true;
+    this->slfx_bitfield = info_slfx.get();
 }
 
 Data::Mission::TilResource::TilResource( const TilResource &obj ) : ModelResource( obj ), point_cloud_3_channel( obj.point_cloud_3_channel ) {
@@ -266,6 +268,10 @@ Utilities::Image2D Data::Mission::TilResource::getImage() const {
 }
 
 void Data::Mission::TilResource::makeEmpty() {
+    InfoSLFX info_slfx( 0 );
+    info_slfx.is_disabled = true;
+    this->slfx_bitfield = info_slfx.get();
+
     point_cloud_3_channel.setDimensions( AMOUNT_OF_TILES + 1, AMOUNT_OF_TILES + 1 );
     
     for( unsigned y = 0; y < point_cloud_3_channel.getHeight(); y++ ) {

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -64,6 +64,8 @@ bool Data::Mission::TilResource::InfoSCTA::setMemorySafe( size_t source_size, si
 const std::string Data::Mission::TilResource::FILE_EXTENSION = "til";
 const uint32_t Data::Mission::TilResource::IDENTIFIER_TAG = 0x4374696C; // which is { 0x43, 0x74, 0x69, 0x6C } or { 'C', 't', 'i', 'l' } or "Ctil"
 
+const std::string Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME = "_TILE_TYPE";
+
 Data::Mission::TilResource::TilResource() {
 
 }
@@ -548,7 +550,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
         unsigned int normal_compon_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::NORMAL_COMPONENT_NAME, Utilities::DataTypes::ComponentType::FLOAT, Utilities::DataTypes::Type::VEC3 );
         unsigned int color_compon_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::FLOAT, Utilities::DataTypes::Type::VEC3 );
         unsigned int tex_coord_0_compon_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC2, true );
-        unsigned int tile_type_compon_index = model_output_p->addVertexComponent( "_TILE_TYPE", Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::VEC2, false );
+        unsigned int tile_type_compon_index = model_output_p->addVertexComponent( TILE_TYPE_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::VEC2, false );
 
         model_output_p->setupVertexComponents();
 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -7,6 +7,7 @@
 #include "../../Utilities/ImageFormat/Chooser.h"
 #include <algorithm>
 #include <fstream>
+#include <iostream>
 #include <cassert>
 #include <set>
 
@@ -223,14 +224,14 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 readCullingTile( culling_bottom_right, reader_sect, settings.endian );
                 
                 // These are most likely bytes.
-                auto unk_byte_0 = reader_sect.readU8();
-                auto unk_byte_1 = reader_sect.readU8();
+                uv_animation.x = std::abs( reader_sect.readI8() );
+                uv_animation.y = std::abs( reader_sect.readI8() );
 
                 // Modifiying this to be other than what it is will cause an error?
-                if( unk_byte_0 != 0 )
-                    debug_log.output << "Expected zero in unk_byte_0 rather than " << (unsigned)unk_byte_0 << ".\n";
-                if( unk_byte_1 != 0 )
-                    debug_log.output << "Expected zero in unk_byte_1 rather than " << (unsigned)unk_byte_1 << ".\n";
+                if( uv_animation.x != 0 )
+                    warning_log.output << "Expected zero in uv_animation.x rather than " << (unsigned)uv_animation.x << ".\n";
+                if( uv_animation.y != 0 )
+                    warning_log.output << "Expected zero in uv_animation.y rather than " << (unsigned)uv_animation.y << ".\n";
                 
                 this->texture_reference = reader_sect.readU16( settings.endian );
 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -175,7 +175,7 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
         }
     }
     else if( info_slfx.activate_diagonal != 0 ) {
-        for( unsigned y = 1; y < image.getHeight(); y++ ) {
+        for( unsigned y = 0; y < image.getHeight(); y++ ) {
             for( unsigned x = 0; x < image.getWidth(); x++ ) {
                 image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( 1.0, 1.0, 1.0, 1.0 ) );
             }

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -153,16 +153,20 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
     else if( info_slfx.activate_noise ) {
         bool flip = false;
 
-        if( (int)(cycle + 0.5) == 1 ) {
-            flip = !flip;
-        }
-
         for( unsigned y = 0; y < image.getHeight(); y++ ) {
             for( unsigned x = 0; x < image.getWidth(); x++ ) {
+                float pos_unit = 2.0 * cycle;
+                float neg_unit = 2.0 * (0.5 - cycle);
+
+                if( (int)(cycle + 0.5) == 1 ) {
+                    pos_unit = 2.0 * (1.0 - cycle);
+                    neg_unit = 2.0 * (cycle - 0.5);
+                }
+
                 if( flip )
-                    image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( 1.0, 1.0, 1.0, 1.0 ) );
+                    image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( pos_unit, pos_unit, pos_unit, 1.0 ) );
                 else
-                    image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( 0.0, 0.0, 0.0, 1.0 ) );
+                    image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( neg_unit, neg_unit, neg_unit, 1.0 ) );
 
                 flip = !flip;
             }

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -175,7 +175,7 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
 
         const float width = image.getWidth() / (1 << info_slfx.data.wave.gradient_width);
         const float start = image.getWidth() * cycle;
-        const float gradient_light_factor = ((0x20 >> info_slfx.data.wave.gradient_light_level) * 1. / 32.);
+        const float gradient_light_factor = ((0x20 >> info_slfx.data.wave.gradient_light_level) * 1. / 16.);
         const float fraction = 1.0f - std::fmod(start, 1.f);
         const float light_level = info_slfx.data.wave.background_light_level * 1. / 256.;
 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -171,20 +171,27 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
         }
     }
     else if( info_slfx.activate_diagonal != 0 ) {
-        float light_level = static_cast<double>( info_slfx.data.wave.background_light_level ) * 1. / 256.;
+        float light_level = 0.5;
+
+        float start = image.getWidth() * cycle;
+        float end   = start + image.getWidth() / (1 << info_slfx.data.wave.gradient_width);
+
+        float value;
+
+        const float width = image.getWidth() / (1 << info_slfx.data.wave.gradient_width);
+        const float gradient_light_factor = ((0x20 >> info_slfx.data.wave.gradient_light_level) * 1. / 32.);
 
         for( unsigned x = 0; x < image.getWidth(); x++ ) {
-            image.writePixel( x, 0, Utilities::PixelFormatColor::GenericColor( light_level, light_level, light_level, 1.0 ) );
+            value = light_level;
+
+            if( x < width )
+                value = std::cos( glm::pi<float>() * ((x + std::fmod(start, 1.f)) / (1. * width)) );// * gradient_light_factor;
+
+            value = std::min(1.0f, value);
+            value = std::max(0.0f, value);
+
+            image.writePixel( static_cast<unsigned>(start + x) % image.getWidth(), 0, Utilities::PixelFormatColor::GenericColor( value, value, value, 1.0 ) );
         }
-
-        float g1 = std::fmod(image.getWidth() * cycle + (image.getHeight() - 1), image.getWidth());
-        float g2 = std::fmod(image.getWidth() * cycle + (image.getHeight() - 0), image.getWidth());
-
-        float value = std::fmod( g1, 1.0f );
-        float inv_value = 1.0f - value;
-
-        image.writePixel( g1, 0, Utilities::PixelFormatColor::GenericColor( inv_value, inv_value, inv_value, 1.0 ) );
-        image.writePixel( g2, 0, Utilities::PixelFormatColor::GenericColor( value, value, value, 1.0 ) );
 
         for( unsigned y = 1; y < image.getHeight(); y++ ) {
             for( unsigned x = 0; x < image.getWidth() - 1; x++ ) {

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -151,7 +151,7 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
             last = this->last,
             next = this->next;
 
-        const float reduce[4] = { 1., 0.5, 0.25, 0.125 };
+        const float reduce[4] = { 1.00, 0.75, 0.50, 0.25 };
         float current_value, next_value, value;
 
         for( unsigned y = 0; y < image.getHeight(); y++ ) {
@@ -171,13 +171,13 @@ void Data::Mission::TilResource::AnimationSLFX::setImage( Utilities::Image2D &im
         }
     }
     else if( info_slfx.activate_diagonal != 0 ) {
-        float value;
-
         const float width = image.getWidth() / (1 << info_slfx.data.wave.gradient_width);
         const float start = image.getWidth() * cycle;
         const float gradient_light_factor = ((0x20 >> info_slfx.data.wave.gradient_light_level) * 1. / 16.);
         const float fraction = 1.0f - std::fmod(start, 1.f);
         const float light_level = info_slfx.data.wave.background_light_level * 1. / 256.;
+
+        float value;
 
         for( unsigned x = 0; x < image.getWidth(); x++ ) {
             value = light_level;

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -213,7 +213,7 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                 auto color_amount = reader_sect.readU16( settings.endian );
                 auto texture_cordinates_amount = reader_sect.readU16( settings.endian );
 
-                error_log.output << "loc = 0x" << std::hex << getOffset() << std::dec << "\n"
+                debug_log.output << "loc = 0x" << std::hex << getOffset() << std::dec << "\n"
                     << "Color amount = " << color_amount << "\n"
                     << "texture_cordinates_amount = " << texture_cordinates_amount << "\n";
                 

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -399,7 +399,7 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
                     if( !(*i).setMemorySafe( texture_cords.size(), scta_texture_cords.size() ) )
                         error_log.output << "Not bounds safe " << (*i).getString();
                     else
-                        warning_log.output << (*i).getString();
+                        debug_log.output << (*i).getString();
                 }
             }
             else

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -396,6 +396,8 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
 
                 // Bounds check the SCTA
                 for( auto i = SCTA_info.begin(); i != SCTA_info.end(); i++ ) {
+
+                    // setMemorySafe is here for memory safety. This program will not handle these kind of animations.
                     if( !(*i).setMemorySafe( texture_cords.size(), scta_texture_cords.size() ) )
                         error_log.output << "Not bounds safe " << (*i).getString();
                     else

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -41,10 +41,6 @@ std::string Data::Mission::TilResource::InfoSCTA::getString() const {
     stream << "    animated_uv_offset = " << animated_uv_offset << "\n";
     stream << "    source_uv_offset   = " << source_uv_offset   << "\n";
     stream << "  Translated Values:\n";
-    if( isMemorySafe() )
-        stream << "    This is memory safe\n";
-    else
-        stream << "    This is not memory safe\n";
     stream << "    Total Animation Time = " << getSecondsPerCycle() << " seconds\n";
     stream << "    Seconds Per Frame    = " << getSecondsPerFrame() << " seconds\n";
 
@@ -191,6 +187,8 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
     auto debug_log = settings.logger_r->getLog( Utilities::Logger::DEBUG );
     debug_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
     auto warning_log = settings.logger_r->getLog( Utilities::Logger::WARNING );
+    warning_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
+    auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
     warning_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
     if( this->data_p != nullptr ) {
@@ -396,8 +394,10 @@ bool Data::Mission::TilResource::parse( const ParseSettings &settings ) {
 
                 // Bounds check the SCTA
                 for( auto i = SCTA_info.begin(); i != SCTA_info.end(); i++ ) {
-                    (*i).setMemorySafe( texture_cords.size(), scta_texture_cords.size() );
-                    warning_log.output << (*i).getString();
+                    if( !(*i).setMemorySafe( texture_cords.size(), scta_texture_cords.size() ) )
+                        error_log.output << "Not bounds safe " << (*i).getString();
+                    else
+                        warning_log.output << (*i).getString();
                 }
             }
             else

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -711,7 +711,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
         unsigned int normal_compon_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::NORMAL_COMPONENT_NAME, Utilities::DataTypes::ComponentType::FLOAT, Utilities::DataTypes::Type::VEC3 );
         unsigned int color_compon_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::FLOAT, Utilities::DataTypes::Type::VEC3 );
         unsigned int tex_coord_0_compon_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC2, true );
-        unsigned int tile_type_compon_index = model_output_p->addVertexComponent( TILE_TYPE_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::VEC3, false );
+        unsigned int tile_type_compon_index = model_output_p->addVertexComponent( TILE_TYPE_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::VEC4, false );
 
         model_output_p->setupVertexComponents();
 
@@ -856,7 +856,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
                                         model_output_p->setVertexData(      normal_compon_index, Utilities::DataTypes::Vec3Type( normal[p] ) );
                                         model_output_p->setVertexData(       color_compon_index, Utilities::DataTypes::Vec3Type( color[p] ) );
                                         model_output_p->setVertexData( tex_coord_0_compon_index, Utilities::DataTypes::Vec2UByteType( coord[p] ) );
-                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec3UByteType( glm::u8vec3( current_tile.mesh_type, tile_graphics.animated, stca_animation_index[p] ) ) );
+                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4( current_tile.mesh_type, tile_graphics.animated, stca_animation_index[p], tile_graphics.type == 3 ) ) );
                                     }
                                 }
 
@@ -870,7 +870,7 @@ Utilities::ModelBuilder * Data::Mission::TilResource::createPartial( unsigned in
                                         model_output_p->setVertexData(      normal_compon_index, Utilities::DataTypes::Vec3Type( -normal[p - 1] ) );
                                         model_output_p->setVertexData(       color_compon_index, Utilities::DataTypes::Vec3Type(  color[p - 1] ) );
                                         model_output_p->setVertexData( tex_coord_0_compon_index, Utilities::DataTypes::Vec2UByteType( coord[p - 1] ) );
-                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec3UByteType( glm::u8vec3(  current_tile.mesh_type, tile_graphics.animated, stca_animation_index[p - 1] ) ) );
+                                        model_output_p->setVertexData(   tile_type_compon_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4(  current_tile.mesh_type, tile_graphics.animated, stca_animation_index[p - 1], tile_graphics.type == 3 ) ) );
                                     }
                                 }
                             }

--- a/src/Data/Mission/TilResource.cpp
+++ b/src/Data/Mission/TilResource.cpp
@@ -29,6 +29,8 @@ void readCullingTile( Data::Mission::TilResource::CullingTile &tile, Utilities::
     tile.bottom_right = reader.readU16( endian );
     reader.readU16(); // Skip Unknown data.
 }
+
+const Utilities::PixelFormatColor_W8 SLFX_COLOR;
 }
 
 std::string Data::Mission::TilResource::InfoSLFX::getString() const {
@@ -116,6 +118,48 @@ void Data::Mission::TilResource::InfoSLFX::set( const uint32_t bitfield ) {
         data.wave.speed             = (bitfield >>  4) & ((1 << 4) - 1);
         data.wave.unknown_0         = (bitfield >>  3) & 1;
         data.wave.unused_0          = (bitfield >>  0) & ((1 << 3) - 1);
+    }
+}
+
+Utilities::Image2D* Data::Mission::TilResource::InfoSLFX::getImage() const {
+    return new Utilities::Image2D( AMOUNT_OF_TILES, AMOUNT_OF_TILES, SLFX_COLOR );
+}
+
+void Data::Mission::TilResource::InfoSLFX::setImage( Utilities::Random &random, float &time, Utilities::Image2D &image  ) const {
+    while( time > 1.0 ) {
+        // random.getGenerator();
+
+        time -= 1.0;
+    }
+
+    if( activate_noise ) {
+        bool flip = false;
+
+        if( (int)(time + 0.5) == 1 ) {
+            flip = true;
+        }
+
+        for( unsigned y = 0; y < image.getHeight(); y++ ) {
+            for( unsigned x = 0; x < image.getWidth(); x++ ) {
+                if( flip )
+                    image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( 1.0, 1.0, 1.0, 1.0 ) );
+                else
+                    image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( 0.0, 0.0, 0.0, 1.0 ) );
+
+                flip = !flip;
+            }
+        }
+    }
+    else {
+        for( unsigned y = 1; y < image.getHeight(); y++ ) {
+            for( unsigned x = 0; x < image.getWidth(); x++ ) {
+                image.writePixel( x, y, Utilities::PixelFormatColor::GenericColor( 1.0, 1.0, 1.0, 1.0 ) );
+            }
+
+            unsigned medium = static_cast<unsigned>(image.getWidth() * time + y) % image.getWidth();
+
+            image.writePixel( medium, y, Utilities::PixelFormatColor::GenericColor( 0.0, 0.0, 0.0, 1.0 ) );
+        }
     }
 }
 

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -133,7 +133,8 @@ public:
                 ((uint16_t)type << 14);
         }
     };
-    struct InfoSLFX {
+    class InfoSLFX {
+    public:
         union Data {
             struct Wave {
                 // byte 1
@@ -171,6 +172,7 @@ public:
         uint32_t unknown_0:         2;
         uint32_t is_disabled:       1; // Enabling this would disable the animations.
 
+    public:
         InfoSLFX() {}
         InfoSLFX( const uint32_t bitfield ) {
             set( bitfield );
@@ -179,10 +181,28 @@ public:
         std::string getString() const;
         uint32_t get() const;
         void     set( const uint32_t bitfield );
+    };
+
+    class AnimationSLFX {
+    public:
+        InfoSLFX info_slfx;
+
+    private:
+        Utilities::Random random;
+        float cycle;
+        float speed;
+
+    public:
+        AnimationSLFX( InfoSLFX info_slfx );
+
+        void setInfo( InfoSLFX info_slfx );
+
+        void advanceTime( float delta_seconds );
 
         Utilities::Image2D* getImage() const;
-        void setImage( Utilities::Random &random, float &time, Utilities::Image2D &image ) const;
+        void setImage( Utilities::Image2D &image ) const;
     };
+
     struct InfoSCTA {
         static constexpr float units_to_seconds = 1. / 300.;
         static constexpr float seconds_to_units = 300.;

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -136,15 +136,24 @@ public:
         static constexpr float units_to_seconds = 1. / 300.;
         static constexpr float seconds_to_units = 300.;
 
-        uint_fast32_t frame_count;
+        int_fast32_t  frame_count;
         uint_fast32_t duration_per_frame;
         uint_fast32_t animated_uv_offset;
         uint_fast32_t source_uv_offset;
 
         std::string getString() const;
 
+        int_fast32_t getFrameCount() const { return std::abs( frame_count ); }
         float getSecondsPerFrame() const { return duration_per_frame * units_to_seconds; }
-        float getSecondsPerCycle() const { return getSecondsPerFrame() * frame_count; }
+        float getSecondsPerCycle() const { return getSecondsPerFrame() * getFrameCount(); }
+
+        bool isMemorySafe() const { return frame_count >= 0; }
+
+        /**
+         * This method sets the variables inside the struct to be memory safe.
+         * @return false if an element is found to be unstable.
+         */
+        bool setMemorySafe( size_t source_size, size_t animated_size );
     };
     
     static constexpr size_t AMOUNT_OF_TILES = 16;
@@ -195,8 +204,6 @@ public:
     virtual uint32_t getResourceTagID() const;
 
     Utilities::Image2D getImage() const;
-
-    glm::i8vec2 getUVAnimation() const { return uv_animation; }
     
     void makeEmpty();
 
@@ -224,6 +231,10 @@ public:
     const std::vector<Utilities::Collision::Triangle>& getAllTriangles() const;
     Utilities::Image2D getHeightMap( unsigned int rays_per_tile = 4 ) const;
     
+    glm::i8vec2 getUVAnimation() const { return uv_animation; }
+    const std::vector<InfoSCTA>& getInfoSCTA() const { return SCTA_info; }
+    const std::vector<glm::u8vec2>& getSCTATextureCords() const { return scta_texture_cords; }
+
     static std::vector<TilResource*> getVector( IFF &mission_file );
     static const std::vector<TilResource*> getVector( const IFF &mission_file );
 };

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -194,6 +194,7 @@ public:
         float speed;
 
     public:
+        AnimationSLFX();
         AnimationSLFX( InfoSLFX info_slfx );
 
         void setInfo( InfoSLFX info_slfx );
@@ -308,6 +309,8 @@ public:
     glm::i8vec2 getUVAnimation() const { return uv_animation; }
     const std::vector<InfoSCTA>& getInfoSCTA() const { return SCTA_info; }
     const std::vector<glm::u8vec2>& getSCTATextureCords() const { return scta_texture_cords; }
+
+    const InfoSLFX getInfoSLFX() const { return InfoSLFX( slfx_bitfield ); }
 
     static std::vector<TilResource*> getVector( IFF &mission_file );
     static const std::vector<TilResource*> getVector( const IFF &mission_file );

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -6,6 +6,7 @@
 #include "../../Utilities/GridBase2D.h"
 #include "../../Utilities/Collision/Ray.h"
 #include "../../Utilities/Collision/Triangle.h"
+#include "../../Utilities/Random.h"
 
 namespace Data {
 
@@ -178,6 +179,9 @@ public:
         std::string getString() const;
         uint32_t get() const;
         void     set( const uint32_t bitfield );
+
+        Utilities::Image2D* getImage() const;
+        void setImage( Utilities::Random &random, float &time, Utilities::Image2D &image ) const;
     };
     struct InfoSCTA {
         static constexpr float units_to_seconds = 1. / 300.;

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -138,18 +138,14 @@ public:
         union Data {
             struct Wave {
                 // byte 1
-                uint32_t unused_0:          3;
-                uint32_t unknown_0:         1;
-                uint32_t speed:             4;
+                uint32_t speed:                  8; // This is the speed of the gradient.
 
                 // byte 2
-                uint32_t other_wave:        4;
-                uint32_t default_level:     4;
+                uint32_t background_light_level: 8;
 
                 // byte 3
-                uint32_t rate:              3; // Clear rate?
-                uint32_t is_forever_bright: 1;
-                uint32_t apply_level:       4; // Light value
+                uint32_t gradient_width:         4; // This subtracts the width of the gradient. 0x0 smoothest. 0x2 perfect. 0x3 narrow. 0xF so narrow that no animation is seen.
+                uint32_t gradient_light_level:   4; // The Light and Dark Levels of the gradient.
             } wave;
             struct Noise {
                 // byte 1

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -132,6 +132,20 @@ public:
                 ((uint16_t)type << 14);
         }
     };
+    struct InfoSCTA {
+        static constexpr float units_to_seconds = 1. / 300.;
+        static constexpr float seconds_to_units = 300.;
+
+        uint_fast32_t frame_count;
+        uint_fast32_t duration_per_frame;
+        uint_fast32_t animated_uv_offset;
+        uint_fast32_t source_uv_offset;
+
+        std::string getString() const;
+
+        float getSecondsPerFrame() const { return duration_per_frame * units_to_seconds; }
+        float getSecondsPerCycle() const { return getSecondsPerFrame() * frame_count; }
+    };
     
     static constexpr size_t AMOUNT_OF_TILES = 16;
     static constexpr float  SPAN_OF_TIL = AMOUNT_OF_TILES / 2;
@@ -158,6 +172,9 @@ private:
     std::vector<glm::u8vec2> texture_cords; // They contain the UV's for the tiles, they are often read as quads
     std::vector<Utilities::PixelFormatColor::GenericColor> colors;
     std::vector<uint16_t> tile_graphics_bitfield;
+
+    std::vector<InfoSCTA> SCTA_info;
+    std::vector<glm::u8vec2> scta_texture_cords;
     
     uint32_t slfx_bitfield;
     

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -132,6 +132,52 @@ public:
                 ((uint16_t)type << 14);
         }
     };
+    struct InfoSLFX {
+        union Data {
+            struct Wave {
+                // byte 1
+                uint32_t unknown_0:         4;
+                uint32_t speed:             4;
+
+                // byte 2
+                uint32_t other_wave:        4;
+                uint32_t default_level:     4;
+
+                // byte 3
+                uint32_t rate:              3; // Clear rate?
+                uint32_t is_forever_bright: 1;
+                uint32_t apply_level:       4; // Light value
+            } wave;
+            struct Noise {
+                // byte 1
+                uint32_t reducer:    2; // The more tends to decrease the effect. Maybe a rightshift specifier.
+                uint32_t unused_0:   4;
+                uint32_t unknown_0:  1; // This does not seem to affect anything.
+                uint32_t unused_1:   1;
+
+                // byte 2
+                uint32_t brightness: 8; // The more this value the brighter the animations become.
+
+                // byte 3
+                uint32_t unused_2:   8;
+            } noise;
+        } data;
+
+        // byte 4
+        uint32_t activate_diagonal: 4; // Looks like diagonal waves.
+        uint32_t activate_noise:    1; // Looks like perlin noise. This bit overpowers activate_diagonal.
+        uint32_t unknown_0:         2;
+        uint32_t is_disabled:       1; // Enabling this would disable the animations.
+
+        InfoSLFX() {}
+        InfoSLFX( const uint32_t bitfield ) {
+            set( bitfield );
+        }
+
+        std::string getString() const;
+        uint32_t get() const;
+        void     set( const uint32_t bitfield );
+    };
     struct InfoSCTA {
         static constexpr float units_to_seconds = 1. / 300.;
         static constexpr float seconds_to_units = 300.;

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -117,9 +117,9 @@ public:
         void set( const uint16_t bitfield ) {
             shading          = (bitfield >>  0) & ((1 << 8) - 1);
             texture_index    = (bitfield >>  8) & ((1 << 3) - 1);
-            animated         = (bitfield >> 11) & ((1 << 1) - 1);
-            semi_transparent = (bitfield >> 12) & ((1 << 1) - 1);
-            rectangle        = (bitfield >> 13) & ((1 << 1) - 1);
+            animated         = (bitfield >> 11) & 1;
+            semi_transparent = (bitfield >> 12) & 1;
+            rectangle        = (bitfield >> 13) & 1;
             type             = (bitfield >> 14) & ((1 << 2) - 1);
         }
         

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -156,6 +156,7 @@ public:
         bool setMemorySafe( size_t source_size, size_t animated_size );
     };
     
+    static const std::string TILE_TYPE_COMPONENT_NAME;
     static constexpr size_t AMOUNT_OF_TILES = 16;
     static constexpr float  SPAN_OF_TIL = AMOUNT_OF_TILES / 2;
     static constexpr float MAX_HEIGHT = 6.0f; // The highest value is actually MAX_HEIGHT - SAMPLE_HEIGHT due to the span of the pixels being [127, -128].

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -146,6 +146,7 @@ public:
         int_fast32_t getFrameCount() const { return std::abs( frame_count ); }
         float getSecondsPerFrame() const { return duration_per_frame * units_to_seconds; }
         float getSecondsPerCycle() const { return getSecondsPerFrame() * getFrameCount(); }
+        float getDurationToSeconds() const { return seconds_to_units / duration_per_frame; }
 
         bool isMemorySafe() const { return frame_count >= 0; }
 

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -197,6 +197,8 @@ public:
         AnimationSLFX();
         AnimationSLFX( InfoSLFX info_slfx );
 
+        InfoSLFX getInfo() const { return info_slfx; }
+
         void setInfo( InfoSLFX info_slfx );
 
         void advanceTime( float delta_seconds );

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -188,6 +188,7 @@ public:
         InfoSLFX info_slfx;
 
     private:
+        Utilities::Random::Generator last, next;
         Utilities::Random random;
         float cycle;
         float speed;

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -147,6 +147,8 @@ private:
     CullingTile culling_bottom_left;
     CullingTile culling_bottom_right;
 
+    glm::i8vec2 uv_animation;
+
     uint16_t texture_reference; // This is an unknown number, but it affects all the textures in the resource. One change will mess up the tiles.
     Floor mesh_reference_grid[ AMOUNT_OF_TILES ][ AMOUNT_OF_TILES ];
 
@@ -176,6 +178,8 @@ public:
     virtual uint32_t getResourceTagID() const;
 
     Utilities::Image2D getImage() const;
+
+    glm::i8vec2 getUVAnimation() const { return uv_animation; }
     
     void makeEmpty();
 

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -136,7 +136,8 @@ public:
         union Data {
             struct Wave {
                 // byte 1
-                uint32_t unknown_0:         4;
+                uint32_t unused_0:          3;
+                uint32_t unknown_0:         1;
                 uint32_t speed:             4;
 
                 // byte 2

--- a/src/Graphics/SDL2/GLES2/Internal/Texture2D.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Texture2D.cpp
@@ -36,7 +36,7 @@ void Graphics::SDL2::GLES2::Internal::Texture2D::setFilters( GLuint active_textu
 }
 
 void Graphics::SDL2::GLES2::Internal::Texture2D::genChecker( GLuint active_texture, GLsizei width, GLsizei height, GLubyte pixel1[3], GLubyte pixel2[3] ) {
-    GLubyte * spriteData = new GLubyte [ width * height * 3 ];
+    GLubyte * checker_data_p = new GLubyte [ width * height * 3 ];
 
     bool flip = false; // used to flip the pixels to a checker board
     GLsizei sync = 0; // used to count to the width
@@ -51,26 +51,32 @@ void Graphics::SDL2::GLES2::Internal::Texture2D::genChecker( GLuint active_textu
         sync = bounds_check * sync; // reset sync when the width hits
 
         // This choses between two colors depending on the flip bit
-        spriteData[ offset + 0 ] = flip * pixel1[0] | !flip * pixel2[0];
-        spriteData[ offset + 1 ] = flip * pixel1[1] | !flip * pixel2[1];
-        spriteData[ offset + 2 ] = flip * pixel1[2] | !flip * pixel2[2];
+        checker_data_p[ offset + 0 ] = flip * pixel1[0] | !flip * pixel2[0];
+        checker_data_p[ offset + 1 ] = flip * pixel1[1] | !flip * pixel2[1];
+        checker_data_p[ offset + 2 ] = flip * pixel1[2] | !flip * pixel2[2];
 
         // Flip the bit when done.
         flip = !flip;
     }
 
-    this->setImage( active_texture, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, spriteData);
+    this->setImage( active_texture, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, checker_data_p );
 
-    delete [] spriteData;
+    delete [] checker_data_p;
 }
 
-void Graphics::SDL2::GLES2::Internal::Texture2D::setImage( GLuint active_texture, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * data ) {
+void Graphics::SDL2::GLES2::Internal::Texture2D::setImage( GLuint active_texture, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * data_r ) {
     if( !is_allocated )
         generate();
 
     bind( active_texture );
 
-    glTexImage2D( GL_TEXTURE_2D, level, internalformat, width, height, border, format, type, data );
+    glTexImage2D( GL_TEXTURE_2D, level, internalformat, width, height, border, format, type, data_r );
+}
+
+void Graphics::SDL2::GLES2::Internal::Texture2D::updateImage( GLuint active_texture, GLint level, GLsizei width, GLsizei height, GLenum format, GLenum type, const void * data_r ) {
+    bind( active_texture );
+
+    glTexSubImage2D( GL_TEXTURE_2D, level, 0, 0, width, height, format, type, data_r );
 }
 
 void Graphics::SDL2::GLES2::Internal::Texture2D::bind( GLuint active_texture, GLint texture_uniform_id ) const {

--- a/src/Graphics/SDL2/GLES2/Internal/Texture2D.h
+++ b/src/Graphics/SDL2/GLES2/Internal/Texture2D.h
@@ -53,13 +53,25 @@ public:
      * @param border This is the boarder of the image.
      * @param format This is the format of a texel.
      * @param type The data type of the texel
-     * @param data The pointer to the raw pixels of the texture.
+     * @param data_r The pointer to the raw pixels of the texture.
      */
-    void setImage( GLuint active_texture, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * data );
+    void setImage( GLuint active_texture, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * data_r );
 
     /**
-     * This binds the texture when a uniform is used.
-     * This is mostly useful for drawing the texture.
+     * This updates the image.
+     * @note http://docs.gl/es2/glTexSubImage2D could explain what the parameters would do.
+     * @param active_texture This is the active texture slot.
+     * @param level The texture level of the image.
+     * @param width This is the width of the texture. Values must be a power of 2 factor.
+     * @param height This is the height of the texture. Values must be a power of 2 factor.
+     * @param format This is the format of a texel.
+     * @param type The data type of the texel
+     * @param data_r The pointer to the raw pixels of the texture.
+     */
+    void updateImage( GLuint active_texture, GLint level, GLsizei width, GLsizei height, GLenum format, GLenum type, const void * data_r );
+
+    /**
+     * This binds the texture when a uniform is used in a shader.
      * @param active_texture The texture slot to be used.
      * @param texture_uniform_id uniform location of the texture.
      */

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -46,22 +46,26 @@ const GLchar* Graphics::SDL2::GLES2::Internal::World::default_vertex_shader =
     "uniform vec2  AnimatedUVDestination;\n"
     "uniform float GlowTime;\n"
     "uniform float SelectedTile;\n"
+    "uniform vec2  ScTAPositions[16 * 4];\n"
 
     "const vec3 frag_inv = vec3(1,1,1);\n"
 
-    "void main()\n"
-    "{\n"
+    "void main() {\n"
+    "   float SELECT_SPECIFIER = _TILE_TYPE.x;\n"
+    "   float DISPLACEMENT     = _TILE_TYPE.y;\n"
+    "   float FRAME_BY_FRAME   = _TILE_TYPE.z;\n"
+
     "   vec3 inverse_color = frag_inv - COLOR_0;\n"
-    "   float flashing = GlowTime * float(SelectedTile > _TILE_TYPE.z - 0.5 && SelectedTile < _TILE_TYPE.z + 0.5);\n"
+    "   float flashing = GlowTime * float(SelectedTile > SELECT_SPECIFIER - 0.5 && SelectedTile < SELECT_SPECIFIER + 0.5);\n"
     "   vertex_colors = (1.0 - flashing) * COLOR_0 + 2.0 * flashing * inverse_color;\n"
-    "   texture_coord_1 = fract( TEXCOORD_0 + AnimatedUVDestination * _TILE_TYPE.y );\n"
+    "   vec2 tex_coord_pos = TEXCOORD_0 * float( FRAME_BY_FRAME < 1. );\n"
+    "   texture_coord_1 = fract( tex_coord_pos + AnimatedUVDestination * DISPLACEMENT );\n"
     "   gl_Position = Transform * vec4(POSITION.xyz, 1.0);\n"
     "}\n";
 const GLchar* Graphics::SDL2::GLES2::Internal::World::default_fragment_shader =
     "uniform sampler2D Texture;\n"
 
-    "void main()\n"
-    "{\n"
+    "void main() {\n"
     "   vec4 frag_color = texture2D(Texture, texture_coord_1);\n"
     "   if( frag_color.a < 0.015625 )\n"
     "       discard;\n"

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -59,11 +59,16 @@ const GLchar* Graphics::SDL2::GLES2::Internal::World::default_vertex_shader =
     "void main() {\n"
     "   float SELECT_SPECIFIER   = _TILE_TYPE.x;\n"
     "   float DISPLACEMENT       = _TILE_TYPE.y;\n"
-    "   highp int FRAME_BY_FRAME = int( _TILE_TYPE.z );\n"
+    "   int FRAME_BY_FRAME       = int( _TILE_TYPE.z );\n"
+    "   float VERTEX_ANIMATION_ENABLE = _TILE_TYPE.w;\n"
 
-    "   vec3 inverse_color = frag_inv - COLOR_0;\n"
+    "   vec3 normal_color = COLOR_0;\n"
+
+    "   normal_color += vec3( 1, 1, 1 ) * float(VERTEX_ANIMATION_ENABLE == 1.);\n"
+
+    "   vec3 inverse_color = frag_inv - normal_color;\n"
     "   float flashing = GlowTime * float(SelectedTile > SELECT_SPECIFIER - 0.5 && SelectedTile < SELECT_SPECIFIER + 0.5);\n"
-    "   vertex_colors = (1.0 - flashing) * COLOR_0 + 2.0 * flashing * inverse_color;\n"
+    "   vertex_colors = (1.0 - flashing) * normal_color + 2.0 * flashing * inverse_color;\n"
 
     "   vec2 tex_coord_pos = TEXCOORD_0 * float( FRAME_BY_FRAME == 0 );\n"
     "   tex_coord_pos += AnimatedUVFrames[ clamp( FRAME_BY_FRAME - 1, 0, 16 * 4 ) ] * float( FRAME_BY_FRAME != 0 );\n"
@@ -91,7 +96,7 @@ Graphics::SDL2::GLES2::Internal::World::World() {
     attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec4 " + Utilities::ModelBuilder::POSITION_COMPONENT_NAME ) );
     attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 " + Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME ) );
     attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec3 " + Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec3 " + Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec4 " + Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME ) );
 
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec3 vertex_colors" ) );
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec2 texture_coord_1" ) );

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -74,10 +74,10 @@ Graphics::SDL2::GLES2::Internal::World::World() {
     this->current_selected_tile = 112;
     this->selected_tile = this->current_selected_tile + 1;
 
-    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec4 POSITION" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 TEXCOORD_0" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec3 COLOR_0" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec2 _TILE_TYPE" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec4 " + Utilities::ModelBuilder::POSITION_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 " + Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec3 " + Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec2 " + Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME ) );
 
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec3 vertex_colors" ) );
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec2 texture_coord_1" ) );
@@ -139,10 +139,10 @@ int Graphics::SDL2::GLES2::Internal::World::compilieProgram() {
             glow_time_uniform_id       = program.getUniform( "GlowTime",      &std::cout, &uniform_failed );
             selected_tile_uniform_id   = program.getUniform( "SelectedTile",  &std::cout, &uniform_failed );
             
-            attribute_failed |= !program.isAttribute( "POSITION",   &std::cout );
-            attribute_failed |= !program.isAttribute( "TEXCOORD_0", &std::cout );
-            attribute_failed |= !program.isAttribute( "COLOR_0",    &std::cout );
-            attribute_failed |= !program.isAttribute( "_TILE_TYPE", &std::cout );
+            attribute_failed |= !program.isAttribute( Utilities::ModelBuilder::POSITION_COMPONENT_NAME,     &std::cout );
+            attribute_failed |= !program.isAttribute( Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME,     &std::cout );
+            attribute_failed |= !program.isAttribute( Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME,  &std::cout );
+            attribute_failed |= !program.isAttribute( Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME, &std::cout );
         }
         
         if( !link_success || uniform_failed || attribute_failed )
@@ -215,7 +215,7 @@ void Graphics::SDL2::GLES2::Internal::World::setWorld( const Data::Mission::PTCR
                 color_compenent_index = i;
             if( name == Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME )
                 coordinate_compenent_index = i;
-            if( name == "_TILE_TYPE" )
+            if( name == Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME )
                 tile_type_compenent_index = i;
         }
 

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -201,9 +201,10 @@ void Graphics::SDL2::GLES2::Internal::World::setWorld( const Data::Mission::PTCR
 
             if( info.isMemorySafe() ) {
                 const auto factor = glm::vec2( 1. / 256., 1. / 256. );
+                const unsigned frame_index = 0 * 4;
 
                 for( unsigned a = 0; a < 4; a++ ) {
-                    (*i).current_uv_frames[ info_index * 4 + a ] = glm::vec2( uv_frames[ info_index * 4 + a ].x, uv_frames[ info_index * 4 + a ].y ) * factor;
+                    (*i).current_uv_frames[ info_index * 4 + a ] = glm::vec2( uv_frames[ info.animated_uv_offset / 2 + a + frame_index ].x, uv_frames[ info.animated_uv_offset / 2 + a + frame_index].y ) * factor;
                 }
             }
         }

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -52,7 +52,7 @@ const GLchar* Graphics::SDL2::GLES2::Internal::World::default_vertex_shader =
     "void main()\n"
     "{\n"
     "   vec3 inverse_color = frag_inv - COLOR_0;\n"
-    "   float flashing = GlowTime * float(SelectedTile > _TILE_TYPE.x - 0.5 && SelectedTile < _TILE_TYPE.x + 0.5);\n"
+    "   float flashing = GlowTime * float(SelectedTile > _TILE_TYPE.z - 0.5 && SelectedTile < _TILE_TYPE.z + 0.5);\n"
     "   vertex_colors = (1.0 - flashing) * COLOR_0 + 2.0 * flashing * inverse_color;\n"
     "   texture_coord_1 = fract( TEXCOORD_0 + AnimatedUVDestination * _TILE_TYPE.y );\n"
     "   gl_Position = Transform * vec4(POSITION.xyz, 1.0);\n"
@@ -77,7 +77,7 @@ Graphics::SDL2::GLES2::Internal::World::World() {
     attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec4 " + Utilities::ModelBuilder::POSITION_COMPONENT_NAME ) );
     attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 " + Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME ) );
     attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec3 " + Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec2 " + Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec3 " + Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME ) );
 
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec3 vertex_colors" ) );
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec2 texture_coord_1" ) );

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -489,7 +489,7 @@ void Graphics::SDL2::GLES2::Internal::World::draw( Graphics::SDL2::GLES2::Camera
         if( (*i).current_frame_uvs.size() != 0 )
             glUniform2fv( frame_uv_id, (*i).current_frame_uvs.size(), reinterpret_cast<float*>((*i).current_frame_uvs.data()) );
 
-        if( vertex_animation_p != nullptr ) {
+        if( vertex_animation_p != nullptr && !(*i).animation_slfx.getInfo().is_disabled ) {
             (*i).animation_slfx.setImage( *vertex_animation_p );
             vertex_animation_texture.updateImage( 1, 0, vertex_animation_p->getWidth() * vertex_animation_p->getHeight(), 1, GL_LUMINANCE, GL_UNSIGNED_BYTE, vertex_animation_p->getDirectGridData() );
             vertex_animation_texture.bind( 1, vertex_animation_uniform_id );

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -443,20 +443,22 @@ void Graphics::SDL2::GLES2::Internal::World::advanceTime( float seconds_passed )
                 (*i).current -= (*i).change_rate * 2.0;
         }
 
-        const auto frame_time_ratio = (1./5.95); // 5.95 is the amount of secounds that one unit of time.
-        const auto max_displacement = 1.0 / 256.0 * 27.0;
+        const auto frame_time_inverse = (1./5.95); // 5.95 is the amount of secounds that one unit of time.
+        const auto pixel_amount = 27.0;
+        const auto image_ratio  = 1.0 / 256.0; // A single Cbmp texture resource has the resolution of 256 pixels.
+        const auto uv_destination = image_ratio * pixel_amount;
 
-        (*i).animated_uv_time.x += seconds_passed * frame_time_ratio * (*i).animated_uv_factor.x;
+        (*i).animated_uv_time.x += seconds_passed * frame_time_inverse * (*i).animated_uv_factor.x;
 
         if( (*i).animated_uv_time.x > 1.0f )
             (*i).animated_uv_time.x -= 1.0f;
 
-        (*i).animated_uv_time.y += seconds_passed * frame_time_ratio * (*i).animated_uv_factor.y;
+        (*i).animated_uv_time.y += seconds_passed * frame_time_inverse * (*i).animated_uv_factor.y;
 
         if( (*i).animated_uv_time.y  > 1.0f )
             (*i).animated_uv_time.y -= 1.0f;
 
-        (*i).animated_uv_destination = glm::vec2( max_displacement, max_displacement ) * (*i).animated_uv_time;
+        (*i).animated_uv_destination = glm::vec2( uv_destination, uv_destination ) * (*i).animated_uv_time;
     }
     
     // Update glow time.

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -504,7 +504,7 @@ void Graphics::SDL2::GLES2::Internal::World::advanceTime( float seconds_passed )
 
                 last_time = (*i).times[ info_index ];
 
-                (*i).times[ info_index ] += seconds_passed * 1. / info.getSecondsPerFrame();
+                (*i).times[ info_index ] += seconds_passed * info.getDurationToSeconds();
 
                 if( (*i).times[ info_index ] >= info.getFrameCount() )
                     (*i).times[ info_index ] -= info.getFrameCount();

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -66,7 +66,7 @@ const GLchar* Graphics::SDL2::GLES2::Internal::World::default_vertex_shader =
     "   vertex_colors = (1.0 - flashing) * COLOR_0 + 2.0 * flashing * inverse_color;\n"
     "   vec2 tex_coord_pos = TEXCOORD_0 * float( FRAME_BY_FRAME == 0 );\n"
     "   tex_coord_pos += AnimatedUVFrames[ clamp( FRAME_BY_FRAME - 1, 0, 16 * 4 ) ] * float( FRAME_BY_FRAME != 0 );\n"
-    "   texture_coord_1 = fract( tex_coord_pos + AnimatedUVDestination * DISPLACEMENT );\n"
+    "   texture_coord_1 = tex_coord_pos + AnimatedUVDestination * DISPLACEMENT;\n"
     "   gl_Position = Transform * vec4(POSITION.xyz, 1.0);\n"
     "}\n";
 const GLchar* Graphics::SDL2::GLES2::Internal::World::default_fragment_shader =

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -64,9 +64,12 @@ const GLchar* Graphics::SDL2::GLES2::Internal::World::default_vertex_shader =
     "   vec3 inverse_color = frag_inv - COLOR_0;\n"
     "   float flashing = GlowTime * float(SelectedTile > SELECT_SPECIFIER - 0.5 && SelectedTile < SELECT_SPECIFIER + 0.5);\n"
     "   vertex_colors = (1.0 - flashing) * COLOR_0 + 2.0 * flashing * inverse_color;\n"
+
     "   vec2 tex_coord_pos = TEXCOORD_0 * float( FRAME_BY_FRAME == 0 );\n"
     "   tex_coord_pos += AnimatedUVFrames[ clamp( FRAME_BY_FRAME - 1, 0, 16 * 4 ) ] * float( FRAME_BY_FRAME != 0 );\n"
     "   texture_coord_1 = tex_coord_pos + AnimatedUVDestination * DISPLACEMENT;\n"
+    "   texture_coord_1 = fract( texture_coord_1 ) + vec2( float( texture_coord_1.x == 1. ), float( texture_coord_1.y == 1. ) );\n"
+
     "   gl_Position = Transform * vec4(POSITION.xyz, 1.0);\n"
     "}\n";
 const GLchar* Graphics::SDL2::GLES2::Internal::World::default_fragment_shader =

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -200,10 +200,11 @@ void Graphics::SDL2::GLES2::Internal::World::setWorld( const Data::Mission::PTCR
             const Data::Mission::TilResource::InfoSCTA &info = scta_infos[ info_index ];
 
             if( info.isMemorySafe() ) {
-                (*i).current_uv_frames[ info_index * 4 + 0 ] = glm::vec2( 0, 0 );
-                (*i).current_uv_frames[ info_index * 4 + 1 ] = glm::vec2( 0.5, 0 );
-                (*i).current_uv_frames[ info_index * 4 + 2 ] = glm::vec2( 0.5, 0.5 );
-                (*i).current_uv_frames[ info_index * 4 + 3 ] = glm::vec2( 0, 0.5 );
+                const auto factor = glm::vec2( 1. / 256., 1. / 256. );
+
+                for( unsigned a = 0; a < 4; a++ ) {
+                    (*i).current_uv_frames[ info_index * 4 + a ] = glm::vec2( uv_frames[ info_index * 4 + a ].x, uv_frames[ info_index * 4 + a ].y ) * factor;
+                }
             }
         }
 

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -33,7 +33,7 @@ void Graphics::SDL2::GLES2::Internal::World::MeshDraw::Animation::addTriangles( 
         if( info.bitfield.vertex_animation ) {
             if( vertex_animation_p == nullptr ) {
                 for( unsigned t = 0; t < 3; t++ ) {
-                    draw_triangles_r[ i ].vertices[ t ].color += glm::vec4(1,1,1,0);
+                    draw_triangles_r[ i ].vertices[ t ].color += 2.0f * glm::vec4(1,1,1,0);
                 }
             }
             else {

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -21,7 +21,7 @@ void Graphics::SDL2::GLES2::Internal::World::MeshDraw::Animation::addTriangles( 
 
         const auto info = mesh_draw_r->transparent_triangle_info[ i ];
 
-        if( selected_tile == info.type ) {
+        if( selected_tile == info.bitfield.type ) {
             for( unsigned t = 0; t < 3; t++ ) {
                 glm::vec4 inverse_color = frag_inv - draw_triangles_r[ i ].vertices[ t ].color;
                 draw_triangles_r[ i ].vertices[ t ].color = 2.0f * ( (1.0f - glow_time) * draw_triangles_r[ i ].vertices[ t ].color + 2.0f * glow_time * inverse_color );
@@ -29,13 +29,13 @@ void Graphics::SDL2::GLES2::Internal::World::MeshDraw::Animation::addTriangles( 
             }
         }
 
-        if( info.animation.frame_by_frame != 0 ) {
+        if( info.frame_by_frame[0] != 0 ) {
             for( unsigned t = 0; t < 3; t++ ) {
-                draw_triangles_r[ i ].vertices[ t ].coordinate = mesh_draw_r->current_frame_uvs[ (unsigned(info.animation.frame_by_frame) - 1) % mesh_draw_r->current_frame_uvs.size() ];
+                draw_triangles_r[ i ].vertices[ t ].coordinate = mesh_draw_r->current_frame_uvs[ (unsigned(info.frame_by_frame[t]) - 1) % mesh_draw_r->current_frame_uvs.size() ];
             }
         }
 
-        if( info.animation.displacement ) {
+        if( info.bitfield.displacement ) {
             for( unsigned t = 0; t < 3; t++ ) {
                 draw_triangles_r[ i ].vertices[ t ].coordinate += mesh_draw_r->displacement_uv_destination;
 
@@ -289,13 +289,13 @@ void Graphics::SDL2::GLES2::Internal::World::setWorld( const Data::Mission::PTCR
                     if( t == 0 ) {
                         MeshDraw::Info info;
 
-                        info.type = tile_type.x;
-
-                        info.animation.displacement   = tile_type.y;
-                        info.animation.frame_by_frame = tile_type.z;
+                        info.bitfield.type = tile_type.x;
+                        info.bitfield.displacement  = tile_type.y;
 
                         (*i).transparent_triangle_info.push_back( info );
                     }
+
+                    (*i).transparent_triangle_info.back().frame_by_frame[t] = tile_type.z;
                 }
 
                 triangle.setup( cbmp_id, glm::vec3(0, 0, 0) );

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -190,6 +190,23 @@ void Graphics::SDL2::GLES2::Internal::World::setWorld( const Data::Mission::PTCR
         (*i).animated_uv_destination = glm::vec2( 0, 0 );
         (*i).animated_uv_time = glm::vec2( 0, 0 );
 
+        const std::vector<Data::Mission::TilResource::InfoSCTA> &scta_infos = (*i).til_resource_r->getInfoSCTA();
+        const std::vector<glm::u8vec2> &uv_frames = (*i).til_resource_r->getSCTATextureCords();
+
+        (*i).times.resize( scta_infos.size(), 0 );
+        (*i).current_uv_frames.resize( scta_infos.size() * 4 );
+
+        for( unsigned info_index = 0; info_index < scta_infos.size(); info_index++ ) {
+            const Data::Mission::TilResource::InfoSCTA &info = scta_infos[ info_index ];
+
+            if( info.isMemorySafe() ) {
+                (*i).current_uv_frames[ info_index * 4 + 0 ] = glm::vec2( 0, 0 );
+                (*i).current_uv_frames[ info_index * 4 + 1 ] = glm::vec2( 0.5, 0 );
+                (*i).current_uv_frames[ info_index * 4 + 2 ] = glm::vec2( 0.5, 0.5 );
+                (*i).current_uv_frames[ info_index * 4 + 3 ] = glm::vec2( 0, 0.5 );
+            }
+        }
+
         (*i).mesh_p->setup( *model_p, textures );
 
         Utilities::ModelBuilder::TextureMaterial material;
@@ -367,8 +384,6 @@ bool Graphics::SDL2::GLES2::Internal::World::updateCulling( Graphics::SDL2::GLES
     return true;
 }
 
-std::vector<glm::vec2> box = { {0, 0}, {0.5, 0}, {0.5, 0.5}, {0, 0.5} };
-
 void Graphics::SDL2::GLES2::Internal::World::draw( Graphics::SDL2::GLES2::Camera &camera ) {
     glm::mat4 projection_view, final_position, position_mat;
     
@@ -405,10 +420,11 @@ void Graphics::SDL2::GLES2::Internal::World::draw( Graphics::SDL2::GLES2::Camera
     dynamic.selected_tile = this->selected_tile;
     dynamic.glow_time = filtered_glow_time;
 
-    glUniform2fv( animated_uv_frames_id, box.size(), reinterpret_cast<float*>(box.data()) );
-
     for( auto i = tiles.begin(); i != tiles.end(); i++ ) {
         glUniform2f( animated_uv_destination_id, (*i).animated_uv_destination.x, (*i).animated_uv_destination.y );
+
+        if( (*i).current_uv_frames.size() != 0 )
+            glUniform2fv( animated_uv_frames_id, (*i).current_uv_frames.size(), reinterpret_cast<float*>((*i).current_uv_frames.data()) );
 
         if( (*i).current >= 0.0 )
         for( unsigned int d = 0; d < (*i).sections.size(); d++ ) {

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -29,7 +29,13 @@ void Graphics::SDL2::GLES2::Internal::World::MeshDraw::Animation::addTriangles( 
             }
         }
 
-        if( info.animated ) {
+        if( info.animation.frame_by_frame != 0 ) {
+            for( unsigned t = 0; t < 3; t++ ) {
+                draw_triangles_r[ i ].vertices[ t ].coordinate = mesh_draw_r->current_frame_uvs[ (unsigned(info.animation.frame_by_frame) - 1) % mesh_draw_r->current_frame_uvs.size() ];
+            }
+        }
+
+        if( info.animation.displacement ) {
             for( unsigned t = 0; t < 3; t++ ) {
                 draw_triangles_r[ i ].vertices[ t ].coordinate += mesh_draw_r->displacement_uv_destination;
 
@@ -283,8 +289,10 @@ void Graphics::SDL2::GLES2::Internal::World::setWorld( const Data::Mission::PTCR
                     if( t == 0 ) {
                         MeshDraw::Info info;
 
-                        info.type     = tile_type.x;
-                        info.animated = tile_type.y;
+                        info.type = tile_type.x;
+
+                        info.animation.displacement   = tile_type.y;
+                        info.animation.frame_by_frame = tile_type.z;
 
                         (*i).transparent_triangle_info.push_back( info );
                     }

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -79,7 +79,7 @@ const GLchar* Graphics::SDL2::GLES2::Internal::World::default_vertex_shader =
     "void main() {\n"
     "   float SELECT_SPECIFIER   = _TILE_TYPE.x - float( _TILE_TYPE.x >= 128. ) * 128.;\n"
     "   float DISPLACEMENT       = _TILE_TYPE.y;\n"
-    "   int FRAME_BY_FRAME       = int( _TILE_TYPE.z );\n"
+    "   float FRAME_BY_FRAME     = _TILE_TYPE.z;\n"
     "   float VERTEX_ANIMATION_ENABLE = float( _TILE_TYPE.x >= 128. );\n"
 
     "   vec3 normal_color = COLOR_0;\n"
@@ -90,8 +90,8 @@ const GLchar* Graphics::SDL2::GLES2::Internal::World::default_vertex_shader =
     "   float flashing = GlowTime * float(SelectedTile > SELECT_SPECIFIER - 0.5 && SelectedTile < SELECT_SPECIFIER + 0.5);\n"
     "   vertex_colors = (1.0 - flashing) * normal_color + 2.0 * flashing * inverse_color;\n"
 
-    "   vec2 tex_coord_pos = TEXCOORD_0 * float( FRAME_BY_FRAME == 0 );\n"
-    "   tex_coord_pos += AnimatedUVFrames[ clamp( FRAME_BY_FRAME - 1, 0, 16 * 4 ) ] * float( FRAME_BY_FRAME != 0 );\n"
+    "   vec2 tex_coord_pos = TEXCOORD_0 * float( FRAME_BY_FRAME == 0. );\n"
+    "   tex_coord_pos += AnimatedUVFrames[ int( clamp( FRAME_BY_FRAME - 1., 0., 16. * 4. ) ) ] * float( FRAME_BY_FRAME != 0. );\n"
     "   texture_coord_1 = tex_coord_pos + AnimatedUVDestination * DISPLACEMENT;\n"
     "   texture_coord_1 = fract( texture_coord_1 ) + vec2( float( texture_coord_1.x == 1. ), float( texture_coord_1.y == 1. ) );\n"
 

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -448,12 +448,17 @@ void Graphics::SDL2::GLES2::Internal::World::advanceTime( float seconds_passed )
         this->glow_time = 0.0f;
 
     // Update glow time.
-    this->animated_uv_time += seconds_passed * (1./5.95);
+    this->animated_uv_time.x += seconds_passed * (1./5.95) * 8.0;
 
-    if( this->animated_uv_time > 1.0f )
-        this->animated_uv_time -= 1.0f;
+    if( this->animated_uv_time.x > 1.0f )
+        this->animated_uv_time.x -= 1.0f;
 
-    this->animated_uv_destination = glm::vec2( 1.0 / 256.0 * 27.0, 0 ) * this->animated_uv_time;
+    this->animated_uv_time.y += seconds_passed * (1./5.95) * 1.0;
+
+    if( this->animated_uv_time.y  > 1.0f )
+        this->animated_uv_time.y -= 1.0f;
+
+    this->animated_uv_destination = glm::vec2( 1.0 / 256.0 * 27.0, 1.0 / 256.0 * 27.0 ) * this->animated_uv_time;
 }
 
 size_t Graphics::SDL2::GLES2::Internal::World::getTilAmount() const {

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -14,10 +14,6 @@ namespace Internal {
 
 /**
  * This handles everything the world will draw and handle.
- * 
- * Draws every tile of the world map.
- * I might world on occulusion culling in the future, but
- * for now this is good enough.
  */
 class World {
 public:
@@ -49,13 +45,13 @@ public:
         std::vector<Section> sections;
 
         // UV displacement animations.
-        glm::vec2 animated_uv_factor;
-        glm::vec2 animated_uv_destination;
-        glm::vec2 animated_uv_time;
+        glm::vec2 displacement_uv_factor;
+        glm::vec2 displacement_uv_destination;
+        glm::vec2 displacement_uv_time;
 
         // UV frame by frame animations.
-        std::vector<float>     times;
-        std::vector<glm::vec2> current_uv_frames;
+        std::vector<float>     frame_uv_times;
+        std::vector<glm::vec2> current_frame_uvs;
     };
 
     static const GLchar* default_vertex_shader;
@@ -68,8 +64,8 @@ protected:
     Shader fragment_shader;
     GLuint texture_uniform_id;
     GLuint matrix_uniform_id;
-    GLuint animated_uv_destination_id;
-    GLuint animated_uv_frames_id;
+    GLuint displacement_uv_destination_id;
+    GLuint frame_uv_id;
     GLuint glow_time_uniform_id;
     GLuint selected_tile_uniform_id;
     std::vector<MeshDraw> tiles;

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -56,12 +56,14 @@ public:
         // UV frame by frame animations.
         std::vector<float>     frame_uv_times;
         std::vector<glm::vec2> current_frame_uvs;
+
+        //
+        Data::Mission::TilResource::AnimationSLFX animation_slfx;
     };
 
     static const GLchar* default_vertex_shader;
     static const GLchar* default_fragment_shader;
 protected:
-    Data::Mission::TilResource::AnimationSLFX animation_slfx;
     Program program;
     std::vector<Shader::Attribute> attributes;
     std::vector<Shader::Varying>   varyings;

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -31,7 +31,6 @@ public:
             MeshDraw *mesh_draw_r;
             GLfloat selected_tile;
             GLfloat glow_time;
-            glm::vec2 animated_uv_destination;
 
             void addTriangles( const std::vector<DynamicTriangleDraw::Triangle> &triangles, DynamicTriangleDraw::DrawCommand &triangles_draw ) const;
         };
@@ -48,6 +47,10 @@ public:
         float change_rate;
         float current; // [ -change_rate, change_rate ]
         std::vector<Section> sections;
+
+        glm::vec2 animated_uv_factor;
+        glm::vec2 animated_uv_destination;
+        glm::vec2 animated_uv_time;
     };
 
     static const GLchar* default_vertex_shader;
@@ -67,8 +70,6 @@ protected:
     
     GLfloat selected_tile;
     GLfloat current_selected_tile;
-    glm::vec2 animated_uv_destination;
-    glm::vec2 animated_uv_time;
     GLfloat scale;
     GLfloat glow_time;
 public:

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -72,7 +72,10 @@ protected:
     GLuint frame_uv_id;
     GLuint glow_time_uniform_id;
     GLuint selected_tile_uniform_id;
+    GLuint vertex_animation_uniform_id;
     std::vector<MeshDraw> tiles;
+
+    Utilities::Image2D *vertex_animation_p;
     
     GLfloat selected_tile;
     GLfloat current_selected_tile;

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -61,6 +61,7 @@ public:
     static const GLchar* default_vertex_shader;
     static const GLchar* default_fragment_shader;
 protected:
+    Data::Mission::TilResource::AnimationSLFX animation_slfx;
     Program program;
     std::vector<Shader::Attribute> attributes;
     std::vector<Shader::Varying>   varyings;

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -25,6 +25,7 @@ public:
         class Animation : public Mesh::DynamicNormal {
         public:
             MeshDraw *mesh_draw_r;
+            Utilities::Image2D *vertex_animation_p;
             GLfloat selected_tile;
             GLfloat glow_time;
 
@@ -33,11 +34,13 @@ public:
 
         struct Info {
             struct {
-                uint_fast8_t displacement   : 1;
-                uint_fast8_t type           : 7;
+                uint_fast16_t vertex_animation : 1;
+                uint_fast16_t displacement     : 1;
+                uint_fast16_t type             : 7;
             } bitfield;
 
             uint_fast8_t frame_by_frame[3];
+            uint_fast8_t vertex_animation_index[3];
         };
 
         Mesh *mesh_p;

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -33,7 +33,10 @@ public:
 
         struct Info {
             int_fast8_t type;
-            int_fast8_t animated;
+            struct {
+                uint_fast8_t displacement   : 1;
+                uint_fast8_t frame_by_frame : 7;
+            } animation;
         };
 
         Mesh *mesh_p;

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -68,7 +68,7 @@ protected:
     GLfloat selected_tile;
     GLfloat current_selected_tile;
     glm::vec2 animated_uv_destination;
-    float     animated_uv_time;
+    glm::vec2 animated_uv_time;
     GLfloat scale;
     GLfloat glow_time;
 public:

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -32,11 +32,12 @@ public:
         };
 
         struct Info {
-            int_fast8_t type;
             struct {
                 uint_fast8_t displacement   : 1;
-                uint_fast8_t frame_by_frame : 7;
-            } animation;
+                uint_fast8_t type           : 7;
+            } bitfield;
+
+            uint_fast8_t frame_by_frame[3];
         };
 
         Mesh *mesh_p;

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -48,9 +48,14 @@ public:
         float current; // [ -change_rate, change_rate ]
         std::vector<Section> sections;
 
+        // UV displacement animations.
         glm::vec2 animated_uv_factor;
         glm::vec2 animated_uv_destination;
         glm::vec2 animated_uv_time;
+
+        // UV frame by frame animations.
+        std::vector<float>     times;
+        std::vector<glm::vec2> current_uv_frames;
     };
 
     static const GLchar* default_vertex_shader;
@@ -64,6 +69,7 @@ protected:
     GLuint texture_uniform_id;
     GLuint matrix_uniform_id;
     GLuint animated_uv_destination_id;
+    GLuint animated_uv_frames_id;
     GLuint glow_time_uniform_id;
     GLuint selected_tile_uniform_id;
     std::vector<MeshDraw> tiles;

--- a/src/Graphics/SDL2/GLES2/Internal/World.h
+++ b/src/Graphics/SDL2/GLES2/Internal/World.h
@@ -76,6 +76,7 @@ protected:
     std::vector<MeshDraw> tiles;
 
     Utilities::Image2D *vertex_animation_p;
+    Texture2D vertex_animation_texture;
     
     GLfloat selected_tile;
     GLfloat current_selected_tile;

--- a/src/Tests/Data/Mission/TilResource.cpp
+++ b/src/Tests/Data/Mission/TilResource.cpp
@@ -179,6 +179,70 @@ int main() {
             is_not_success = true;
         }
     }
+
+    {
+        Data::Mission::TilResource::InfoSLFX info_slfx;
+
+        // Test the diagonal vertex data.
+        {
+            const uint32_t code = 0x01710080;
+
+            info_slfx.set( code );
+            if( info_slfx.data.wave.gradient_light_level   != 7    || info_slfx.data.wave.gradient_width != 1 ||
+                info_slfx.data.wave.background_light_level != 0x00 || info_slfx.data.wave.speed != 0x80 ||
+                info_slfx.activate_noise != 0 || info_slfx.activate_diagonal != 1 || info_slfx.is_disabled != 0 ||
+                info_slfx.get() != code ) {
+                std::cout << "Error: the InfoSLFX bitfield regarding type is flawed!\n";
+                std::cout << "Code = 0x" << std::hex << code << " which is also should be 0x" << info_slfx.get() << "\n";
+                std::cout << info_slfx.getString() << std::endl;
+                is_not_success = true;
+            }
+        }
+
+        {
+            const uint32_t code = 0x81826603;
+
+            info_slfx.set( code );
+            if( info_slfx.data.wave.gradient_light_level   != 8    || info_slfx.data.wave.gradient_width != 2 ||
+                info_slfx.data.wave.background_light_level != 0x66 || info_slfx.data.wave.speed != 0x03 ||
+                info_slfx.activate_noise != 0 || info_slfx.activate_diagonal != 1 || info_slfx.is_disabled != 1 ||
+                info_slfx.get() != code ) {
+                std::cout << "Error: the InfoSLFX bitfield regarding type is flawed!\n";
+                std::cout << "Code = 0x" << std::hex << code << " which is also should be 0x" << info_slfx.get() << "\n";
+                std::cout << info_slfx.getString() << std::endl;
+                is_not_success = true;
+            }
+        }
+
+        // Test the noise vertex animation data.
+        {
+            const uint32_t code = 0x10000101;
+
+            info_slfx.set( code );
+            if( info_slfx.data.noise.brightness != 1 || info_slfx.data.noise.unknown_0 != 0 || info_slfx.data.noise.reducer != 1 ||
+                info_slfx.activate_noise != 1 || info_slfx.activate_diagonal != 0 || info_slfx.is_disabled != 0 ||
+                info_slfx.get() != code ) {
+                std::cout << "Error: the InfoSLFX bitfield regarding type is flawed!\n";
+                std::cout << "Code = 0x" << std::hex << code << " which is also should be 0x" << info_slfx.get() << "\n";
+                std::cout << info_slfx.getString() << std::endl;
+                is_not_success = true;
+            }
+        }
+
+        {
+            const uint32_t code = 0x90008042;
+
+            info_slfx.set( code );
+            if( info_slfx.data.noise.brightness != 0x80 || info_slfx.data.noise.unknown_0 != 1 || info_slfx.data.noise.reducer != 2 ||
+                info_slfx.activate_noise != 1 || info_slfx.activate_diagonal != 0 || info_slfx.is_disabled != 1 ||
+                info_slfx.get() != code ) {
+                std::cout << "Error: the InfoSLFX bitfield regarding type is flawed!\n";
+                std::cout << "Code = 0x" << std::hex << code << " which is also should be 0x" << info_slfx.get() << "\n";
+                std::cout << info_slfx.getString() << std::endl;
+                is_not_success = true;
+            }
+        }
+    }
     
     {
         // This resource will be created

--- a/src/Utilities/Random.cpp
+++ b/src/Utilities/Random.cpp
@@ -58,23 +58,15 @@ void Random::setSeeder( uint64_t seeder ) {
     if( seeder == 0 )
         seeder = 1;
 
-    guard.lock();
-
     current_seeder = seeder;
-
-    guard.unlock();
 }
 
 Random::Generator Random::getGenerator() {
-    guard.lock();
-
     auto generator = Generator( reverseBits( current_seeder ) );
 
     current_seeder++;
     if( current_seeder == 0 )
         current_seeder = 1;
-
-    guard.unlock();
 
     return generator;
 }

--- a/src/Utilities/Random.h
+++ b/src/Utilities/Random.h
@@ -53,7 +53,6 @@ public:
     };
 private:
     uint64_t current_seeder;
-    std::mutex guard;
 
 public:
     Random( uint64_t current_seeder = 1 );


### PR DESCRIPTION
Implemented Embedded Vertex Animations for the map sections.
- UV (Texture Coordinate) Displacement Animations are supported.
- ScTA Animations are supported. ScTA is a series of texture coordinate quads referring to each "frame" of animation.
- SLFX Animations are also supported. SLFX is the vertex value animation data.

Fixed the geometry of the quads for map decoding.