### PR TITLE
3DRF chunk in Cobj is now parsed.

### DIFF
--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -1231,8 +1231,10 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 auto reader3DRF = reader.getReader( data_tag_size );
 
                 auto reference_number = reader3DRF.readU32( settings.endian );
-                auto reference_to     = reader3DRF.readU32( settings.endian );
+                auto reference_tag    = reader3DRF.readU32( settings.endian );
                 auto reference_count  = reader3DRF.readU32( settings.endian );
+
+                assert((reference_tag == TAG_4DVL && reference_number == 1) || (reference_tag == TAG_4DNL && reference_number == 2) || (reference_tag == TAG_3DRL && reference_number == 3));
 
                 std::vector<uint32_t> id_array;
 

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -17,10 +17,6 @@ namespace {
     const uint32_t TAG_3DTL = 0x3344544C; // which is { 0x33, 0x44, 0x54, 0x4C } or { '3', 'D', 'T', 'L' } or "3DTL"
     // Face Quad list holding offsets of vertices and normals.
     const uint32_t TAG_3DQL = 0x3344514C; // which is { 0x33, 0x44, 0x51, 0x4C } or { '3', 'D', 'Q', 'L' } or "3DQL"
-    // 3D reference?
-    const uint32_t TAG_3DRF = 0x33445246; // which is { 0x33, 0x44, 0x52, 0x46 } or { '3', 'D', 'R', 'F' } or "3DRF"
-    // 3D reference lengths.
-    const uint32_t TAG_3DRL = 0x3344524C; // which is { 0x33, 0x44, 0x52, 0x4C } or { '3', 'D', 'R', 'L' } or "3DRL"
     // Bones.
     const uint32_t TAG_3DHY = 0x33444859; // which is { 0x33, 0x44, 0x48, 0x59 } or { '3', 'D', 'H', 'Y' } or "3DHY"
     // Positions of other objects
@@ -31,10 +27,14 @@ namespace {
     const uint32_t TAG_3DTA = 0x33445441; // which is { 0x33, 0x44, 0x54, 0x41 } or { '3', 'D', 'T', 'A' } or "3DTA"
     // 3D array list?
     const uint32_t TAG_3DAL = 0x3344414C; // which is { 0x33, 0x44, 0x41, 0x4C } or { '3', 'D', 'A', 'L' } or "3DAL"
+    // Reference IDs
+    const uint32_t TAG_3DRF = 0x33445246; // which is { 0x33, 0x44, 0x52, 0x46 } or { '3', 'D', 'R', 'F' } or "3DRF"
     // 4D vertex list (Note: Ignore the 4D data).
     const uint32_t TAG_4DVL = 0x3444564C; // which is { 0x34, 0x44, 0x56, 0x4C } or { '4', 'D', 'V', 'L' } or "4DVL"
     // 4D normal list
     const uint32_t TAG_4DNL = 0x34444E4C; // which is { 0x34, 0x44, 0x4E, 0x4C } or { '4', 'D', 'N', 'L' } or "4DNL"
+    // 3D reference lengths.
+    const uint32_t TAG_3DRL = 0x3344524C; // which is { 0x33, 0x44, 0x52, 0x4C } or { '3', 'D', 'R', 'L' } or "3DRL"
     // Animation track data
     const uint32_t TAG_AnmD = 0x416e6d44; // which is { 0x41, 0x6e, 0x6d, 0x44 } or { 'A', 'n', 'm', 'D' } or "AnmD"
     // 3D bounding box

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -738,6 +738,8 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
     auto error_log = settings.logger_r->getLog( Utilities::Logger::ERROR );
     error_log.info << FILE_EXTENSION << ": " << getResourceID() << "\n";
 
+    int count_of_3drf = 0;
+
     if( this->data_p != nullptr )
     {
         auto reader = this->data_p->getReader();
@@ -1068,6 +1070,8 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
 
                 if( reader3DRF.totalSize() != 0x10 )
                     warning_log.output << "reader3DRF.totalSize() is not 0x10, but 0x" << std::hex << reader3DRF.totalSize() << ".\n";
+
+                count_of_3drf++;
             }
             else
             if( identifier == TAG_3DRL ) {
@@ -1527,6 +1531,8 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 primitive.face_type_r = &this->face_types[ primitive.face_type_offset ];
             }
         }
+
+        assert(count_of_3drf == 3);
 
         return !file_is_not_valid;
     }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -737,9 +737,13 @@ uint32_t Data::Mission::ObjResource::VertexDataReference::get3DRFItem(Data::Miss
 
 void Data::Mission::ObjResource::VertexDataReference::set4DVLSize(int32_t size_of_4DVL) {
     this->size_of_4DVL = size_of_4DVL;
+
+    positions.resize(size_of_4DVL * get3DRFSize());
 }
 void Data::Mission::ObjResource::VertexDataReference::set4DNLSize(int32_t size_of_4DNL) {
     this->size_of_4DNL = size_of_4DNL;
+
+    normals.resize(size_of_4DNL * get3DRFSize());
 }
 void Data::Mission::ObjResource::VertexDataReference::set3DRLSize(int32_t size_of_3DRL) {
     this->size_of_3DRL = size_of_3DRL;
@@ -755,6 +759,34 @@ int32_t Data::Mission::ObjResource::VertexDataReference::get4DNLSize() const {
 }
 int32_t Data::Mission::ObjResource::VertexDataReference::get3DRLSize() const {
     return this->size_of_3DRL;
+}
+
+glm::i16vec3* Data::Mission::ObjResource::VertexDataReference::get4DVLPointer(uint32_t id) {
+    return const_cast<glm::i16vec3*>(const_cast<const VertexDataReference *const>(this)->get4DVLPointer(id));
+}
+
+const glm::i16vec3* const Data::Mission::ObjResource::VertexDataReference::get4DVLPointer(uint32_t id) const {
+    for(int32_t index = 0; index < get3DRFSize(); index++)
+    {
+        if(get3DRFItem(C_4DVL, index) == id)
+            return &positions[index * this->size_of_4DVL];
+    }
+
+    return nullptr;
+}
+
+glm::i16vec3* Data::Mission::ObjResource::VertexDataReference::get4DNLPointer(uint32_t id) {
+    return const_cast<glm::i16vec3*>(const_cast<const VertexDataReference *const>(this)->get4DNLPointer(id));
+}
+
+const glm::i16vec3* const Data::Mission::ObjResource::VertexDataReference::get4DNLPointer(uint32_t id) const {
+    for(int32_t index = 0; index < get3DRFSize(); index++)
+    {
+        if(get3DRFItem(C_4DVL, index) == id)
+            return &normals[index * this->size_of_4DNL];
+    }
+
+    return nullptr;
 }
 
 uint16_t* Data::Mission::ObjResource::VertexDataReference::get3DRLPointer(uint32_t id) {

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -810,7 +810,7 @@ glm::i16vec3* Data::Mission::ObjResource::VertexData::get4DNLPointer(uint32_t id
 const glm::i16vec3* const Data::Mission::ObjResource::VertexData::get4DNLPointer(uint32_t id) const {
     for(int32_t index = 0; index < get3DRFSize(); index++)
     {
-        if(get3DRFItem(C_4DVL, index) == id)
+        if(get3DRFItem(C_4DNL, index) == id)
             return &normals[index * this->size_of_4DNL];
     }
 

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -184,7 +184,7 @@ bool Data::Mission::ObjResource::Primitive::operator() ( const Primitive & l_ope
         return (l_operand.visual.visability < r_operand.visual.visability);
 }
 
-int Data::Mission::ObjResource::Primitive::setTriangle(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
+int Data::Mission::ObjResource::Primitive::setTriangle(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
     if( !isWithinBounds( vertex_data_reference.get4DVLSize(), vertex_data_reference.get4DNLSize() ) )
         return 0;
 
@@ -210,7 +210,7 @@ int Data::Mission::ObjResource::Primitive::setTriangle(const VertexDataReference
 
     triangle.color = glm::u8vec4( 0xff, 0xff, 0xff, 0xff );
 
-    const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 0);
+    const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 0);
     const glm::i16vec3* const positions_r = vertex_data_reference.get4DVLPointer(id_position);
 
     handlePositions( triangle.points[0].position, positions_r, v[2] );
@@ -218,7 +218,7 @@ int Data::Mission::ObjResource::Primitive::setTriangle(const VertexDataReference
     handlePositions( triangle.points[2].position, positions_r, v[0] );
 
     if( vertex_data_reference.get4DNLSize() > 0 ) {
-        const uint32_t id_normal = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DNL, 0);
+        const uint32_t id_normal = vertex_data_reference.get3DRFItem(VertexData::C_4DNL, 0);
         const glm::i16vec3* const normals_r = vertex_data_reference.get4DNLPointer(id_normal);
 
         handleNormals( triangle.points[0].normal, normals_r, n[2] );
@@ -238,7 +238,7 @@ int Data::Mission::ObjResource::Primitive::setTriangle(const VertexDataReference
     }
 
     for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-        const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 1 + morph_frames);
+        const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
         const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
 
         handlePositions( morph_triangle.points[0].position, anm_positions_r, v[2] );
@@ -246,7 +246,7 @@ int Data::Mission::ObjResource::Primitive::setTriangle(const VertexDataReference
         handlePositions( morph_triangle.points[2].position, anm_positions_r, v[0] );
 
         if( vertex_data_reference.get4DNLSize() > 0 ) {
-            const uint32_t id_normal = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DNL, 1 + morph_frames);
+            const uint32_t id_normal = vertex_data_reference.get3DRFItem(VertexData::C_4DNL, 1 + morph_frames);
             const glm::i16vec3* const anm_normals_r = vertex_data_reference.get4DNLPointer(id_normal);
 
             handleNormals( morph_triangle.points[0].normal, anm_normals_r, n[2] );
@@ -278,7 +278,7 @@ int Data::Mission::ObjResource::Primitive::setTriangle(const VertexDataReference
     return 1;
 }
 
-int Data::Mission::ObjResource::Primitive::setQuad(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
+int Data::Mission::ObjResource::Primitive::setQuad(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
     const PrimitiveType TYPES[] = {PrimitiveType::TRIANGLE, PrimitiveType::TRIANGLE_OTHER};
 
     Primitive new_tri;
@@ -313,7 +313,7 @@ int Data::Mission::ObjResource::Primitive::setQuad(const VertexDataReference& ve
     return counter;
 }
 
-int Data::Mission::ObjResource::Primitive::setBillboard(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
+int Data::Mission::ObjResource::Primitive::setBillboard(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
     Triangle triangle;
     MorphTriangle morph_triangle;
     glm::u8vec2 coords[2][3];
@@ -387,9 +387,9 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexDataReferenc
         }
     }
 
-    const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 0);
+    const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 0);
     const glm::i16vec3* const positions_r = vertex_data_reference.get4DVLPointer(id_position);
-    const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexDataReference::C_3DRL, 0);
+    const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 0);
     const uint16_t* const lengths_r = vertex_data_reference.get3DRLPointer(id_length);
 
      // v[0] is a vertex position and v[2] is a width offset. v[1] and v[3] are just 0xFF. All normals are 0 probably unused.
@@ -424,9 +424,9 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexDataReferenc
         triangles.push_back( triangle );
 
         for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 1 + morph_frames);
+            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
             const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexDataReference::C_3DRL, 1 + morph_frames);
+            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
             const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
 
             handlePositions( morph_center, anm_positions_r, v[0] );
@@ -442,9 +442,9 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexDataReferenc
         triangles.push_back( triangle );
 
         for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 1 + morph_frames);
+            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
             const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexDataReference::C_3DRL, 1 + morph_frames);
+            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
             const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
 
             handlePositions( morph_center, anm_positions_r, v[0] );
@@ -466,9 +466,9 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexDataReferenc
         triangles.push_back( triangle );
 
         for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 1 + morph_frames);
