### PR TITLE
Parameter Options for Metadata for Cobj and Ctil, Cobj Commands Shortened, Model Export Optional for Cobj.

### DIFF
--- a/src/Data/Mission/IFFOptions.h
+++ b/src/Data/Mission/IFFOptions.h
@@ -158,12 +158,13 @@ struct IFFOptions {
     } snds;
 
     struct TilOption : public ResourceOption {
+        bool export_metadata;
         bool enable_point_cloud_export;
         bool enable_height_map_export;
         bool enable_til_export_model;
         bool enable_til_backface_culling;
 
-        TilOption() : ResourceOption(), enable_point_cloud_export( false ), enable_height_map_export( false ), enable_til_export_model( false ), enable_til_backface_culling(false) {}
+        TilOption() : ResourceOption(), export_metadata( false ), enable_point_cloud_export( false ), enable_height_map_export( false ), enable_til_export_model( false ), enable_til_backface_culling(false) {}
         std::string getNameSpace() const { return "TIL"; }
         virtual bool readParams( std::map<std::string, std::vector<std::string>> &arguments, std::ostream *output_r );
         virtual std::string getOptions() const;

--- a/src/Data/Mission/IFFOptions.h
+++ b/src/Data/Mission/IFFOptions.h
@@ -110,10 +110,11 @@ struct IFFOptions {
     } net;
 
     struct ObjOption : public ResourceOption {
+        bool no_model;
         bool export_metadata;
         bool export_bounding_box;
 
-        ObjOption() : ResourceOption(), export_metadata( false ), export_bounding_box( false ) {}
+        ObjOption() : ResourceOption(), no_model(false), export_metadata( false ), export_bounding_box( false ) {}
         std::string getNameSpace() const { return "OBJ"; }
         virtual bool readParams( std::map<std::string, std::vector<std::string>> &arguments, std::ostream *output_r );
         virtual std::string getOptions() const;

--- a/src/Data/Mission/IFFOptions.h
+++ b/src/Data/Mission/IFFOptions.h
@@ -110,10 +110,10 @@ struct IFFOptions {
     } net;
 
     struct ObjOption : public ResourceOption {
-        bool export_no_metadata;
+        bool export_metadata;
         bool export_bounding_box;
 
-        ObjOption() : ResourceOption(), export_no_metadata( false ), export_bounding_box( false ) {}
+        ObjOption() : ResourceOption(), export_metadata( false ), export_bounding_box( false ) {}
         std::string getNameSpace() const { return "OBJ"; }
         virtual bool readParams( std::map<std::string, std::vector<std::string>> &arguments, std::ostream *output_r );
         virtual std::string getOptions() const;

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -1778,22 +1778,24 @@ int Data::Mission::ObjResource::write( const std::string& file_path, const Data:
 
     if( iff_options.obj.shouldWrite( iff_options.enable_global_dry_default ) ) {
         // Make sure that the model has some vertex data.
-        if( model_output->getNumVertices() >= 3 ) {
-            
-            if( !bones.empty() )
-                model_output->applyJointTransforms( 0 );
-            
-            glTF_return = model_output->write( std::string( file_path ), "cobj_" + std::to_string( getResourceID() ) );
-        }
-        else {
-            // Make it easier on the user to identify empty Obj's
-            std::ofstream resource;
-            
-            resource.open( std::string(file_path) + "_empty.txt", std::ios::out );
-            
-            if( resource.is_open() ) {
-                resource << "Obj with index number of " << getIndexNumber() << " or with id number " << getResourceID() << " is empty." << std::endl;
-                resource.close();
+        if( !iff_options.obj.no_model ) {
+            if( model_output->getNumVertices() >= 3 ) {
+
+                if( !bones.empty() )
+                    model_output->applyJointTransforms( 0 );
+
+                glTF_return = model_output->write( std::string( file_path ), "cobj_" + std::to_string( getResourceID() ) );
+            }
+            else {
+                // Make it easier on the user to identify empty Obj's
+                std::ofstream resource;
+
+                resource.open( std::string(file_path) + "_empty.txt", std::ios::out );
+
+                if( resource.is_open() ) {
+                    resource << "Obj with index number of " << getIndexNumber() << " or with id number " << getResourceID() << " is empty." << std::endl;
+                    resource.close();
+                }
             }
         }
 
@@ -1806,14 +1808,14 @@ int Data::Mission::ObjResource::write( const std::string& file_path, const Data:
                 delete bounding_boxes_p;
             }
             else {
-            std::ofstream resource;
+                std::ofstream resource;
 
-            resource.open( std::string(file_path) + "_empty_bb.txt", std::ios::out );
+                resource.open( std::string(file_path) + "_empty_bb.txt", std::ios::out );
 
-            if( resource.is_open() ) {
-                resource << "Obj with index number of " << getIndexNumber() << " or with id number " << getResourceID() << " has failed!" << std::endl;
-                resource.close();
-            }
+                if( resource.is_open() ) {
+                    resource << "Obj with index number of " << getIndexNumber() << " or with id number " << getResourceID() << " has failed!" << std::endl;
+                    resource.close();
+                }
             }
         }
     }
@@ -2313,19 +2315,22 @@ const std::vector<Data::Mission::ObjResource*> Data::Mission::ObjResource::getVe
 }
 
 bool Data::Mission::IFFOptions::ObjOption::readParams( std::map<std::string, std::vector<std::string>> &arguments, std::ostream *output_r ) {
-    if( !singleArgument( arguments, "--" + getNameSpace() + "_EXPORT_METADATA", output_r, export_metadata ) )
+    if( !singleArgument( arguments, "--" + getNameSpace() + "_NO_MODEL", output_r, no_model ) )
         return false; // The single argument is not valid.
-    if( !singleArgument( arguments, "--" + getNameSpace() + "_EXPORT_BOUNDING_BOXES", output_r, export_bounding_box ) )
+    if( !singleArgument( arguments, "--" + getNameSpace() + "_METADATA", output_r, export_metadata ) )
+        return false; // The single argument is not valid.
+    if( !singleArgument( arguments, "--" + getNameSpace() + "_BOUNDING_BOXES", output_r, export_bounding_box ) )
         return false; // The single argument is not valid.
 
     return IFFOptions::ResourceOption::readParams( arguments, output_r );
 }
 
 std::string Data::Mission::IFFOptions::ObjOption::getOptions() const {
-    std::string information_text = getBuiltInOptions();
+    std::string information_text = getBuiltInOptions(8);
 
-    information_text += "  --OBJ_EXPORT_METADATA Export the primary glTF file without its metadata.\n";
-    information_text += "  --OBJ_EXPORT_BOUNDING_BOXES Export a glTF file per resource containing bounding boxes.\n";
+    information_text += "  --" + getNameSpace() + "_NO_MODEL       Disable model exporting for the map.\n";
+    information_text += "  --" + getNameSpace() + "_METADATA       Export the primary glTF file without its metadata.\n";
+    information_text += "  --" + getNameSpace() + "_BOUNDING_BOXES Export a glTF file per resource containing bounding boxes.\n";
 
     return information_text;
 }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -1774,7 +1774,7 @@ glm::vec3 Data::Mission::ObjResource::getPosition( unsigned index ) const {
 int Data::Mission::ObjResource::write( const std::string& file_path, const Data::Mission::IFFOptions &iff_options ) const {
     int glTF_return = 0;
 
-    Utilities::ModelBuilder *model_output = createMesh(iff_options.obj.export_no_metadata);
+    Utilities::ModelBuilder *model_output = createMesh(!iff_options.obj.export_metadata);
 
     if( iff_options.obj.shouldWrite( iff_options.enable_global_dry_default ) ) {
         // Make sure that the model has some vertex data.
@@ -2313,7 +2313,7 @@ const std::vector<Data::Mission::ObjResource*> Data::Mission::ObjResource::getVe
 }
 
 bool Data::Mission::IFFOptions::ObjOption::readParams( std::map<std::string, std::vector<std::string>> &arguments, std::ostream *output_r ) {
-    if( !singleArgument( arguments, "--" + getNameSpace() + "_EXPORT_NO_METADATA", output_r, export_no_metadata ) )
+    if( !singleArgument( arguments, "--" + getNameSpace() + "_EXPORT_METADATA", output_r, export_metadata ) )
         return false; // The single argument is not valid.
     if( !singleArgument( arguments, "--" + getNameSpace() + "_EXPORT_BOUNDING_BOXES", output_r, export_bounding_box ) )
         return false; // The single argument is not valid.
@@ -2324,7 +2324,7 @@ bool Data::Mission::IFFOptions::ObjOption::readParams( std::map<std::string, std
 std::string Data::Mission::IFFOptions::ObjOption::getOptions() const {
     std::string information_text = getBuiltInOptions();
 
-    information_text += "  --OBJ_EXPORT_NO_METADATA Export the primary glTF file without its metadata.\n";
+    information_text += "  --OBJ_EXPORT_METADATA Export the primary glTF file without its metadata.\n";
     information_text += "  --OBJ_EXPORT_BOUNDING_BOXES Export a glTF file per resource containing bounding boxes.\n";
 
     return information_text;

--- a/src/Data/Mission/PTCResource.cpp
+++ b/src/Data/Mission/PTCResource.cpp
@@ -209,7 +209,7 @@ int Data::Mission::PTCResource::writeEntireMap( std::string file_path, bool make
                 auto tile_r = getTile( w, h );
 
                 if( tile_r != nullptr ) {
-                    auto model_p = tile_r->createPartial( i, make_culled, -y * 16.0f, -x * 16.0f );
+                    auto model_p = tile_r->createPartial( i, make_culled, false, -y * 16.0f, -x * 16.0f );
 
                     if( model_p != nullptr )
                         texture_tils.push_back( model_p );

--- a/src/Data/Mission/TilResource.h
+++ b/src/Data/Mission/TilResource.h
@@ -292,12 +292,12 @@ public:
 
     virtual int write( const std::string& file_path, const Data::Mission::IFFOptions &iff_options = IFFOptions() ) const;
 
-    virtual Utilities::ModelBuilder * createModel() const { return createModel( false ); }
-    virtual Utilities::ModelBuilder * createCulledModel() const { return createModel( true ); }
+    virtual Utilities::ModelBuilder * createModel() const { return createModel( false, true ); }
+    virtual Utilities::ModelBuilder * createCulledModel() const { return createModel( true, true ); }
 
-    virtual Utilities::ModelBuilder * createModel( bool is_culled, Utilities::Logger &logger = Utilities::logger ) const;
+    virtual Utilities::ModelBuilder * createModel( bool is_culled, bool metadata, Utilities::Logger &logger = Utilities::logger ) const;
     
-    Utilities::ModelBuilder * createPartial( unsigned int texture_index, bool is_culled = false, float x_offset = 0.0f, float z_offset = 0.0f, Utilities::Logger &logger = Utilities::logger ) const;
+    Utilities::ModelBuilder * createPartial( unsigned int texture_index, bool is_culled, bool metadata, float x_offset = 0.0f, float z_offset = 0.0f, Utilities::Logger &logger = Utilities::logger ) const;
     
     void createPhysicsCell( unsigned int x, unsigned int z );
     


### PR DESCRIPTION
Because metadata does nothing but add space for most users I am excluding most metadata by default.

PTC exports are modified not to include metadata at all. It is because the metadata stored in Ctil would not work when
other Ctils are combined with it anyways.