### PR TITLE
Cobj Bounding Box Rendering, GLES Mesh Upgrade, and Bugfixes.

### DIFF
--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2176,7 +2176,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createBoundingBoxes() cons
 
         for( unsigned int box_index = 0; box_index < this->bounding_box_per_frame; box_index++ )
         {
-            const BoundingBox3D &current_box = this->bounding_boxes[ box_index ];
+            const BoundingBox3D &current_box = this->bounding_boxes[ box_index * bounding_box_frames ];
             const glm::vec3 bb_center = FIXED_POINT_UNIT * glm::vec3(current_box.x, current_box.y, current_box.z);
             const glm::vec3 bb_scale  = FIXED_POINT_UNIT * glm::vec3(current_box.length_x + 1, current_box.length_y + 1, current_box.length_z + 1);
 
@@ -2213,7 +2213,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createBoundingBoxes() cons
                 box_output->setVertexData( color_coord_component_index, Utilities::DataTypes::Vec4UByteType( color ) );
 
                 for(unsigned int f = 1; f < bounding_box_frames; f++) {
-                    const BoundingBox3D &morph_box = this->bounding_boxes[ box_index + f * bounding_box_per_frame ];
+                    const BoundingBox3D &morph_box = this->bounding_boxes[ box_index * bounding_box_frames + f ];
                     const glm::vec3 morph_center = FIXED_POINT_UNIT * glm::vec3(morph_box.x, morph_box.y, morph_box.z);
                     const glm::vec3 morph_scale  = FIXED_POINT_UNIT * glm::vec3(morph_box.length_x, morph_box.length_y, morph_box.length_z);
 

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2155,7 +2155,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createBoundingBoxes() cons
         Utilities::ModelBuilder *box_output = new Utilities::ModelBuilder( Utilities::ModelBuilder::LINES );
 
         unsigned int position_component_index = box_output->addVertexComponent( Utilities::ModelBuilder::POSITION_COMPONENT_NAME, Utilities::DataTypes::ComponentType::FLOAT, Utilities::DataTypes::Type::VEC3 );
-        unsigned int color_coord_component_index = box_output->addVertexComponent( Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC3, true );
+        unsigned int color_coord_component_index = box_output->addVertexComponent( Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC4, true );
         unsigned int position_morph_component_index = 0;
 
         if( bounding_box_frames > 1 )

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -1801,7 +1801,7 @@ int Data::Mission::ObjResource::write( const std::string& file_path, const Data:
             Utilities::ModelBuilder *bounding_boxes_p = createBoundingBoxes();
 
             if(bounding_boxes_p != nullptr) {
-                bounding_boxes_p->write( std::string( file_path + "_bb"), "Bounding Boxes " + std::to_string( getResourceID() ) );
+                bounding_boxes_p->write( std::string( file_path + "_bb"), "cobj_" + std::to_string( getResourceID() )+ "_bb"  );
 
                 delete bounding_boxes_p;
             }

--- a/src/Graphics/Environment.h
+++ b/src/Graphics/Environment.h
@@ -102,6 +102,18 @@ public:
     virtual int setTilPolygonBlink( unsigned polygon_type, float rate = 1.0f) = 0;
 
     /**
+     * @return If bounding box drawing is enabled then this is true.
+     */
+    virtual bool getBoundingBoxDraw() const = 0;
+
+    /**
+     * This sets up bounding box rendering.
+     * @note This feature is optional, it is only there for debugging purposes.
+     * @param draw If true then bounding boes
+     */
+    virtual void setBoundingBoxDraw(bool draw) = 0;
+
+    /**
      * Setup the draw graph for the renderer.
      */
     virtual void setupFrame() = 0;

--- a/src/Graphics/SDL2/GLES2/Environment.cpp
+++ b/src/Graphics/SDL2/GLES2/Environment.cpp
@@ -197,6 +197,16 @@ int Environment::loadResources( const Data::Accessor &accessor ) {
         if( err != GL_NO_ERROR )
             std::cout << "Static Model shader is broken!: " << err << std::endl;
 
+        // Setup the vertex and fragment shaders
+        this->static_model_draw_bb_routine.setVertexShader();
+        this->static_model_draw_bb_routine.setFragmentShader();
+        this->static_model_draw_bb_routine.compileProgram();
+
+        err = glGetError();
+
+        if( err != GL_NO_ERROR )
+            std::cout << "Static Model Bounding Box shader is broken!: " << err << std::endl;
+
         this->morph_model_draw_routine.setVertexShader();
         this->morph_model_draw_routine.setFragmentShader();
         this->morph_model_draw_routine.compileProgram();
@@ -205,6 +215,16 @@ int Environment::loadResources( const Data::Accessor &accessor ) {
 
         if( err != GL_NO_ERROR )
             std::cout << "Morph Model shader is broken!: " << err << std::endl;
+
+        // Setup the vertex and fragment shaders
+        this->morph_model_draw_bb_routine.setVertexShader();
+        this->morph_model_draw_bb_routine.setFragmentShader();
+        this->morph_model_draw_bb_routine.compileProgram();
+
+        err = glGetError();
+
+        if( err != GL_NO_ERROR )
+            std::cout << "Morph Model Bounding Box shader is broken!: " << err << std::endl;
 
         this->skeletal_model_draw_routine.setVertexShader();
         this->skeletal_model_draw_routine.setFragmentShader();
@@ -242,12 +262,10 @@ int Environment::loadResources( const Data::Accessor &accessor ) {
     std::vector<const Data::Mission::ObjResource*> model_types = accessor.getAllOBJ();
 
     for( unsigned int i = 0; i < model_types.size(); i++ ) {
-        if( model_types[ i ] != nullptr )
-        {
+        if( model_types[ i ] != nullptr ) {
             model_r = model_types[ i ]->createModel();
 
-            if( model_r != nullptr )
-            {
+            if( model_r != nullptr ) {
                 if( model_r->getNumJoints() > 0 )
                     this->skeletal_model_draw_routine.inputModel( model_r, model_types[ i ]->getResourceID(), this->textures, model_types[ i ]->getFaceOverrideTypes(), model_types[ i ]->getFaceOverrideData() );
                 else
@@ -255,6 +273,15 @@ int Environment::loadResources( const Data::Accessor &accessor ) {
                     this->morph_model_draw_routine.inputModel( model_r, model_types[ i ]->getResourceID(), this->textures, model_types[ i ]->getFaceOverrideTypes(), model_types[ i ]->getFaceOverrideData() );
                 else
                     this->static_model_draw_routine.inputModel( model_r, model_types[ i ]->getResourceID(), this->textures, model_types[ i ]->getFaceOverrideTypes(), model_types[ i ]->getFaceOverrideData() );
+            }
+
+            model_r = model_types[ i ]->createBoundingBoxes();
+
+            if( model_r != nullptr ) {
+                if( model_r->getNumMorphFrames() > 0)
+                    this->morph_model_draw_bb_routine.inputModel( model_r, model_types[ i ]->getResourceID(), this->textures, model_types[ i ]->getFaceOverrideTypes(), model_types[ i ]->getFaceOverrideData() );
+                else
+                    this->static_model_draw_bb_routine.inputModel( model_r, model_types[ i ]->getResourceID(), this->textures, model_types[ i ]->getFaceOverrideTypes(), model_types[ i ]->getFaceOverrideData() );
             }
         }
     }
@@ -374,6 +401,14 @@ void Environment::drawFrame() {
 
             // When drawing the GUI elements depth test must be turned off.
             glDisable(GL_DEPTH_TEST);
+
+            glDisable( GL_CULL_FACE );
+            glDisable( GL_BLEND );
+            this->static_model_draw_bb_routine.draw(   *current_camera_r );
+            this->morph_model_draw_bb_routine.draw(    *current_camera_r );
+            glEnable( GL_CULL_FACE );
+            glEnable( GL_BLEND );
+
             glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 
             current_camera_r->getProjectionView2D( camera_3D_projection_view_model );

--- a/src/Graphics/SDL2/GLES2/Environment.cpp
+++ b/src/Graphics/SDL2/GLES2/Environment.cpp
@@ -251,6 +251,9 @@ int Environment::loadResources( const Data::Accessor &accessor ) {
         this->skeletal_model_draw_routine.clearModels();
         this->morph_model_draw_routine.clearModels();
         this->static_model_draw_routine.clearModels();
+
+        this->static_model_draw_bb_routine.clearModels();
+        this->morph_model_draw_bb_routine.clearModels();
     }
 
     this->static_model_draw_routine.setEnvironmentTexture( this->shiney_texture_p );
@@ -414,8 +417,8 @@ void Environment::drawFrame() {
             if(draw_bounding_boxes) {
                 glDisable( GL_CULL_FACE );
                 glDisable( GL_BLEND );
-                this->static_model_draw_bb_routine.draw(   *current_camera_r );
-                this->morph_model_draw_bb_routine.draw(    *current_camera_r );
+                this->static_model_draw_bb_routine.draw( *current_camera_r );
+                this->morph_model_draw_bb_routine.draw(  *current_camera_r );
                 glEnable( GL_CULL_FACE );
                 glEnable( GL_BLEND );
             }

--- a/src/Graphics/SDL2/GLES2/Environment.cpp
+++ b/src/Graphics/SDL2/GLES2/Environment.cpp
@@ -19,6 +19,7 @@ Environment::Environment() {
 
     this->display_world = false;
     this->has_initialized_routines = false;
+    this->draw_bounding_boxes = false;
 }
 
 Environment::~Environment() {
@@ -335,6 +336,14 @@ int Environment::setTilPolygonBlink( unsigned polygon_type, float rate ) {
         return -1; // The world_p needs allocating first!
 }
 
+bool Environment::getBoundingBoxDraw() const {
+    return this->draw_bounding_boxes;
+}
+
+void Environment::setBoundingBoxDraw(bool draw) {
+    this->draw_bounding_boxes = draw;
+}
+
 void Environment::setupFrame() {
     for( unsigned int i = 0; i < window_p->getCameras()->size(); i++ )
     {
@@ -402,12 +411,14 @@ void Environment::drawFrame() {
             // When drawing the GUI elements depth test must be turned off.
             glDisable(GL_DEPTH_TEST);
 
-            glDisable( GL_CULL_FACE );
-            glDisable( GL_BLEND );
-            this->static_model_draw_bb_routine.draw(   *current_camera_r );
-            this->morph_model_draw_bb_routine.draw(    *current_camera_r );
-            glEnable( GL_CULL_FACE );
-            glEnable( GL_BLEND );
+            if(draw_bounding_boxes) {
+                glDisable( GL_CULL_FACE );
+                glDisable( GL_BLEND );
+                this->static_model_draw_bb_routine.draw(   *current_camera_r );
+                this->morph_model_draw_bb_routine.draw(    *current_camera_r );
+                glEnable( GL_CULL_FACE );
+                glEnable( GL_BLEND );
+            }
 
             glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 

--- a/src/Graphics/SDL2/GLES2/Environment.h
+++ b/src/Graphics/SDL2/GLES2/Environment.h
@@ -33,6 +33,9 @@ public:
     Graphics::SDL2::GLES2::Internal::SkeletalModelDraw   skeletal_model_draw_routine;
     Graphics::SDL2::GLES2::Internal::DynamicTriangleDraw dynamic_triangle_draw_routine;
 
+    Graphics::SDL2::GLES2::Internal::StaticModelDraw     static_model_draw_bb_routine;
+    Graphics::SDL2::GLES2::Internal::MorphModelDraw      morph_model_draw_bb_routine = Graphics::SDL2::GLES2::Internal::MorphModelDraw(false);
+
 public:
     Environment();
     virtual ~Environment();

--- a/src/Graphics/SDL2/GLES2/Environment.h
+++ b/src/Graphics/SDL2/GLES2/Environment.h
@@ -33,6 +33,7 @@ public:
     Graphics::SDL2::GLES2::Internal::SkeletalModelDraw   skeletal_model_draw_routine;
     Graphics::SDL2::GLES2::Internal::DynamicTriangleDraw dynamic_triangle_draw_routine;
 
+    bool draw_bounding_boxes;
     Graphics::SDL2::GLES2::Internal::StaticModelDraw     static_model_draw_bb_routine;
     Graphics::SDL2::GLES2::Internal::MorphModelDraw      morph_model_draw_bb_routine = Graphics::SDL2::GLES2::Internal::MorphModelDraw(false);
 
@@ -49,6 +50,8 @@ public:
     virtual size_t getTilAmount() const;
     virtual int setTilBlink( unsigned til_index, float seconds );
     virtual int setTilPolygonBlink( unsigned polygon_type, float rate = 1.0f);
+    virtual bool getBoundingBoxDraw() const;
+    virtual void setBoundingBoxDraw(bool draw);
     virtual void setupFrame();
     virtual void drawFrame();
     virtual bool screenshot( Utilities::Image2D &image ) const;

--- a/src/Graphics/SDL2/GLES2/Internal/Mesh.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Mesh.cpp
@@ -33,7 +33,7 @@ void Graphics::SDL2::GLES2::Internal::Mesh::addCommand( GLint first, GLsizei opa
     draw_command.back().texture_r = texture_r;
 }
 
-void Graphics::SDL2::GLES2::Internal::Mesh::setup( Utilities::ModelBuilder &model, const std::map<uint32_t, Internal::Texture2D*>& textures ) {
+void Graphics::SDL2::GLES2::Internal::Mesh::setup( Utilities::ModelBuilder &model, const std::map<uint32_t, Internal::Texture2D*>& textures, const VertexAttributeArray *const default_vertex_array ) {
     switch(model.getPrimativeMode()) {
         case Utilities::ModelBuilder::MeshPrimativeMode::POINTS:
             draw_command_array_mode = GL_POINTS;

--- a/src/Graphics/SDL2/GLES2/Internal/Mesh.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Mesh.cpp
@@ -34,6 +34,30 @@ void Graphics::SDL2::GLES2::Internal::Mesh::addCommand( GLint first, GLsizei opa
 }
 
 void Graphics::SDL2::GLES2::Internal::Mesh::setup( Utilities::ModelBuilder &model, const std::map<uint32_t, Internal::Texture2D*>& textures ) {
+    switch(model.getPrimativeMode()) {
+        case Utilities::ModelBuilder::MeshPrimativeMode::POINTS:
+            draw_command_array_mode = GL_POINTS;
+            break;
+        case Utilities::ModelBuilder::MeshPrimativeMode::LINES:
+            draw_command_array_mode = GL_LINES;
+            break;
+        case Utilities::ModelBuilder::MeshPrimativeMode::LINE_LOOP:
+            draw_command_array_mode = GL_LINE_LOOP;
+            break;
+        case Utilities::ModelBuilder::MeshPrimativeMode::LINE_STRIP:
+            draw_command_array_mode = GL_LINE_STRIP;
+            break;
+        case Utilities::ModelBuilder::MeshPrimativeMode::TRIANGLES:
+            draw_command_array_mode = GL_TRIANGLES;
+            break;
+        case Utilities::ModelBuilder::MeshPrimativeMode::TRIANGLE_STRIP:
+            draw_command_array_mode = GL_TRIANGLE_STRIP;
+            break;
+        case Utilities::ModelBuilder::MeshPrimativeMode::TRIANGLE_FAN:
+            draw_command_array_mode = GL_TRIANGLE_FAN;
+            break;
+    }
+
     void * vertex_buffer_data = model.getBuffer( vertex_buffer_size );
     bool bounds;
     

--- a/src/Graphics/SDL2/GLES2/Internal/Mesh.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Mesh.cpp
@@ -33,7 +33,7 @@ void Graphics::SDL2::GLES2::Internal::Mesh::addCommand( GLint first, GLsizei opa
     draw_command.back().texture_r = texture_r;
 }
 
-void Graphics::SDL2::GLES2::Internal::Mesh::setup( Utilities::ModelBuilder &model, const std::map<uint32_t, Internal::Texture2D*>& textures, const VertexAttributeArray *const default_vertex_array ) {
+void Graphics::SDL2::GLES2::Internal::Mesh::setup( Utilities::ModelBuilder &model, const std::map<uint32_t, Internal::Texture2D*>& textures, const VertexAttributeArray *const default_vertex_array_r ) {
     switch(model.getPrimativeMode()) {
         case Utilities::ModelBuilder::MeshPrimativeMode::POINTS:
             draw_command_array_mode = GL_POINTS;
@@ -110,7 +110,10 @@ void Graphics::SDL2::GLES2::Internal::Mesh::setup( Utilities::ModelBuilder &mode
     }
 
     vertex_array.getAttributesFrom( *program_r, model );
-    
+
+    if(default_vertex_array_r != nullptr)
+        vertex_array.combineFrom(*default_vertex_array_r);
+
     vertex_array.allocate( *program_r );
     
     // If there is some kind of bug where there are some attributes not recognized

--- a/src/Graphics/SDL2/GLES2/Internal/Mesh.h
+++ b/src/Graphics/SDL2/GLES2/Internal/Mesh.h
@@ -56,7 +56,7 @@ public:
     Mesh( Program *program_r );
     virtual ~Mesh();
 
-    void setup( Utilities::ModelBuilder &model, const std::map<uint32_t, Internal::Texture2D*>& textures, const VertexAttributeArray *const default_vertex_array = nullptr );
+    void setup( Utilities::ModelBuilder &model, const std::map<uint32_t, Internal::Texture2D*>& textures, const VertexAttributeArray *const default_vertex_array_r );
 
     void setDrawCommandArrayMode( GLenum draw_command_array_mode ) { this->draw_command_array_mode = draw_command_array_mode; }
 

--- a/src/Graphics/SDL2/GLES2/Internal/Mesh.h
+++ b/src/Graphics/SDL2/GLES2/Internal/Mesh.h
@@ -56,7 +56,7 @@ public:
     Mesh( Program *program_r );
     virtual ~Mesh();
 
-    void setup( Utilities::ModelBuilder &model, const std::map<uint32_t, Internal::Texture2D*>& textures );
+    void setup( Utilities::ModelBuilder &model, const std::map<uint32_t, Internal::Texture2D*>& textures, const VertexAttributeArray *const default_vertex_array = nullptr );
 
     void setDrawCommandArrayMode( GLenum draw_command_array_mode ) { this->draw_command_array_mode = draw_command_array_mode; }
 

--- a/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.cpp
@@ -143,7 +143,6 @@ Graphics::SDL2::GLES2::Internal::MorphModelDraw::MorphModelDraw(bool has_normals
 
     const size_t MORPH_BUFFER_NO_NORMALS_SIZE = 3 * sizeof( float );
     const size_t MORPH_BUFFER_SIZE = (3 + 3) * sizeof( float );
-    float normal_default[4] = {1.0f, 0.0f, 0.0f, 0.0f};
 
     if(has_normals) {
         morph_attribute_array.addAttribute( "POSITION_Last", 3, GL_FLOAT, GL_FALSE, MORPH_BUFFER_SIZE, 0 );
@@ -151,7 +150,7 @@ Graphics::SDL2::GLES2::Internal::MorphModelDraw::MorphModelDraw(bool has_normals
     }
     else {
         morph_attribute_array.addAttribute( "POSITION_Last", 3, GL_FLOAT, GL_FALSE, MORPH_BUFFER_NO_NORMALS_SIZE, 0 );
-        morph_attribute_array.addAttribute( "NORMAL_Last",   3, normal_default );
+        morph_attribute_array.addAttribute( "NORMAL_Last",   3, glm::vec4(1.0f, 0.0f, 0.0f, 0.0f) );
     }
 }
 

--- a/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.h
@@ -40,8 +40,7 @@ public:
         const DeltaTriangle *const getFrame( unsigned frame_index ) const;
     };
 protected:
-    VertexAttributeArray morph_attribute_array_last;
-    VertexAttributeArray morph_attribute_array_next;
+    VertexAttributeArray morph_attribute_array;
 
     // uniforms are used for morpth attributes.
     GLuint sample_last_uniform_id;
@@ -49,7 +48,7 @@ protected:
     std::map<uint32_t, Animation*> model_animation_p;
     
 public:
-    MorphModelDraw();
+    MorphModelDraw(bool has_normals = true);
     virtual ~MorphModelDraw();
 
     /**

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -436,6 +436,29 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::allocateObjModel( uint32_t
         return -1; // The requested index_obj does not exist
 }
 
+int Graphics::SDL2::GLES2::Internal::StaticModelDraw::allocateObjBBModel( uint32_t obj_identifier, GLES2::ModelInstance &model_instance ) {
+    if( models_p.find( obj_identifier ) != models_p.end() ) // Do some bounds checking!
+    {
+        // This holds the model instance sheet.
+        ModelArray *model_array_r = models_p[ obj_identifier ];
+
+        model_instance.bb_array_r = model_array_r;
+
+        if( !models_p[ obj_identifier ]->mesh.getBoundingSphere( model_instance.culling_sphere_position, model_instance.culling_sphere_radius ) )
+        {
+            model_instance.culling_sphere_position = glm::vec3( 0, 0, 0 );
+            model_instance.culling_sphere_radius = 1.0f;
+        }
+
+        // Finally added the instance.
+        model_array_r->instances_r.insert( &model_instance );
+
+        return 1; // The instance is successfully allocated.
+    }
+    else
+        return -1; // The requested index_obj does not exist
+}
+
 void Graphics::SDL2::GLES2::Internal::StaticModelDraw::advanceTime( float seconds_passed ) {
     // Go through every model array.
     for( auto model_type = models_p.begin(); model_type != models_p.end(); model_type++ ) {

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -221,8 +221,15 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( Utilities::Mod
 
     if( model_type_r->getNumVertices() > 0 )
     {
+        VertexAttributeArray vertex_array;
+
+        vertex_array.addAttribute("NORMAL", 3, glm::vec4(1.0f, 0.0f, 0.0f, 0.0f));
+        vertex_array.addAttribute("COLOR_0", 4, glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));
+        vertex_array.addAttribute("TEXCOORD_0", 2, glm::vec4(0.0f, 0.0f, 0.0f, 0.0f));
+        vertex_array.addAttribute("_METADATA", 2, glm::vec4(0.0f, 0.0f, 0.0f, 0.0f));
+
         models_p[ obj_identifier ] = new ModelArray( &program );
-        models_p[ obj_identifier ]->mesh.setup( *model_type_r, textures );
+        models_p[ obj_identifier ]->mesh.setup( *model_type_r, textures, &vertex_array );
         state =  1;
 
         Utilities::ModelBuilder::TextureMaterial material;

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
@@ -54,7 +54,6 @@ protected:
     GLuint view_uniform_id;
     GLuint view_inv_uniform_id;
 
-    // The models need to be accessed.
     std::map<uint32_t, ModelArray*> models_p;
 
     std::vector<glm::vec2> uv_frame_buffer;
@@ -147,6 +146,8 @@ public:
     void draw( Graphics::SDL2::GLES2::Camera &camera );
 
     int allocateObjModel( uint32_t resource_cobj, GLES2::ModelInstance &model_instance );
+
+    int allocateObjBBModel( uint32_t resource_cobj, GLES2::ModelInstance &model_instance );
 
     /**
      * This advances the time of every instance.

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
@@ -141,7 +141,7 @@ public:
     /**
      * This draws all the models that are opeqe.
      * @note Make sure setFragmentShader, loadFragmentShader, compileProgram and setWorld in this order are called SUCCESSFULLY.
-     * @param This is the camera data to be passed into world.
+     * @param camera This is the camera data to be passed into world.
      */
     void draw( Graphics::SDL2::GLES2::Camera &camera );
 

--- a/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.cpp
@@ -66,6 +66,27 @@ bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const 
         return false;
 }
 
+int Graphics::SDL2::GLES2::Internal::VertexAttributeArray::combineFrom(const VertexAttributeArray& combine) {
+    int added_attributes = 0;
+
+    for( auto c = combine.attributes.begin(); c != combine.attributes.end(); c++) {
+        bool missing_attribute = true;
+
+        for( auto s = attributes.begin(); s != attributes.end(); s++) {
+            if( (*s).name.compare((*c).name) == 0 ) {
+                missing_attribute = false;
+            }
+        }
+
+        if( missing_attribute ) {
+            attributes.push_back( (*c) );
+            added_attributes++;
+        }
+    }
+
+    return added_attributes;
+}
+
 int Graphics::SDL2::GLES2::Internal::VertexAttributeArray::allocate( Graphics::SDL2::GLES2::Internal::Program & program ) {
     int found_attributes = 0;
 

--- a/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.cpp
@@ -37,7 +37,7 @@ bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const 
         return false;
 }
 
-bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const std::basic_string<GLchar>& name, GLint size, float values[4] ) {
+bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const std::basic_string<GLchar>& name, GLint size, glm::vec4 value ) {
     bool name_is_not_found = true;
 
     for( unsigned int i = 0; i < attributes.size(); i++ )
@@ -55,10 +55,10 @@ bool Graphics::SDL2::GLES2::Internal::VertexAttributeArray::addAttribute( const 
         attributes.back().index = -1; // This will be set by allocate.
         attributes.back().size = size;
 
-        attributes.back().values[0] = values[0];
-        attributes.back().values[1] = values[1];
-        attributes.back().values[2] = values[2];
-        attributes.back().values[3] = values[3];
+        attributes.back().values[0] = value[0];
+        attributes.back().values[1] = value[1];
+        attributes.back().values[2] = value[2];
+        attributes.back().values[3] = value[3];
 
         return true;
     }

--- a/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.h
+++ b/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.h
@@ -28,6 +28,9 @@ protected:
         GLsizei stride;
         
         void *offset_r;
+
+        bool is_generic;
+        float values[4];
     };
     std::vector<AttributeType> attributes;
 public:
@@ -36,11 +39,17 @@ public:
 
     /**
      * Add an attribute to this class.
-     * The program must be set first though.
+     * The program must be set first.
      * @note The parameters will be directly passed into an AttributeType.
      * @return If a name already exists then return false.
      */
     bool addAttribute( const std::basic_string<GLchar>& name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, void *pointer_r );
+
+    /**
+     * Add an attribute to this class.
+     * @return If a name already exists then return false.
+     */
+    bool addAttribute( const std::basic_string<GLchar>& name, GLint size, float values[4] );
 
     /**
      * The VertexAttributeArray has to be filled in order for this method to work.

--- a/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.h
+++ b/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.h
@@ -52,6 +52,12 @@ public:
     bool addAttribute( const std::basic_string<GLchar>& name, GLint size, float values[4] );
 
     /**
+     * Add attributes that are not found.
+     * @return The number of missing attributes that where added.
+     */
+    int combineFrom(const VertexAttributeArray& combine);
+
+    /**
      * The VertexAttributeArray has to be filled in order for this method to work.
      * @return The number of successfull attributeTypeBinds.
      */

--- a/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.h
+++ b/src/Graphics/SDL2/GLES2/Internal/VertexAttributeArray.h
@@ -49,7 +49,7 @@ public:
      * Add an attribute to this class.
      * @return If a name already exists then return false.
      */
-    bool addAttribute( const std::basic_string<GLchar>& name, GLint size, float values[4] );
+    bool addAttribute( const std::basic_string<GLchar>& name, GLint size, glm::vec4 value );
 
     /**
      * Add attributes that are not found.

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -257,7 +257,7 @@ void Graphics::SDL2::GLES2::Internal::World::setWorld( const Data::Mission::PTCR
         if( vertex_animation_p == nullptr)
             vertex_animation_p = (*i).animation_slfx.getImage();
 
-        (*i).mesh_p->setup( *model_p, textures );
+        (*i).mesh_p->setup( *model_p, textures, nullptr ); // TODO Replace the nullptr with something more important.
 
         // TODO Add addition render path for "light".
         Utilities::ModelBuilder::TextureMaterial material;

--- a/src/Graphics/SDL2/GLES2/ModelInstance.h
+++ b/src/Graphics/SDL2/GLES2/ModelInstance.h
@@ -15,6 +15,7 @@ namespace GLES2 {
 class ModelInstance : public Graphics::ModelInstance {
 public:
     Internal::StaticModelDraw::ModelArray *array_r;
+    Internal::StaticModelDraw::ModelArray *bb_array_r;
     glm::vec3 culling_sphere_position;
     float culling_sphere_radius;
     

--- a/src/MainProgram.cpp
+++ b/src/MainProgram.cpp
@@ -349,6 +349,7 @@ void MainProgram::loadResources() {
 void MainProgram::loadGraphics( bool show_map ) {
     this->environment_p->loadResources( this->accessor );
     this->environment_p->displayMap( show_map );
+    this->environment_p->setBoundingBoxDraw( false );
 
     // Get the font from the resource file.
     if( Graphics::Text2DBuffer::loadFonts( *this->environment_p, this->accessor ) == 0 ) {

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -150,9 +150,16 @@ void ModelViewer::update( MainProgram &main_program, std::chrono::microseconds d
             }
         }
 
-        input_r = main_program.controllers_r[0]->getInput( Controls::StandardInputSet::Buttons::RIGHT );
+        input_r = main_program.controllers_r[0]->getInput( Controls::StandardInputSet::Buttons::CHANGE_TARGET );
+
+        if( input_r->isChanged() && input_r->getState() < 0.5 && this->count_down < 0.0f ) {
+            main_program.environment_p->setBoundingBoxDraw(!main_program.environment_p->getBoundingBoxDraw());
+            this->count_down = 0.5f;
+        }
 
         int next = 0;
+
+        input_r = main_program.controllers_r[0]->getInput( Controls::StandardInputSet::Buttons::RIGHT );
 
         if( input_r->isChanged() && input_r->getState() < 0.5 && this->count_down < 0.0f )
             next++;

--- a/src/PrimaryGame.cpp
+++ b/src/PrimaryGame.cpp
@@ -188,6 +188,11 @@ void PrimaryGame::update( MainProgram &main_program, std::chrono::microseconds d
                 is_camera_moving = false;
         }
 
+        input_r = main_program.controllers_r[0]->getInput( Controls::StandardInputSet::Buttons::CHANGE_TARGET );
+        if( input_r->isChanged() && input_r->getState() < 0.5 ) {
+            main_program.environment_p->setBoundingBoxDraw(!main_program.environment_p->getBoundingBoxDraw());
+        }
+
         input_r = main_program.controllers_r[0]->getInput( Controls::StandardInputSet::Buttons::ROTATE_LEFT );
         if( input_r->isChanged() && input_r->getState() > 0.5 )
         {


### PR DESCRIPTION
Bounding Box Rendering can be toggled on or off with the CHANGE_TARGET key for both the map viewer and the model viewer.

The bounding box animations are now correctly decoded. Long story short, I assumed the bounding box data was interlaced rather than being their own separate arrays.

I had also upgraded Mesh so it handles cases where models are not complete. Otherwise the bounding boxes will have
rendering artifacts.

Also, I revised the export naming of the bounding boxes to make it sound closer to the models that contain it.