+            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
             const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexDataReference::C_3DRL, 1 + morph_frames);
+            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
             const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
 
             handlePositions( morph_center, anm_positions_r, v[0] );
@@ -484,9 +484,9 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexDataReferenc
         triangles.push_back( triangle );
 
         for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 1 + morph_frames);
+            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
             const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexDataReference::C_3DRL, 1 + morph_frames);
+            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
             const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
 
             handlePositions( morph_center, anm_positions_r, v[0] );
@@ -502,7 +502,7 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexDataReferenc
     return getTriangleAmount( PrimitiveType::BILLBOARD );
 }
 
-int Data::Mission::ObjResource::Primitive::setLine(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
+int Data::Mission::ObjResource::Primitive::setLine(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
     Triangle      triangle;
     MorphTriangle morph_triangle;
     glm::u8vec2   coords[2][3];
@@ -566,9 +566,9 @@ int Data::Mission::ObjResource::Primitive::setLine(const VertexDataReference& ve
     glm::vec3 segments[2];
     glm::vec3 &offset = segments[0];
 
-    const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 0);
+    const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 0);
     const glm::i16vec3* const positions_r = vertex_data_reference.get4DVLPointer(id_position);
-    const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexDataReference::C_3DRL, 0);
+    const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 0);
     const uint16_t* const lengths_r = vertex_data_reference.get3DRLPointer(id_length);
 
     // v[0] and v[1] are vertex position offsets, v[2] and v[3] are width offsets. All normals are 0 probably unused.
@@ -677,9 +677,9 @@ int Data::Mission::ObjResource::Primitive::setLine(const VertexDataReference& ve
 
             // TODO THIS IS A NULL STATEMENT
             for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-                const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 1 + morph_frames);
+                const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
                 const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-                const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexDataReference::C_3DRL, 1 + morph_frames);
+                const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
                 const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
 
                 glm::vec3 morph_segments[2];
@@ -702,9 +702,9 @@ int Data::Mission::ObjResource::Primitive::setLine(const VertexDataReference& ve
 
             // TODO THIS IS A NULL STATEMENT
             for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-                const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 1 + morph_frames);
+                const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
                 const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-                const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexDataReference::C_3DRL, 1 + morph_frames);
+                const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
                 const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
 
                 glm::vec3 morph_segments[2];
@@ -742,58 +742,58 @@ size_t Data::Mission::ObjResource::Primitive::getTriangleAmount( PrimitiveType t
     }
 }
 
-Data::Mission::ObjResource::VertexDataReference::VertexDataReference() {
+Data::Mission::ObjResource::VertexData::VertexData() {
     size_of_4DVL = -1;
     size_of_4DNL = -1;
     size_of_3DRL = -1;
 }
 
-uint32_t Data::Mission::ObjResource::VertexDataReference::get3DRFSize() const {
+uint32_t Data::Mission::ObjResource::VertexData::get3DRFSize() const {
     return reference_ids.size() / 3;
 }
 
-void Data::Mission::ObjResource::VertexDataReference::set3DRFSize(uint32_t size) {
+void Data::Mission::ObjResource::VertexData::set3DRFSize(uint32_t size) {
     reference_ids.resize(size * 3);
 }
 
-void Data::Mission::ObjResource::VertexDataReference::set3DRFItem(Data::Mission::ObjResource::VertexDataReference::Tag tag, uint32_t index, uint32_t id) {
+void Data::Mission::ObjResource::VertexData::set3DRFItem(Data::Mission::ObjResource::VertexData::Tag tag, uint32_t index, uint32_t id) {
     reference_ids[tag * (reference_ids.size() / 3) + index] = id;
 }
-uint32_t Data::Mission::ObjResource::VertexDataReference::get3DRFItem(Data::Mission::ObjResource::VertexDataReference::Tag tag, uint32_t index) const {
+uint32_t Data::Mission::ObjResource::VertexData::get3DRFItem(Data::Mission::ObjResource::VertexData::Tag tag, uint32_t index) const {
     return reference_ids[tag * (reference_ids.size() / 3) + index];
 }
 
-void Data::Mission::ObjResource::VertexDataReference::set4DVLSize(int32_t size_of_4DVL) {
+void Data::Mission::ObjResource::VertexData::set4DVLSize(int32_t size_of_4DVL) {
     this->size_of_4DVL = size_of_4DVL;
 
     positions.resize(size_of_4DVL * get3DRFSize());
 }
-void Data::Mission::ObjResource::VertexDataReference::set4DNLSize(int32_t size_of_4DNL) {
+void Data::Mission::ObjResource::VertexData::set4DNLSize(int32_t size_of_4DNL) {
     this->size_of_4DNL = size_of_4DNL;
 
     normals.resize(size_of_4DNL * get3DRFSize());
 }
-void Data::Mission::ObjResource::VertexDataReference::set3DRLSize(int32_t size_of_3DRL) {
+void Data::Mission::ObjResource::VertexData::set3DRLSize(int32_t size_of_3DRL) {
     this->size_of_3DRL = size_of_3DRL;
 
     lengths.resize(size_of_3DRL * get3DRFSize());
 }
 
-int32_t Data::Mission::ObjResource::VertexDataReference::get4DVLSize() const {
+int32_t Data::Mission::ObjResource::VertexData::get4DVLSize() const {
     return this->size_of_4DVL;
 }
-int32_t Data::Mission::ObjResource::VertexDataReference::get4DNLSize() const {
+int32_t Data::Mission::ObjResource::VertexData::get4DNLSize() const {
     return this->size_of_4DNL;
 }
-int32_t Data::Mission::ObjResource::VertexDataReference::get3DRLSize() const {
+int32_t Data::Mission::ObjResource::VertexData::get3DRLSize() const {
     return this->size_of_3DRL;
 }
 
-glm::i16vec3* Data::Mission::ObjResource::VertexDataReference::get4DVLPointer(uint32_t id) {
-    return const_cast<glm::i16vec3*>(const_cast<const VertexDataReference *const>(this)->get4DVLPointer(id));
+glm::i16vec3* Data::Mission::ObjResource::VertexData::get4DVLPointer(uint32_t id) {
+    return const_cast<glm::i16vec3*>(const_cast<const VertexData *const>(this)->get4DVLPointer(id));
 }
 
-const glm::i16vec3* const Data::Mission::ObjResource::VertexDataReference::get4DVLPointer(uint32_t id) const {
+const glm::i16vec3* const Data::Mission::ObjResource::VertexData::get4DVLPointer(uint32_t id) const {
     for(int32_t index = 0; index < get3DRFSize(); index++)
     {
         if(get3DRFItem(C_4DVL, index) == id)
@@ -803,11 +803,11 @@ const glm::i16vec3* const Data::Mission::ObjResource::VertexDataReference::get4D
     return nullptr;
 }
 
-glm::i16vec3* Data::Mission::ObjResource::VertexDataReference::get4DNLPointer(uint32_t id) {
-    return const_cast<glm::i16vec3*>(const_cast<const VertexDataReference *const>(this)->get4DNLPointer(id));
+glm::i16vec3* Data::Mission::ObjResource::VertexData::get4DNLPointer(uint32_t id) {
+    return const_cast<glm::i16vec3*>(const_cast<const VertexData *const>(this)->get4DNLPointer(id));
 }
 
-const glm::i16vec3* const Data::Mission::ObjResource::VertexDataReference::get4DNLPointer(uint32_t id) const {
+const glm::i16vec3* const Data::Mission::ObjResource::VertexData::get4DNLPointer(uint32_t id) const {
     for(int32_t index = 0; index < get3DRFSize(); index++)
     {
         if(get3DRFItem(C_4DVL, index) == id)
@@ -817,11 +817,11 @@ const glm::i16vec3* const Data::Mission::ObjResource::VertexDataReference::get4D
     return nullptr;
 }
 
-uint16_t* Data::Mission::ObjResource::VertexDataReference::get3DRLPointer(uint32_t id) {
-    return const_cast<uint16_t*>(const_cast<const VertexDataReference *const>(this)->get3DRLPointer(id));
+uint16_t* Data::Mission::ObjResource::VertexData::get3DRLPointer(uint32_t id) {
+    return const_cast<uint16_t*>(const_cast<const VertexData *const>(this)->get3DRLPointer(id));
 }
 
-const uint16_t* const Data::Mission::ObjResource::VertexDataReference::get3DRLPointer(uint32_t id) const {
+const uint16_t* const Data::Mission::ObjResource::VertexData::get3DRLPointer(uint32_t id) const {
     for(int32_t index = 0; index < get3DRFSize(); index++)
     {
         if(get3DRFItem(C_3DRL, index) == id)
@@ -1364,18 +1364,18 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 auto reference_tag    = reader3DRF.readU32( settings.endian );
                 auto reference_count  = reader3DRF.readU32( settings.endian );
 
-                VertexDataReference::Tag tag;
+                VertexData::Tag tag;
 
                 switch(reference_tag) {
                     case TAG_3DRL:
-                        tag = VertexDataReference::C_3DRL;
+                        tag = VertexData::C_3DRL;
                         break;
                     case TAG_4DNL:
-                        tag = VertexDataReference::C_4DNL;
+                        tag = VertexData::C_4DNL;
                         break;
                     default:
                     case TAG_4DVL:
-                        tag = VertexDataReference::C_4DVL;
+                        tag = VertexData::C_4DVL;
                         break;
                 }
 
@@ -1697,7 +1697,7 @@ glm::vec3 Data::Mission::ObjResource::getPosition( unsigned index ) const {
     glm::vec3 position(0, 0, 0);
 
     if( isPositionValid( index ) ) {
-        const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexDataReference::C_4DVL, 0);
+        const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 0);
         const glm::i16vec3* const vertex_positions_r = vertex_data_reference.get4DVLPointer(id_length);
 
         position  = vertex_positions_r[ position_indexes[index] ];

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -1230,12 +1230,19 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
             if( identifier == TAG_3DRF ) {
                 auto reader3DRF = reader.getReader( data_tag_size );
 
-                debug_log.output << "3DRF" << std::hex << "\n"
-                    << "Index " << getIndexNumber() << "\n"
-                    << "reader3DRF.totalSize() = " << reader3DRF.totalSize() << "\n";
+                auto reference_number = reader3DRF.readU32( settings.endian );
+                auto reference_to     = reader3DRF.readU32( settings.endian );
+                auto reference_count  = reader3DRF.readU32( settings.endian );
 
-                if( reader3DRF.totalSize() != 0x10 )
-                    warning_log.output << "reader3DRF.totalSize() is not 0x10, but 0x" << std::hex << reader3DRF.totalSize() << ".\n";
+                std::vector<uint32_t> id_array;
+
+                id_array.resize(reference_count);
+
+                for(auto i = id_array.begin(); i != id_array.end(); i++) {
+                    (*i) = reader3DRF.readU32( settings.endian );
+
+                    assert((*i) == i - id_array.begin() + 1);
+                }
             }
             else
             if( identifier == TAG_4DVL ) {

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -184,8 +184,8 @@ bool Data::Mission::ObjResource::Primitive::operator() ( const Primitive & l_ope
         return (l_operand.visual.visability < r_operand.visual.visability);
 }
 
-int Data::Mission::ObjResource::Primitive::setTriangle(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
-    if( !isWithinBounds( vertex_data_reference.get4DVLSize(), vertex_data_reference.get4DNLSize() ) )
+int Data::Mission::ObjResource::Primitive::setTriangle(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
+    if( !isWithinBounds( vertex_data.get4DVLSize(), vertex_data.get4DNLSize() ) )
         return 0;
 
     Triangle triangle;
@@ -210,16 +210,16 @@ int Data::Mission::ObjResource::Primitive::setTriangle(const VertexData& vertex_
 
     triangle.color = glm::u8vec4( 0xff, 0xff, 0xff, 0xff );
 
-    const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 0);
-    const glm::i16vec3* const positions_r = vertex_data_reference.get4DVLPointer(id_position);
+    const uint32_t id_position = vertex_data.get3DRFItem(VertexData::C_4DVL, 0);
+    const glm::i16vec3* const positions_r = vertex_data.get4DVLPointer(id_position);
 
     handlePositions( triangle.points[0].position, positions_r, v[2] );
     handlePositions( triangle.points[1].position, positions_r, v[1] );
     handlePositions( triangle.points[2].position, positions_r, v[0] );
 
-    if( vertex_data_reference.get4DNLSize() > 0 ) {
-        const uint32_t id_normal = vertex_data_reference.get3DRFItem(VertexData::C_4DNL, 0);
-        const glm::i16vec3* const normals_r = vertex_data_reference.get4DNLPointer(id_normal);
+    if( vertex_data.get4DNLSize() > 0 ) {
+        const uint32_t id_normal = vertex_data.get3DRFItem(VertexData::C_4DNL, 0);
+        const glm::i16vec3* const normals_r = vertex_data.get4DNLPointer(id_normal);
 
         handleNormals( triangle.points[0].normal, normals_r, n[2] );
         handleNormals( triangle.points[1].normal, normals_r, n[1] );
@@ -237,17 +237,17 @@ int Data::Mission::ObjResource::Primitive::setTriangle(const VertexData& vertex_
         triangle.points[t].face_override_index = face_override_indexes[2 - t];
     }
 
-    for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-        const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
-        const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
+    for( unsigned morph_frames = 0; morph_frames < vertex_data.get3DRFSize() - 1; morph_frames++ ) {
+        const uint32_t id_position = vertex_data.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
+        const glm::i16vec3* const anm_positions_r = vertex_data.get4DVLPointer(id_position);
 
         handlePositions( morph_triangle.points[0].position, anm_positions_r, v[2] );
         handlePositions( morph_triangle.points[1].position, anm_positions_r, v[1] );
         handlePositions( morph_triangle.points[2].position, anm_positions_r, v[0] );
 
-        if( vertex_data_reference.get4DNLSize() > 0 ) {
-            const uint32_t id_normal = vertex_data_reference.get3DRFItem(VertexData::C_4DNL, 1 + morph_frames);
-            const glm::i16vec3* const anm_normals_r = vertex_data_reference.get4DNLPointer(id_normal);
+        if( vertex_data.get4DNLSize() > 0 ) {
+            const uint32_t id_normal = vertex_data.get3DRFItem(VertexData::C_4DNL, 1 + morph_frames);
+            const glm::i16vec3* const anm_normals_r = vertex_data.get4DNLPointer(id_normal);
 
             handleNormals( morph_triangle.points[0].normal, anm_normals_r, n[2] );
             handleNormals( morph_triangle.points[1].normal, anm_normals_r, n[1] );
@@ -278,7 +278,7 @@ int Data::Mission::ObjResource::Primitive::setTriangle(const VertexData& vertex_
     return 1;
 }
 
-int Data::Mission::ObjResource::Primitive::setQuad(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
+int Data::Mission::ObjResource::Primitive::setQuad(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
     const PrimitiveType TYPES[] = {PrimitiveType::TRIANGLE, PrimitiveType::TRIANGLE_OTHER};
 
     Primitive new_tri;
@@ -307,13 +307,13 @@ int Data::Mission::ObjResource::Primitive::setQuad(const VertexData& vertex_data
         new_tri.n[1] = n[QUAD_TABLE[i][1]];
         new_tri.n[2] = n[QUAD_TABLE[i][2]];
 
-        counter += new_tri.setTriangle(vertex_data_reference, triangles, morph_triangles, bones);
+        counter += new_tri.setTriangle(vertex_data, triangles, morph_triangles, bones);
     }
 
     return counter;
 }
 
-int Data::Mission::ObjResource::Primitive::setBillboard(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
+int Data::Mission::ObjResource::Primitive::setBillboard(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
     Triangle triangle;
     MorphTriangle morph_triangle;
     glm::u8vec2 coords[2][3];
@@ -387,10 +387,10 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexData& vertex
         }
     }
 
-    const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 0);
-    const glm::i16vec3* const positions_r = vertex_data_reference.get4DVLPointer(id_position);
-    const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 0);
-    const uint16_t* const lengths_r = vertex_data_reference.get3DRLPointer(id_length);
+    const uint32_t id_position = vertex_data.get3DRFItem(VertexData::C_4DVL, 0);
+    const glm::i16vec3* const positions_r = vertex_data.get4DVLPointer(id_position);
+    const uint32_t id_length = vertex_data.get3DRFItem(VertexData::C_3DRL, 0);
+    const uint16_t* const lengths_r = vertex_data.get3DRLPointer(id_length);
 
      // v[0] is a vertex position and v[2] is a width offset. v[1] and v[3] are just 0xFF. All normals are 0 probably unused.
     handlePositions( center, positions_r, v[0] );
@@ -423,11 +423,11 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexData& vertex
 
         triangles.push_back( triangle );
 
-        for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
-            const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
-            const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
+        for( unsigned morph_frames = 0; morph_frames < vertex_data.get3DRFSize() - 1; morph_frames++ ) {
+            const uint32_t id_position = vertex_data.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
+            const glm::i16vec3* const anm_positions_r = vertex_data.get4DVLPointer(id_position);
+            const uint32_t id_length = vertex_data.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
+            const uint16_t* const anm_lengths_r = vertex_data.get3DRLPointer(id_length);
 
             handlePositions( morph_center, anm_positions_r, v[0] );
             morph_length = anm_lengths_r[ v[2] ] * FIXED_POINT_UNIT;
@@ -441,11 +441,11 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexData& vertex
         triangle.switchPoints();
         triangles.push_back( triangle );
 
-        for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
-            const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
-            const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
+        for( unsigned morph_frames = 0; morph_frames < vertex_data.get3DRFSize() - 1; morph_frames++ ) {
+            const uint32_t id_position = vertex_data.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
+            const glm::i16vec3* const anm_positions_r = vertex_data.get4DVLPointer(id_position);
+            const uint32_t id_length = vertex_data.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
+            const uint16_t* const anm_lengths_r = vertex_data.get3DRLPointer(id_length);
 
             handlePositions( morph_center, anm_positions_r, v[0] );
             morph_length = anm_lengths_r[ v[2] ] * FIXED_POINT_UNIT;
@@ -465,11 +465,11 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexData& vertex
 
         triangles.push_back( triangle );
 
-        for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
-            const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
-            const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
+        for( unsigned morph_frames = 0; morph_frames < vertex_data.get3DRFSize() - 1; morph_frames++ ) {
+            const uint32_t id_position = vertex_data.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
+            const glm::i16vec3* const anm_positions_r = vertex_data.get4DVLPointer(id_position);
+            const uint32_t id_length = vertex_data.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
+            const uint16_t* const anm_lengths_r = vertex_data.get3DRLPointer(id_length);
 
             handlePositions( morph_center, anm_positions_r, v[0] );
             morph_length = anm_lengths_r[ v[2] ] * FIXED_POINT_UNIT;
@@ -483,11 +483,11 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexData& vertex
         triangle.switchPoints();
         triangles.push_back( triangle );
 
-        for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-            const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
-            const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-            const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
-            const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
+        for( unsigned morph_frames = 0; morph_frames < vertex_data.get3DRFSize() - 1; morph_frames++ ) {
+            const uint32_t id_position = vertex_data.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
+            const glm::i16vec3* const anm_positions_r = vertex_data.get4DVLPointer(id_position);
+            const uint32_t id_length = vertex_data.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
+            const uint16_t* const anm_lengths_r = vertex_data.get3DRLPointer(id_length);
 
             handlePositions( morph_center, anm_positions_r, v[0] );
             morph_length = anm_lengths_r[ v[2] ] * FIXED_POINT_UNIT;
@@ -502,7 +502,7 @@ int Data::Mission::ObjResource::Primitive::setBillboard(const VertexData& vertex
     return getTriangleAmount( PrimitiveType::BILLBOARD );
 }
 
-int Data::Mission::ObjResource::Primitive::setLine(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
+int Data::Mission::ObjResource::Primitive::setLine(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
     Triangle      triangle;
     MorphTriangle morph_triangle;
     glm::u8vec2   coords[2][3];
@@ -566,10 +566,10 @@ int Data::Mission::ObjResource::Primitive::setLine(const VertexData& vertex_data
     glm::vec3 segments[2];
     glm::vec3 &offset = segments[0];
 
-    const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 0);
-    const glm::i16vec3* const positions_r = vertex_data_reference.get4DVLPointer(id_position);
-    const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 0);
-    const uint16_t* const lengths_r = vertex_data_reference.get3DRLPointer(id_length);
+    const uint32_t id_position = vertex_data.get3DRFItem(VertexData::C_4DVL, 0);
+    const glm::i16vec3* const positions_r = vertex_data.get4DVLPointer(id_position);
+    const uint32_t id_length = vertex_data.get3DRFItem(VertexData::C_3DRL, 0);
+    const uint16_t* const lengths_r = vertex_data.get3DRLPointer(id_length);
 
     // v[0] and v[1] are vertex position offsets, v[2] and v[3] are width offsets. All normals are 0 probably unused.
     handlePositions( segments[0], positions_r, v[0] );
@@ -676,11 +676,11 @@ int Data::Mission::ObjResource::Primitive::setLine(const VertexData& vertex_data
             triangles.push_back( triangle );
 
             // TODO THIS IS A NULL STATEMENT
-            for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-                const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
-                const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-                const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
-                const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
+            for( unsigned morph_frames = 0; morph_frames < vertex_data.get3DRFSize() - 1; morph_frames++ ) {
+                const uint32_t id_position = vertex_data.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
+                const glm::i16vec3* const anm_positions_r = vertex_data.get4DVLPointer(id_position);
+                const uint32_t id_length = vertex_data.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
+                const uint16_t* const anm_lengths_r = vertex_data.get3DRLPointer(id_length);
 
                 glm::vec3 morph_segments[2];
                 handlePositions( morph_segments[0], anm_positions_r, v[0] );
@@ -701,11 +701,11 @@ int Data::Mission::ObjResource::Primitive::setLine(const VertexData& vertex_data
             triangles.push_back( triangle );
 
             // TODO THIS IS A NULL STATEMENT
-            for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ ) {
-                const uint32_t id_position = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
-                const glm::i16vec3* const anm_positions_r = vertex_data_reference.get4DVLPointer(id_position);
-                const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
-                const uint16_t* const anm_lengths_r = vertex_data_reference.get3DRLPointer(id_length);
+            for( unsigned morph_frames = 0; morph_frames < vertex_data.get3DRFSize() - 1; morph_frames++ ) {
+                const uint32_t id_position = vertex_data.get3DRFItem(VertexData::C_4DVL, 1 + morph_frames);
+                const glm::i16vec3* const anm_positions_r = vertex_data.get4DVLPointer(id_position);
+                const uint32_t id_length = vertex_data.get3DRFItem(VertexData::C_3DRL, 1 + morph_frames);
+                const uint16_t* const anm_lengths_r = vertex_data.get3DRLPointer(id_length);
 
                 glm::vec3 morph_segments[2];
                 handlePositions( morph_segments[0], anm_positions_r, v[0] );
@@ -1379,12 +1379,12 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                         break;
                 }
 
-                if(vertex_data_reference.get3DRFSize() == 0) {
-                    vertex_data_reference.set3DRFSize(reference_count);
+                if(vertex_data.get3DRFSize() == 0) {
+                    vertex_data.set3DRFSize(reference_count);
                 }
 
                 for(uint32_t i = 0; i < reference_count; i++) {
-                    vertex_data_reference.set3DRFItem(tag, i, reader3DRF.readU32( settings.endian ));
+                    vertex_data.set3DRFItem(tag, i, reader3DRF.readU32( settings.endian ));
                 }
 
                 // assert(reference_count > 0);
@@ -1399,10 +1399,10 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
 
                 auto amount_of_vertices = reader4DVL.readU32( settings.endian );
 
-                if(vertex_data_reference.get4DVLSize() < 0)
-                    vertex_data_reference.set4DVLSize(amount_of_vertices);
+                if(vertex_data.get4DVLSize() < 0)
+                    vertex_data.set4DVLSize(amount_of_vertices);
 
-                glm::i16vec3 *positions_r = vertex_data_reference.get4DVLPointer(frame_id);
+                glm::i16vec3 *positions_r = vertex_data.get4DVLPointer(frame_id);
 
                 assert(positions_r != nullptr);
 
@@ -1421,11 +1421,11 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
 
                 auto amount_of_normals = reader4DNL.readU32( settings.endian );
 
-                if(vertex_data_reference.get4DNLSize() < 0)
-                    vertex_data_reference.set4DNLSize(amount_of_normals);
+                if(vertex_data.get4DNLSize() < 0)
+                    vertex_data.set4DNLSize(amount_of_normals);
 
-                if(vertex_data_reference.get4DNLSize() > 0) {
-                    glm::i16vec3 *normals_r = vertex_data_reference.get4DNLPointer(frame_id);
+                if(vertex_data.get4DNLSize() > 0) {
+                    glm::i16vec3 *normals_r = vertex_data.get4DNLPointer(frame_id);
 
                     assert(normals_r != nullptr);
 
@@ -1446,11 +1446,11 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
 
                 auto count = reader3DRL.readU32(settings.endian);
 
-                if(vertex_data_reference.get3DRLSize() < 0)
-                    vertex_data_reference.set3DRLSize(count);
+                if(vertex_data.get3DRLSize() < 0)
+                    vertex_data.set3DRLSize(count);
 
                 if( count != 0 ) {
-                    uint16_t *length_data_r = vertex_data_reference.get3DRLPointer(frame_id);
+                    uint16_t *length_data_r = vertex_data.get3DRLPointer(frame_id);
 
                     assert(length_data_r != nullptr);
 
@@ -1600,7 +1600,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
         }
         
         // This warning tells that there are only two options for animations either morphing or bone animation.
-        if( !( !(( bytes_per_frame_3DMI > 0 ) & ( vertex_data_reference.get3DRFSize() > 1 )) ) )
+        if( !( !(( bytes_per_frame_3DMI > 0 ) & ( vertex_data.get3DRFSize() > 1 )) ) )
             warning_log.output << "Both animation systems are used. This might be a problem because normal Future Cop models do not have both bone and morph animations.\n";
         
         if( bytes_per_frame_3DMI > 0 )
@@ -1627,21 +1627,21 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
             }
         }
         else
-        if( vertex_data_reference.get3DRFSize() > 1 )
+        if( vertex_data.get3DRFSize() > 1 )
         {
             // This proves that each model with morph animation has an equal number of
             // vertex frames as the bounding box frames.
-            if( bounding_box_frames != vertex_data_reference.get3DRFSize() )
+            if( bounding_box_frames != vertex_data.get3DRFSize() )
             {
                 error_log.output << "bounding box per frame is " << std::dec << bounding_box_per_frame << "\n";
                 error_log.output << "3DBB frames is " << bounding_box_frames << "\n";
-                error_log.output << "3DBB frames not equal to " << (vertex_data_reference.get3DRFSize() - 1) << "\n";
+                error_log.output << "3DBB frames not equal to " << (vertex_data.get3DRFSize() - 1) << "\n";
             }
             
-            if( num_frames_4DGI != vertex_data_reference.get3DRFSize() )
+            if( num_frames_4DGI != vertex_data.get3DRFSize() )
             {
                 error_log.output << "4DGI frames is " << std::dec << num_frames_4DGI << "\n";
-                error_log.output << "4DGI frames not equal to " << vertex_data_reference.get3DRFSize() << "\n";
+                error_log.output << "4DGI frames not equal to " << vertex_data.get3DRFSize() << "\n";
             }
 
             if(!override_uvs.empty()) {
@@ -1687,7 +1687,7 @@ Data::Mission::Resource * Data::Mission::ObjResource::duplicate() const {
 }
 
 bool Data::Mission::ObjResource::isPositionValid( unsigned index ) const {
-    if( index < 4 && vertex_data_reference.get4DVLSize() > position_indexes[index] )
+    if( index < 4 && vertex_data.get4DVLSize() > position_indexes[index] )
         return true;
     else
         return false;
@@ -1697,8 +1697,8 @@ glm::vec3 Data::Mission::ObjResource::getPosition( unsigned index ) const {
     glm::vec3 position(0, 0, 0);
 
     if( isPositionValid( index ) ) {
-        const uint32_t id_length = vertex_data_reference.get3DRFItem(VertexData::C_4DVL, 0);
-        const glm::i16vec3* const vertex_positions_r = vertex_data_reference.get4DVLPointer(id_length);
+        const uint32_t id_length = vertex_data.get3DRFItem(VertexData::C_4DVL, 0);
+        const glm::i16vec3* const vertex_positions_r = vertex_data.get4DVLPointer(id_length);
 
         position  = vertex_positions_r[ position_indexes[index] ];
         position *= glm::vec3(FIXED_POINT_UNIT, FIXED_POINT_UNIT, FIXED_POINT_UNIT);
@@ -1834,7 +1834,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createModel() const {
         triangle_buffer_size += face_quads.size() * Primitive::getTriangleAmount( PrimitiveType::QUAD );
 
         triangle_buffer.reserve( triangle_buffer_size );
-        morph_triangle_buffer.reserve( triangle_buffer_size * (vertex_data_reference.get3DRFSize() - 1) );
+        morph_triangle_buffer.reserve( triangle_buffer_size * (vertex_data.get3DRFSize() - 1) );
         primitive_buffer.reserve( triangle_buffer_size );
 
         // Go through the normal triangles first.
@@ -1866,13 +1866,13 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createModel() const {
 
         for( auto i = primitive_buffer.begin(); i != primitive_buffer.end(); i++ ) {
             if( (*i).type == PrimitiveType::TRIANGLE )
-                (*i).setTriangle(vertex_data_reference, triangle_buffer, morph_triangle_buffer, bones);
+                (*i).setTriangle(vertex_data, triangle_buffer, morph_triangle_buffer, bones);
             else if( (*i).type == PrimitiveType::QUAD )
-                (*i).setQuad(vertex_data_reference, triangle_buffer, morph_triangle_buffer, bones);
+                (*i).setQuad(vertex_data, triangle_buffer, morph_triangle_buffer, bones);
             else if( (*i).type == PrimitiveType::BILLBOARD )
-                (*i).setBillboard(vertex_data_reference, triangle_buffer, morph_triangle_buffer, bones);
+                (*i).setBillboard(vertex_data, triangle_buffer, morph_triangle_buffer, bones);
             else if( (*i).type == PrimitiveType::LINE )
-                (*i).setLine(vertex_data_reference, triangle_buffer, morph_triangle_buffer, bones);
+                (*i).setLine(vertex_data, triangle_buffer, morph_triangle_buffer, bones);
         }
     }
 
@@ -1938,13 +1938,13 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createModel() const {
     unsigned int position_morph_component_index = -1;
     unsigned int normal_morph_component_index = -1;
 
-    if( vertex_data_reference.get3DRFSize() > 1 ) {
+    if( vertex_data.get3DRFSize() > 1 ) {
         position_morph_component_index = model_output->setVertexComponentMorph( position_component_index );
         normal_morph_component_index = model_output->setVertexComponentMorph( normal_component_index );
     }
 
     // Setup the vertex components now that every field had been entered.
-    model_output->setupVertexComponents( vertex_data_reference.get3DRFSize() - 1 );
+    model_output->setupVertexComponents( vertex_data.get3DRFSize() - 1 );
 
     model_output->allocateVertices( triangle_buffer.size() * 3 );
 
@@ -2027,7 +2027,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createModel() const {
 
                 auto morph_triangle_frame = morph_triangle;
 
-                for( unsigned morph_frames = 0; morph_frames < vertex_data_reference.get3DRFSize() - 1; morph_frames++ )
+                for( unsigned morph_frames = 0; morph_frames < vertex_data.get3DRFSize() - 1; morph_frames++ )
                 {
                     const MorphPoint morph_point = (*morph_triangle_frame).points[vertex_index];
 
@@ -2046,7 +2046,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createModel() const {
             previous_triangle = triangle - 1;
 
             if( morph_triangle != morph_triangle_buffer.end() )
-                morph_triangle += vertex_data_reference.get3DRFSize() - 1;
+                morph_triangle += vertex_data.get3DRFSize() - 1;
         }
     }
     

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -1234,6 +1234,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                 auto reference_tag    = reader3DRF.readU32( settings.endian );
                 auto reference_count  = reader3DRF.readU32( settings.endian );
 
+                assert(reference_count > 0);
                 assert((reference_tag == TAG_4DVL && reference_number == 1) || (reference_tag == TAG_4DNL && reference_number == 2) || (reference_tag == TAG_3DRL && reference_number == 3));
 
                 std::vector<uint32_t> id_array;

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -719,6 +719,8 @@ void Data::Mission::ObjResource::VertexDataReference::set4DNLSize(int32_t size_o
 }
 void Data::Mission::ObjResource::VertexDataReference::set3DRLSize(int32_t size_of_3DRL) {
     this->size_of_3DRL = size_of_3DRL;
+
+    lengths.resize(size_of_3DRL * get3DRFSize());
 }
 
 int32_t Data::Mission::ObjResource::VertexDataReference::get4DVLSize() const {
@@ -729,6 +731,17 @@ int32_t Data::Mission::ObjResource::VertexDataReference::get4DNLSize() const {
 }
 int32_t Data::Mission::ObjResource::VertexDataReference::get3DRLSize() const {
     return this->size_of_3DRL;
+}
+
+uint16_t* Data::Mission::ObjResource::VertexDataReference::get3DRLPointer(uint32_t id) {
+
+    for(int32_t index = 0; index < get3DRFSize(); index++)
+    {
+        if(get3DRFItem(C_3DRL, index) == id)
+            return &lengths[index * this->size_of_3DRL];
+    }
+
+    return nullptr;
 }
 
 unsigned int Data::Mission::ObjResource::Bone::getNumAttributes() const {
@@ -1369,8 +1382,11 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                         lengths_pointer = &anm_lengths.back();
                     }
 
+                    uint16_t *length_data_r = vertex_data_reference.get3DRLPointer(frame_id);
+
                     for( uint32_t i = 0; i < count; i++ ) {
                         lengths_pointer->push_back( reader3DRL.readU16(settings.endian) );
+                        length_data_r[i] = lengths_pointer->back();
                     }
                 }
             }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -758,13 +758,7 @@ int32_t Data::Mission::ObjResource::VertexDataReference::get3DRLSize() const {
 }
 
 uint16_t* Data::Mission::ObjResource::VertexDataReference::get3DRLPointer(uint32_t id) {
-    for(int32_t index = 0; index < get3DRFSize(); index++)
-    {
-        if(get3DRFItem(C_3DRL, index) == id)
-            return &lengths[index * this->size_of_3DRL];
-    }
-
-    return nullptr;
+    return const_cast<uint16_t*>(const_cast<const VertexDataReference *const>(this)->get3DRLPointer(id));
 }
 
 const uint16_t* const Data::Mission::ObjResource::VertexDataReference::get3DRLPointer(uint32_t id) const {

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -178,10 +178,10 @@ public:
         uint32_t getBmpID() const;
         bool isWithinBounds( uint32_t vertex_limit, uint32_t normal_limit ) const;
 
-        int setTriangle( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
-        int setQuad( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
-        int setBillboard( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
-        int setLine( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
+        int setTriangle(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setQuad(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setBillboard(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setLine(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
 
         static size_t getTriangleAmount( PrimitiveType type );
 
@@ -214,8 +214,6 @@ private:
 
     VertexDataReference vertex_data_reference;
 
-    std::vector<glm::i16vec3> vertex_normals;
-
     std::map<uint_fast16_t, FaceType> face_types;
     std::vector<FaceOverrideType>     face_type_overrides;
     std::vector<glm::u8vec2>          override_uvs;
@@ -230,8 +228,6 @@ private:
     unsigned int              bone_frames;
     int16_t                  *bone_animation_data; // Where the animation data is stored.
     unsigned int              bone_animation_data_size;
-
-    std::vector<std::vector<glm::i16vec3>> vertex_anm_normals;
     
     unsigned int bounding_box_per_frame;
     unsigned int bounding_box_frames;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -178,10 +178,10 @@ public:
         uint32_t getBmpID() const;
         bool isWithinBounds( uint32_t vertex_limit, uint32_t normal_limit ) const;
 
-        int setTriangle(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
-        int setQuad(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
-        int setBillboard(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
-        int setLine(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setTriangle(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setQuad(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setBillboard(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setLine(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
 
         static size_t getTriangleAmount( PrimitiveType type );
 
@@ -212,7 +212,7 @@ private:
     } info;
     unsigned position_indexes[4];
 
-    VertexData vertex_data_reference;
+    VertexData vertex_data;
 
     std::map<uint_fast16_t, FaceType> face_types;
     std::vector<FaceOverrideType>     face_type_overrides;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -121,7 +121,7 @@ public:
          */
         unsigned int getNumAttributes() const;
     };
-    class VertexDataReference {
+    class VertexData {
     private:
         std::vector<uint32_t>     reference_ids;
         std::vector<glm::i16vec3> positions;
@@ -140,7 +140,7 @@ public:
         };
 
     public:
-        VertexDataReference();
+        VertexData();
 
         uint32_t get3DRFSize() const;
         void     set3DRFSize(uint32_t size);
@@ -178,10 +178,10 @@ public:
         uint32_t getBmpID() const;
         bool isWithinBounds( uint32_t vertex_limit, uint32_t normal_limit ) const;
 
-        int setTriangle(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
-        int setQuad(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
-        int setBillboard(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
-        int setLine(const VertexDataReference& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setTriangle(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setQuad(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setBillboard(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setLine(const VertexData& vertex_data_reference, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
 
         static size_t getTriangleAmount( PrimitiveType type );
 
@@ -212,7 +212,7 @@ private:
     } info;
     unsigned position_indexes[4];
 
-    VertexDataReference vertex_data_reference;
+    VertexData vertex_data_reference;
 
     std::map<uint_fast16_t, FaceType> face_types;
     std::vector<FaceOverrideType>     face_type_overrides;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -160,7 +160,10 @@ public:
     };
     class VertexDataReference {
     private:
-        std::vector<uint32_t> reference_ids;
+        std::vector<uint32_t>     reference_ids;
+        std::vector<glm::i16vec3> vertex_data; // Stores both positions and normals
+        std::vector<uint16_t>     lengths;
+
         int32_t size_of_4DVL;
         int32_t size_of_4DNL;
         int32_t size_of_3DRL;
@@ -188,6 +191,8 @@ public:
         int32_t get4DVLSize() const;
         int32_t get4DNLSize() const;
         int32_t get3DRLSize() const;
+
+        uint16_t* get3DRLPointer(uint32_t id);
     };
 private:
     struct {

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -124,7 +124,8 @@ public:
     class VertexDataReference {
     private:
         std::vector<uint32_t>     reference_ids;
-        std::vector<glm::i16vec3> vertex_data; // Stores both positions and normals
+        std::vector<glm::i16vec3> positions;
+        std::vector<glm::i16vec3> normals;
         std::vector<uint16_t>     lengths;
 
         int32_t size_of_4DVL;
@@ -154,6 +155,12 @@ public:
         int32_t get4DVLSize() const;
         int32_t get4DNLSize() const;
         int32_t get3DRLSize() const;
+
+        uint16_t* get4DVLPointer(uint32_t id);
+        const uint16_t* const get4DVLPointer(uint32_t id) const;
+
+        uint16_t* get4DNLPointer(uint32_t id);
+        const uint16_t* const get4DNLPointer(uint32_t id) const;
 
         uint16_t* get3DRLPointer(uint32_t id);
         const uint16_t* const get3DRLPointer(uint32_t id) const;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -121,43 +121,6 @@ public:
          */
         unsigned int getNumAttributes() const;
     };
-    struct Primitive {
-        PrimitiveType type;
-
-        Material visual;
-
-        uint16_t  face_type_offset;
-        FaceType *face_type_r;
-
-        uint8_t v[4], n[4];
-
-        uint32_t getBmpID() const;
-        bool isWithinBounds( uint32_t vertex_limit, uint32_t normal_limit ) const;
-
-        int setTriangle( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const std::vector<uint16_t> &lengths, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<std::vector<uint16_t>> &anm_lengths, const std::vector<Bone> &bones ) const;
-        int setQuad( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const std::vector<uint16_t> &lengths, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<std::vector<uint16_t>> &anm_lengths, const std::vector<Bone> &bones ) const;
-        int setBillboard( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const std::vector<uint16_t> &lengths, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<std::vector<uint16_t>> &anm_lengths, const std::vector<Bone> &bones ) const;
-        int setLine( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const std::vector<uint16_t> &lengths, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<std::vector<uint16_t>> &anm_lengths, const std::vector<Bone> &bones ) const;
-
-        static size_t getTriangleAmount( PrimitiveType type );
-
-        bool operator() ( const Primitive &l_operand, const Primitive &r_operand ) const;
-    };
-    // Warning: I do not know if this is actually the bounding box's data structure.
-    struct BoundingBox3D {
-        int16_t x;
-        int16_t y;
-        int16_t z;
-        uint16_t length_x;
-        uint16_t length_y;
-        uint16_t length_z;
-        uint16_t rotation_x;
-        uint16_t rotation_y;
-    };
-    struct TextureReference {
-        uint32_t resource_id;
-        std::string name;
-    };
     class VertexDataReference {
     private:
         std::vector<uint32_t>     reference_ids;
@@ -193,6 +156,44 @@ public:
         int32_t get3DRLSize() const;
 
         uint16_t* get3DRLPointer(uint32_t id);
+        const uint16_t* const get3DRLPointer(uint32_t id) const;
+    };
+    struct Primitive {
+        PrimitiveType type;
+
+        Material visual;
+
+        uint16_t  face_type_offset;
+        FaceType *face_type_r;
+
+        uint8_t v[4], n[4];
+
+        uint32_t getBmpID() const;
+        bool isWithinBounds( uint32_t vertex_limit, uint32_t normal_limit ) const;
+
+        int setTriangle( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
+        int setQuad( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
+        int setBillboard( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
+        int setLine( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
+
+        static size_t getTriangleAmount( PrimitiveType type );
+
+        bool operator() ( const Primitive &l_operand, const Primitive &r_operand ) const;
+    };
+    // Warning: I do not know if this is actually the bounding box's data structure.
+    struct BoundingBox3D {
+        int16_t x;
+        int16_t y;
+        int16_t z;
+        uint16_t length_x;
+        uint16_t length_y;
+        uint16_t length_z;
+        uint16_t rotation_x;
+        uint16_t rotation_y;
+    };
+    struct TextureReference {
+        uint32_t resource_id;
+        std::string name;
     };
 private:
     struct {
@@ -208,7 +209,6 @@ private:
 
     std::vector<glm::i16vec3> vertex_positions;
     std::vector<glm::i16vec3> vertex_normals;
-    std::vector<uint16_t>     lengths;
 
     std::map<uint_fast16_t, FaceType> face_types;
     std::vector<FaceOverrideType>     face_type_overrides;
@@ -227,7 +227,6 @@ private:
 
     std::vector<std::vector<glm::i16vec3>> vertex_anm_positions;
     std::vector<std::vector<glm::i16vec3>> vertex_anm_normals;
-    std::vector<std::vector<uint16_t>>     anm_lengths;
     
     unsigned int bounding_box_per_frame;
     unsigned int bounding_box_frames;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -158,6 +158,24 @@ public:
         uint32_t resource_id;
         std::string name;
     };
+    class VertexDataReference {
+    private:
+        std::vector<uint32_t> reference_ids;
+
+    public:
+        enum Tag {
+            C_4DVL = 0,
+            C_4DNL = 1,
+            C_3DRL = 2
+        };
+
+    public:
+        uint32_t getSize() const;
+        void     setSize(uint32_t size);
+
+        void     setItem(Tag tag, uint32_t index, uint32_t id);
+        uint32_t getItem(Tag tag, uint32_t index);
+    };
 private:
     struct {
         unsigned has_skeleton:     1;
@@ -167,6 +185,8 @@ private:
         unsigned animation:        1;
     } info;
     unsigned position_indexes[4];
+
+    VertexDataReference vertex_data_reference;
 
     std::vector<glm::i16vec3> vertex_positions;
     std::vector<glm::i16vec3> vertex_normals;
@@ -206,7 +226,6 @@ private:
     static unsigned int getOpcodeBytesPerFrame( Bone::Opcode opcode );
 public:
     ObjResource();
-    ObjResource( const ObjResource &obj );
     virtual ~ObjResource();
 
     virtual std::string getFileExtension() const;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -156,11 +156,11 @@ public:
         int32_t get4DNLSize() const;
         int32_t get3DRLSize() const;
 
-        uint16_t* get4DVLPointer(uint32_t id);
-        const uint16_t* const get4DVLPointer(uint32_t id) const;
+        glm::i16vec3* get4DVLPointer(uint32_t id);
+        const glm::i16vec3* const get4DVLPointer(uint32_t id) const;
 
-        uint16_t* get4DNLPointer(uint32_t id);
-        const uint16_t* const get4DNLPointer(uint32_t id) const;
+        glm::i16vec3* get4DNLPointer(uint32_t id);
+        const glm::i16vec3* const get4DNLPointer(uint32_t id) const;
 
         uint16_t* get3DRLPointer(uint32_t id);
         const uint16_t* const get3DRLPointer(uint32_t id) const;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -178,10 +178,10 @@ public:
         uint32_t getBmpID() const;
         bool isWithinBounds( uint32_t vertex_limit, uint32_t normal_limit ) const;
 
-        int setTriangle( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
-        int setQuad( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
-        int setBillboard( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
-        int setLine( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &positions, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_positions, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
+        int setTriangle( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
+        int setQuad( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
+        int setBillboard( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
+        int setLine( std::vector<Triangle> &triangles, const std::vector<glm::i16vec3> &normals, const VertexDataReference& vertex_data_reference, std::vector<MorphTriangle> &morph_triangles, const std::vector<std::vector<glm::i16vec3>> &vertex_anm_normals, const std::vector<Bone> &bones ) const;
 
         static size_t getTriangleAmount( PrimitiveType type );
 
@@ -214,7 +214,6 @@ private:
 
     VertexDataReference vertex_data_reference;
 
-    std::vector<glm::i16vec3> vertex_positions;
     std::vector<glm::i16vec3> vertex_normals;
 
     std::map<uint_fast16_t, FaceType> face_types;
@@ -232,7 +231,6 @@ private:
     int16_t                  *bone_animation_data; // Where the animation data is stored.
     unsigned int              bone_animation_data_size;
 
-    std::vector<std::vector<glm::i16vec3>> vertex_anm_positions;
     std::vector<std::vector<glm::i16vec3>> vertex_anm_normals;
     
     unsigned int bounding_box_per_frame;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -161,6 +161,9 @@ public:
     class VertexDataReference {
     private:
         std::vector<uint32_t> reference_ids;
+        int32_t size_of_4DVL;
+        int32_t size_of_4DNL;
+        int32_t size_of_3DRL;
 
     public:
         enum Tag {
@@ -170,11 +173,21 @@ public:
         };
 
     public:
-        uint32_t getSize() const;
-        void     setSize(uint32_t size);
+        VertexDataReference();
 
-        void     setItem(Tag tag, uint32_t index, uint32_t id);
-        uint32_t getItem(Tag tag, uint32_t index);
+        uint32_t get3DRFSize() const;
+        void     set3DRFSize(uint32_t size);
+
+        void     set3DRFItem(Tag tag, uint32_t index, uint32_t id);
+        uint32_t get3DRFItem(Tag tag, uint32_t index) const;
+
+        void set4DVLSize(int32_t size_of_4DVL);
+        void set4DNLSize(int32_t size_of_4DNL);
+        void set3DRLSize(int32_t size_of_3DRL);
+
+        int32_t get4DVLSize() const;
+        int32_t get4DNLSize() const;
+        int32_t get3DRLSize() const;
     };
 private:
     struct {


### PR DESCRIPTION
I made it so my parser is more accurate.

This is technically a bug fix. I realized that my parser relies on the order of chunks in which they appear. Identifiers on 3DRF chunks start from 1 to the count of the chunks that it will refer to. The chunks are organized from 1 to the count of chunks so my old parser will not make errors.