### PR TITLE
Circles to Stars; Stars are now drawn as billboards; Star Vertex Color Animations

### DIFF
--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2192,7 +2192,9 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
         facer_polygon.color.g = (*i).v[2] * (1. / 256.);
         facer_polygon.color.b = (*i).v[3] * (1. / 256.);
         facer_polygon.width = lengths_r[(*i).n[0]] * FIXED_POINT_UNIT;
-        facer_polygon.primitive.star.position = glm::vec3(positions_r[(*i).v[0]]) * FIXED_POINT_UNIT;
+        facer_polygon.primitive.star.point.position = glm::vec3(positions_r[(*i).v[0]]) * FIXED_POINT_UNIT;
+        facer_polygon.primitive.star.point.weights  = glm::u8vec4(0);
+        facer_polygon.primitive.star.point.joints   = glm::u8vec4(0);
 
         polys.push_back( facer_polygon );
     }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2206,7 +2206,7 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
             }
         }
 
-        triangle_amount += 1;
+        triangle_amount += 2;
 
         polys.push_back( facer_polygon );
     }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -1680,8 +1680,8 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                     // 3DAL is almost like 3DTA
                     face_color_overrides.push_back(VertexColorOverride());
 
-                    face_color_overrides.back().face_index = reader3DAL.readU8();                // 3DQL index to primative type star
-                    face_color_overrides.back().speed_factor = 1.0f; reader3DAL.readU8();        // TODO Decode the speed value.
+                    face_color_overrides.back().face_index = reader3DAL.readU8(); // 3DQL index to primative type star
+                    face_color_overrides.back().speed_factor = 2.0f * (0.0757594 * reader3DAL.readU8() + 0.0520309);
                     face_color_overrides.back().colors[0].r = reader3DAL.readU8() * (1. / 256.);
                     face_color_overrides.back().colors[0].g = reader3DAL.readU8() * (1. / 256.);
                     face_color_overrides.back().colors[0].b = reader3DAL.readU8() * (1. / 256.);

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -1482,8 +1482,9 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
 
                     Primitive primitive;
 
-                    primitive.face_type_offset = face_type_offset;
-                    primitive.face_type_r      = nullptr;
+                    primitive.face_type_offset        = face_type_offset;
+                    primitive.face_type_r             = nullptr;
+                    primitive.vertex_color_override_r = nullptr;
 
                     primitive.visual.uses_texture       = is_texture;
                     primitive.visual.normal_shading     = normal_shadows;
@@ -2062,6 +2063,15 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
         for( auto &primitive : this->primitives ) {
             if( primitive.type != PrimitiveType::STAR && this->face_types.find( primitive.face_type_offset ) != this->face_types.end() ) {
                 primitive.face_type_r = &this->face_types[ primitive.face_type_offset ];
+            }
+        }
+
+        for( auto i = this->face_color_overrides.begin(); i != this->face_color_overrides.end(); i++ ) {
+            auto &face_color_override = (*i);
+
+            if(primitives.size() > face_color_override.face_index) {
+                if(primitives.at(face_color_override.face_index).type == PrimitiveType::STAR)
+                    primitives[face_color_override.face_index].vertex_color_override_r = &(*i);
             }
         }
 

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2121,17 +2121,17 @@ int Data::Mission::ObjResource::write( const std::string& file_path, const Data:
     allowed_primitives.billboard = true;
     allowed_primitives.line      = true;
 
-    Utilities::ModelBuilder *model_output = createMesh(!iff_options.obj.export_metadata, false, allowed_primitives);
+    Utilities::ModelBuilder *model_output_p = createMesh(!iff_options.obj.export_metadata, false, allowed_primitives);
 
     if( iff_options.obj.shouldWrite( iff_options.enable_global_dry_default ) ) {
         // Make sure that the model has some vertex data.
         if( !iff_options.obj.no_model ) {
-            if( model_output->getNumVertices() >= 3 ) {
+            if( model_output_p->getNumVertices() >= 3 ) {
 
                 if( !bones.empty() )
-                    model_output->applyJointTransforms( 0 );
+                    model_output_p->applyJointTransforms( 0 );
 
-                glTF_return = model_output->write( std::string( file_path ), "cobj_" + std::to_string( getResourceID() ) );
+                glTF_return = model_output_p->write( std::string( file_path ), "cobj_" + std::to_string( getResourceID() ) );
             }
             else {
                 // Make it easier on the user to identify empty Obj's
@@ -2167,7 +2167,7 @@ int Data::Mission::ObjResource::write( const std::string& file_path, const Data:
         }
     }
 
-    delete model_output;
+    delete model_output_p;
 
     return glTF_return;
 }
@@ -2352,7 +2352,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createModel() const {
 }
 
 Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_metadata, bool force_normal, AllowedPrimitives allowed_primitives ) const {
-    Utilities::ModelBuilder *model_output = new Utilities::ModelBuilder();
+    Utilities::ModelBuilder *model_output_p = new Utilities::ModelBuilder();
 
     // This buffer will be used to store every triangle that the write function has.
     std::vector<Triangle> triangle_buffer;
@@ -2429,26 +2429,26 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
 
     bool build_normals = (vertex_data.get4DNLSize() != 0) | force_normal;
 
-    unsigned int position_component_index = model_output->addVertexComponent( Utilities::ModelBuilder::POSITION_COMPONENT_NAME, Utilities::DataTypes::ComponentType::FLOAT, Utilities::DataTypes::Type::VEC3 );
+    unsigned int position_component_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::POSITION_COMPONENT_NAME, Utilities::DataTypes::ComponentType::FLOAT, Utilities::DataTypes::Type::VEC3 );
     unsigned int normal_component_index = -1;
 
     if(build_normals)
-        normal_component_index = model_output->addVertexComponent( Utilities::ModelBuilder::NORMAL_COMPONENT_NAME, Utilities::DataTypes::ComponentType::FLOAT, Utilities::DataTypes::Type::VEC3 );
+        normal_component_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::NORMAL_COMPONENT_NAME, Utilities::DataTypes::ComponentType::FLOAT, Utilities::DataTypes::Type::VEC3 );
 
-    unsigned int color_component_index = model_output->addVertexComponent( Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC4, true );
-    unsigned int tex_coord_component_index = model_output->addVertexComponent( Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC2, true );
+    unsigned int color_component_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC4, true );
+    unsigned int tex_coord_component_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC2, true );
     unsigned int metadata_component_index = -1;
     unsigned int joints_0_component_index = -1;
     unsigned int weights_0_component_index = -1;
 
     if(!exclude_metadata)
-        metadata_component_index = model_output->addVertexComponent( METADATA_COMPONENT_NAME, Utilities::DataTypes::ComponentType::SHORT, Utilities::DataTypes::Type::VEC2, false );
+        metadata_component_index = model_output_p->addVertexComponent( METADATA_COMPONENT_NAME, Utilities::DataTypes::ComponentType::SHORT, Utilities::DataTypes::Type::VEC2, false );
 
     if( !bones.empty() ) {
-        joints_0_component_index  = model_output->addVertexComponent( Utilities::ModelBuilder::JOINTS_INDEX_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC4, false );
-        weights_0_component_index = model_output->addVertexComponent( Utilities::ModelBuilder::WEIGHTS_INDEX_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC4, true );
+        joints_0_component_index  = model_output_p->addVertexComponent( Utilities::ModelBuilder::JOINTS_INDEX_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC4, false );
+        weights_0_component_index = model_output_p->addVertexComponent( Utilities::ModelBuilder::WEIGHTS_INDEX_0_COMPONENT_NAME, Utilities::DataTypes::ComponentType::UNSIGNED_BYTE, Utilities::DataTypes::Type::VEC4, true );
 
-        model_output->allocateJoints( bones.size(), bone_frames );
+        model_output_p->allocateJoints( bones.size(), bone_frames );
         
         glm::mat4 bone_matrix;
         
@@ -2458,7 +2458,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
             childern[ bones.at( bone_index ).parent_amount - 1 ] = bone_index;
             
             if( bones.at( bone_index ).parent_amount > 1 )
-                model_output->setJointParent( childern[ bones.at( bone_index ).parent_amount - 2 ], bone_index );
+                model_output_p->setJointParent( childern[ bones.at( bone_index ).parent_amount - 2 ], bone_index );
         }
 
         for( unsigned int bone_index = 0; bone_index < bones.size(); bone_index++ ) {
@@ -2491,7 +2491,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
                 auto position  = glm::vec3( -frame_position.x, frame_position.y, frame_position.z ) * static_cast<float>( FIXED_POINT_UNIT );
                 auto quaterion = glm::quat_cast( bone_matrix );
                 
-                model_output->setJointFrame( frame, bone_index, position, quaterion );
+                model_output_p->setJointFrame( frame, bone_index, position, quaterion );
             }
         }
     }
@@ -2499,19 +2499,19 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
     unsigned int normal_morph_component_index = -1;
 
     if( vertex_data.get3DRFSize() > 1 ) {
-        position_morph_component_index = model_output->setVertexComponentMorph( position_component_index );
+        position_morph_component_index = model_output_p->setVertexComponentMorph( position_component_index );
 
         if(build_normals)
-            normal_morph_component_index = model_output->setVertexComponentMorph( normal_component_index );
+            normal_morph_component_index = model_output_p->setVertexComponentMorph( normal_component_index );
     }
 
     // Setup the vertex components now that every field had been entered.
-    model_output->setupVertexComponents( vertex_data.get3DRFSize() - 1 );
+    model_output_p->setupVertexComponents( vertex_data.get3DRFSize() - 1 );
 
-    model_output->allocateVertices( triangle_buffer.size() * 3 );
+    model_output_p->allocateVertices( triangle_buffer.size() * 3 );
 
     if( texture_references.size() == 0 )
-        model_output->setMaterial( "" );
+        model_output_p->setMaterial( "" );
 
     glm::i16vec2 metadata;
 
@@ -2532,7 +2532,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
             if( texture_references.at( t_index ).resource_id == (*count_it).first ) {
 
                 // Set this material.
-                model_output->setMaterial( texture_references.at( t_index ).name, texture_references.at( t_index ).resource_id, true );
+                model_output_p->setMaterial( texture_references.at( t_index ).name, texture_references.at( t_index ).resource_id, true );
 
                 // The material is found.
                 found = true;
@@ -2560,16 +2560,16 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
                 if( (*triangle).bmp_id == (*previous_triangle).bmp_id )
                 {
                     if( (*previous_triangle).visual.visability < (*triangle).visual.visability )
-                        model_output->beginSemiTransperency( (*triangle).visual.visability == VisabilityMode::ADDITION );
+                        model_output_p->beginSemiTransperency( (*triangle).visual.visability == VisabilityMode::ADDITION );
                     else if( (*previous_triangle).visual.visability > (*triangle).visual.visability )
                         assert( false && "Sorting is wrong!" );
                 }
                 else if( (*triangle).visual.visability != VisabilityMode::OPAQUE ) {
-                    model_output->beginSemiTransperency( (*triangle).visual.visability == VisabilityMode::ADDITION );
+                    model_output_p->beginSemiTransperency( (*triangle).visual.visability == VisabilityMode::ADDITION );
                 }
             }
             else if( (*triangle).visual.visability != VisabilityMode::OPAQUE ) {
-                model_output->beginSemiTransperency( (*triangle).visual.visability == VisabilityMode::ADDITION );
+                model_output_p->beginSemiTransperency( (*triangle).visual.visability == VisabilityMode::ADDITION );
             }
 
             for( unsigned vertex_index = 0; vertex_index < 3; vertex_index++ ) {
@@ -2579,22 +2579,22 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
 
                 assert(point.face_override_index <= 4 * face_type_overrides.size());
 
-                model_output->startVertex();
+                model_output_p->startVertex();
 
-                model_output->setVertexData( position_component_index, Utilities::DataTypes::Vec3Type( point.position ) );
+                model_output_p->setVertexData( position_component_index, Utilities::DataTypes::Vec3Type( point.position ) );
 
                 if(build_normals)
-                    model_output->setVertexData( normal_component_index, Utilities::DataTypes::Vec3Type( point.normal ) );
+                    model_output_p->setVertexData( normal_component_index, Utilities::DataTypes::Vec3Type( point.normal ) );
 
                 if(vertex_index != 1 && (*triangle).visual.is_color_fade)
-                    model_output->setVertexData( color_component_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4(0, 0, 0, 0) ) );
+                    model_output_p->setVertexData( color_component_index, Utilities::DataTypes::Vec4UByteType( glm::u8vec4(0, 0, 0, 0) ) );
                 else
-                    model_output->setVertexData( color_component_index, Utilities::DataTypes::Vec4UByteType( (*triangle).color ) );
+                    model_output_p->setVertexData( color_component_index, Utilities::DataTypes::Vec4UByteType( (*triangle).color ) );
 
-                model_output->setVertexData( tex_coord_component_index, Utilities::DataTypes::Vec2UByteType(  point.coords ) );
+                model_output_p->setVertexData( tex_coord_component_index, Utilities::DataTypes::Vec2UByteType(  point.coords ) );
 
                 if(!exclude_metadata)
-                    model_output->setVertexData( metadata_component_index, Utilities::DataTypes::Vec2SShortType( metadata ) );
+                    model_output_p->setVertexData( metadata_component_index, Utilities::DataTypes::Vec2SShortType( metadata ) );
 
                 auto morph_triangle_frame = morph_triangle;
 
@@ -2602,16 +2602,16 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
                 {
                     const MorphPoint morph_point = (*morph_triangle_frame).points[vertex_index];
 
-                    model_output->addMorphVertexData( position_morph_component_index, morph_frames, Utilities::DataTypes::Vec3Type( point.position ), Utilities::DataTypes::Vec3Type( morph_point.position ) );
+                    model_output_p->addMorphVertexData( position_morph_component_index, morph_frames, Utilities::DataTypes::Vec3Type( point.position ), Utilities::DataTypes::Vec3Type( morph_point.position ) );
 
                     if(build_normals)
-                        model_output->addMorphVertexData( normal_morph_component_index, morph_frames, Utilities::DataTypes::Vec3Type( point.normal ),   Utilities::DataTypes::Vec3Type( morph_point.normal ) );
+                        model_output_p->addMorphVertexData( normal_morph_component_index, morph_frames, Utilities::DataTypes::Vec3Type( point.normal ),   Utilities::DataTypes::Vec3Type( morph_point.normal ) );
 
                     morph_triangle_frame++;
                 }
                 if( !bones.empty() ) {
-                    model_output->setVertexData( joints_0_component_index, Utilities::DataTypes::Vec4UByteType( point.joints ) );
-                    model_output->setVertexData( weights_0_component_index, Utilities::DataTypes::Vec4UByteType( point.weights ) );
+                    model_output_p->setVertexData( joints_0_component_index, Utilities::DataTypes::Vec4UByteType( point.joints ) );
+                    model_output_p->setVertexData( weights_0_component_index, Utilities::DataTypes::Vec4UByteType( point.weights ) );
                 }
             }
 
@@ -2623,9 +2623,9 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
         }
     }
     
-    model_output->finish();
+    model_output_p->finish();
     
-    return model_output;
+    return model_output_p;
 }
 
 Utilities::ModelBuilder * Data::Mission::ObjResource::createBoundingBoxes() const {

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2172,15 +2172,7 @@ int Data::Mission::ObjResource::write( const std::string& file_path, const Data:
     return glTF_return;
 }
 
-#define BOUNDS(v) \
-min.x = std::min(min.x, v.x);\
-min.y = std::min(min.y, v.y);\
-min.z = std::min(min.z, v.z);\
-max.x = std::max(max.x, v.x);\
-max.y = std::max(max.y, v.y);\
-max.z = std::max(max.z, v.z)
-
-std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource::generateFacingPolygons(unsigned &triangle_amount, uint32_t index, glm::vec3 *sphere_position_r, float *radius_r) const {
+std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource::generateFacingPolygons(unsigned &triangle_amount, uint32_t index) const {
     std::vector<Data::Mission::ObjResource::FacerPolygon> polys;
     FacerPolygon facer_polygon;
 
@@ -2191,9 +2183,6 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
     const glm::i16vec3 *positions_r = vertex_data.get4DVLPointer(v_frame_id);
     const glm::i16vec3 *normals_r   = vertex_data.get4DNLPointer(n_frame_id);
     const uint16_t     *lengths_r   = vertex_data.get3DRLPointer(r_frame_id);
-
-    glm::vec3 min =  glm::vec3(std::numeric_limits<float>::max());
-    glm::vec3 max = -glm::vec3(std::numeric_limits<float>::max());
 
     triangle_amount = 0;
 
@@ -2229,22 +2218,44 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
         triangle_amount += facer_polygon.primitive.star.vertex_count;
 
         polys.push_back( facer_polygon );
-
-        BOUNDS((facer_polygon.primitive.star.point.position + glm::vec3( facer_polygon.width, 0, 0)) );
-        BOUNDS((facer_polygon.primitive.star.point.position - glm::vec3( facer_polygon.width, 0, 0)) );
-        BOUNDS((facer_polygon.primitive.star.point.position + glm::vec3( 0, facer_polygon.width, 0)) );
-        BOUNDS((facer_polygon.primitive.star.point.position - glm::vec3( 0, facer_polygon.width, 0)) );
-        BOUNDS((facer_polygon.primitive.star.point.position + glm::vec3( 0, 0, facer_polygon.width)) );
-        BOUNDS((facer_polygon.primitive.star.point.position - glm::vec3( 0, 0, facer_polygon.width)) );
     }
 
-    if(sphere_position_r != nullptr)
-        *sphere_position_r = (max + min) * 0.5f;
-
-    if(radius_r != nullptr)
-        *radius_r = glm::distance(max, min) * 0.5f;
-
     return polys;
+}
+
+#define BOUNDS(v) \
+min.x = std::min(min.x, v.x);\
+min.y = std::min(min.y, v.y);\
+min.z = std::min(min.z, v.z);\
+max.x = std::max(max.x, v.x);\
+max.y = std::max(max.y, v.y);\
+max.z = std::max(max.z, v.z)
+
+bool Data::Mission::ObjResource::getBoundingSphereFacingPolygons(const std::vector<FacerPolygon> polygons, glm::vec3 &sphere_position, float &radius) const {
+    bool has_data = false;
+    glm::vec3 min =  glm::vec3(std::numeric_limits<float>::max());
+    glm::vec3 max = -glm::vec3(std::numeric_limits<float>::max());
+
+    for(const FacerPolygon &facer_polygon: polygons) {
+        if(facer_polygon.type == FacerPolygon::STAR) {
+            BOUNDS((facer_polygon.primitive.star.point.position + glm::vec3( facer_polygon.width, 0, 0)) );
+            BOUNDS((facer_polygon.primitive.star.point.position - glm::vec3( facer_polygon.width, 0, 0)) );
+            BOUNDS((facer_polygon.primitive.star.point.position + glm::vec3( 0, facer_polygon.width, 0)) );
+            BOUNDS((facer_polygon.primitive.star.point.position - glm::vec3( 0, facer_polygon.width, 0)) );
+            BOUNDS((facer_polygon.primitive.star.point.position + glm::vec3( 0, 0, facer_polygon.width)) );
+            BOUNDS((facer_polygon.primitive.star.point.position - glm::vec3( 0, 0, facer_polygon.width)) );
+
+            has_data = true;
+        }
+    }
+
+    if(!has_data)
+        return false;
+
+    sphere_position = (max + min) * 0.5f;
+    radius = glm::distance(max, min) * 0.5f;
+
+    return true;
 }
 
 bool Data::Mission::ObjResource::loadTextures( const std::vector<BMPResource*> &textures ) {

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2195,6 +2195,14 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
         facer_polygon.primitive.star.point.position = glm::vec3(positions_r[(*i).v[0]]) * FIXED_POINT_UNIT;
         facer_polygon.primitive.star.point.weights  = glm::u8vec4(0);
         facer_polygon.primitive.star.point.joints   = glm::u8vec4(0);
+        for(auto it = this->bones.cbegin(); it != this->bones.cend(); it++) {
+            const Bone& bone = (*it);
+
+            if( (*i).v[0] >= bone.vertex_start && (*i).v[0] < bone.vertex_start + bone.vertex_stride ) {
+                facer_polygon.primitive.star.point.weights.x = 0xFF;
+                facer_polygon.primitive.star.point.joints.x = it - this->bones.cbegin();
+            }
+        }
 
         polys.push_back( facer_polygon );
     }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2172,7 +2172,7 @@ int Data::Mission::ObjResource::write( const std::string& file_path, const Data:
     return glTF_return;
 }
 
-std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource::generateFacingPolygons(uint32_t index) const {
+std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource::generateFacingPolygons(unsigned &triangle_amount, uint32_t index) const {
     std::vector<Data::Mission::ObjResource::FacerPolygon> polys;
     FacerPolygon facer_polygon;
 
@@ -2183,6 +2183,8 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
     const glm::i16vec3 *positions_r = vertex_data.get4DVLPointer(v_frame_id);
     const glm::i16vec3 *normals_r   = vertex_data.get4DNLPointer(n_frame_id);
     const uint16_t     *lengths_r   = vertex_data.get3DRLPointer(r_frame_id);
+
+    triangle_amount = 0;
 
     // Add the stars.
     for( auto i = face_stars.begin(); i != face_stars.end(); i++ ) {
@@ -2203,6 +2205,8 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
                 facer_polygon.primitive.star.point.joints.x = it - this->bones.cbegin();
             }
         }
+
+        triangle_amount += 8;
 
         polys.push_back( facer_polygon );
     }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2216,14 +2216,12 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
 
             facer_polygon.primitive.star.time_index  = (*i).vertex_color_override_index;
             facer_polygon.primitive.star.other_color = glm::vec3(1.);
-            facer_polygon.primitive.star.blink_rate  = 0;
 
             if(facer_polygon.primitive.star.time_index != 0) {
                 const auto &face_color_override = face_color_overrides.at(facer_polygon.primitive.star.time_index - 1);
 
                 facer_polygon.color                      = face_color_override.colors[0];
                 facer_polygon.primitive.star.other_color = face_color_override.colors[1];
-                facer_polygon.primitive.star.blink_rate  = face_color_override.speed_factor;
             }
 
             polys.push_back( facer_polygon );

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -200,7 +200,7 @@ bool Data::Mission::ObjResource::Primitive::operator() ( const Primitive & l_ope
         return (l_operand.visual.visability < r_operand.visual.visability);
 }
 
-int Data::Mission::ObjResource::Primitive::setCircle(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
+int Data::Mission::ObjResource::Primitive::setStar(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
     Triangle triangle;
     MorphTriangle morph_triangle;
     int16_t     tex_animation_index[2][3];
@@ -229,13 +229,13 @@ int Data::Mission::ObjResource::Primitive::setCircle(const VertexData& vertex_da
 
     // face_type_offset // Unknown. They range from 4, 8, and 12.
 
-    // this->v[0] // Actual vertex index. Origin of circle.
+    // this->v[0] // Actual vertex index. Origin of star.
 
     // this->v[1] // Red
     // this->v[2] // Green
     // this->v[3] // Blue
 
-    // this->n[0] // Actual length index. Radius of circle.
+    // this->n[0] // Actual length index. Radius of star.
 
     // this->n[1] // Always Zero
     // this->n[2] // Always Zero
@@ -265,7 +265,7 @@ int Data::Mission::ObjResource::Primitive::setCircle(const VertexData& vertex_da
 
     const float UNIT_45_DEGREES = 0.707106781187; // M_SQRT2 / 2.0;
 
-    const glm::vec2 circle_quadrant[2][3] = {
+    const glm::vec2 star_quadrant[2][3] = {
         // Triangle 0
             { { UNIT_45_DEGREES, UNIT_45_DEGREES}, { 0, 0}, { 0, 1} },
         // Triangle 1
@@ -277,57 +277,57 @@ int Data::Mission::ObjResource::Primitive::setCircle(const VertexData& vertex_da
     for( unsigned axis = 0; axis < 3; axis++ ) {
         glm::vec2 q[2][3] = {
             // Triangle 0
-                { circle_quadrant[0][0], circle_quadrant[0][1], circle_quadrant[0][2] },
+                { star_quadrant[0][0], star_quadrant[0][1], star_quadrant[0][2] },
             // Triangle 1
-                { circle_quadrant[1][0], circle_quadrant[1][1], circle_quadrant[1][2] }
+                { star_quadrant[1][0], star_quadrant[1][1], star_quadrant[1][2] }
         };
 
         for( unsigned quadrant = 0; quadrant < 4; quadrant++ ) {
-            glm::vec3 mapped_circle_quadrant[2][3] = {};
-            glm::vec3 circle_direction;
+            glm::vec3 mapped_star_quadrant[2][3] = {};
+            glm::vec3 star_direction;
 
             switch(axis) {
                 case 0:
-                    mapped_circle_quadrant[0][0] = {q[0][0].x, 0, q[0][0].y};
-                    mapped_circle_quadrant[0][1] = {q[0][1].x, 0, q[0][1].y};
-                    mapped_circle_quadrant[0][2] = {q[0][2].x, 0, q[0][2].y};
+                    mapped_star_quadrant[0][0] = {q[0][0].x, 0, q[0][0].y};
+                    mapped_star_quadrant[0][1] = {q[0][1].x, 0, q[0][1].y};
+                    mapped_star_quadrant[0][2] = {q[0][2].x, 0, q[0][2].y};
 
-                    mapped_circle_quadrant[1][0] = {q[1][0].x, 0, q[1][0].y};
-                    mapped_circle_quadrant[1][1] = {q[1][1].x, 0, q[1][1].y};
-                    mapped_circle_quadrant[1][2] = {q[1][2].x, 0, q[1][2].y};
+                    mapped_star_quadrant[1][0] = {q[1][0].x, 0, q[1][0].y};
+                    mapped_star_quadrant[1][1] = {q[1][1].x, 0, q[1][1].y};
+                    mapped_star_quadrant[1][2] = {q[1][2].x, 0, q[1][2].y};
 
-                    circle_direction = glm::vec3(0, 1, 0);
+                    star_direction = glm::vec3(0, 1, 0);
                     break;
 
                 case 1:
-                    mapped_circle_quadrant[0][0] = {q[0][0].x, q[0][0].y, 0};
-                    mapped_circle_quadrant[0][1] = {q[0][1].x, q[0][1].y, 0};
-                    mapped_circle_quadrant[0][2] = {q[0][2].x, q[0][2].y, 0};
+                    mapped_star_quadrant[0][0] = {q[0][0].x, q[0][0].y, 0};
+                    mapped_star_quadrant[0][1] = {q[0][1].x, q[0][1].y, 0};
+                    mapped_star_quadrant[0][2] = {q[0][2].x, q[0][2].y, 0};
 
-                    mapped_circle_quadrant[1][0] = {q[1][0].x, q[1][0].y, 0};
-                    mapped_circle_quadrant[1][1] = {q[1][1].x, q[1][1].y, 0};
-                    mapped_circle_quadrant[1][2] = {q[1][2].x, q[1][2].y, 0};
+                    mapped_star_quadrant[1][0] = {q[1][0].x, q[1][0].y, 0};
+                    mapped_star_quadrant[1][1] = {q[1][1].x, q[1][1].y, 0};
+                    mapped_star_quadrant[1][2] = {q[1][2].x, q[1][2].y, 0};
 
-                    circle_direction = glm::vec3(0, 0, -1);
+                    star_direction = glm::vec3(0, 0, -1);
                     break;
 
                 case 2:
-                    mapped_circle_quadrant[0][0] = {0, q[0][0].x, q[0][0].y};
-                    mapped_circle_quadrant[0][1] = {0, q[0][1].x, q[0][1].y};
-                    mapped_circle_quadrant[0][2] = {0, q[0][2].x, q[0][2].y};
+                    mapped_star_quadrant[0][0] = {0, q[0][0].x, q[0][0].y};
+                    mapped_star_quadrant[0][1] = {0, q[0][1].x, q[0][1].y};
+                    mapped_star_quadrant[0][2] = {0, q[0][2].x, q[0][2].y};
 
-                    mapped_circle_quadrant[1][0] = {0, q[1][0].x, q[1][0].y};
-                    mapped_circle_quadrant[1][1] = {0, q[1][1].x, q[1][1].y};
-                    mapped_circle_quadrant[1][2] = {0, q[1][2].x, q[1][2].y};
+                    mapped_star_quadrant[1][0] = {0, q[1][0].x, q[1][0].y};
+                    mapped_star_quadrant[1][1] = {0, q[1][1].x, q[1][1].y};
+                    mapped_star_quadrant[1][2] = {0, q[1][2].x, q[1][2].y};
 
-                    circle_direction = glm::vec3(-1, 0, 0);
+                    star_direction = glm::vec3(-1, 0, 0);
                     break;
             }
 
             // Triangle 0
             for( unsigned i = 0; i < 3; i++ ) {
-                triangle.points[i].position = center + length_90d * mapped_circle_quadrant[0][i];
-                triangle.points[i].normal = circle_direction;
+                triangle.points[i].position = center + length_90d * mapped_star_quadrant[0][i];
+                triangle.points[i].normal = star_direction;
                 triangle.points[i].coords = glm::u8vec2( 0x00, 0x00 );
                 triangle.points[i].face_override_index = 0;
             }
@@ -344,8 +344,8 @@ int Data::Mission::ObjResource::Primitive::setCircle(const VertexData& vertex_da
                 morph_length_90d = anm_lengths_r[ n[0] ] * FIXED_POINT_UNIT;
 
                 for( unsigned i = 0; i < 3; i++ ) {
-                    morph_triangle.points[i].position = morph_center + morph_length_90d * mapped_circle_quadrant[0][i];
-                    morph_triangle.points[i].normal = circle_direction;
+                    morph_triangle.points[i].position = morph_center + morph_length_90d * mapped_star_quadrant[0][i];
+                    morph_triangle.points[i].normal = star_direction;
                 }
 
                 morph_triangles.push_back( morph_triangle );
@@ -353,9 +353,9 @@ int Data::Mission::ObjResource::Primitive::setCircle(const VertexData& vertex_da
 
             triangle.switchPoints();
 
-            circle_direction = -circle_direction;
+            star_direction = -star_direction;
             for( unsigned i = 0; i < 3; i++ ) {
-                triangle.points[i].normal = circle_direction;
+                triangle.points[i].normal = star_direction;
             }
 
             triangles.push_back( triangle );
@@ -370,19 +370,19 @@ int Data::Mission::ObjResource::Primitive::setCircle(const VertexData& vertex_da
                 morph_length_90d = anm_lengths_r[ n[0] ] * FIXED_POINT_UNIT;
 
                 for( unsigned i = 0; i < 3; i++ ) {
-                    morph_triangle.points[i].position = morph_center + morph_length_90d * mapped_circle_quadrant[0][2 - i];
-                    morph_triangle.points[i].normal = circle_direction;
+                    morph_triangle.points[i].position = morph_center + morph_length_90d * mapped_star_quadrant[0][2 - i];
+                    morph_triangle.points[i].normal = star_direction;
                 }
 
                 morph_triangles.push_back( morph_triangle );
             }
 
-            circle_direction = -circle_direction;
+            star_direction = -star_direction;
 
             // Triangle 1
             for( unsigned i = 0; i < 3; i++ ) {
-                triangle.points[i].position = center + length_90d * mapped_circle_quadrant[1][i];
-                triangle.points[i].normal = circle_direction;
+                triangle.points[i].position = center + length_90d * mapped_star_quadrant[1][i];
+                triangle.points[i].normal = star_direction;
                 triangle.points[i].coords = glm::u8vec2( 0x00, 0x00 );
                 triangle.points[i].face_override_index = 0;
             }
@@ -399,17 +399,17 @@ int Data::Mission::ObjResource::Primitive::setCircle(const VertexData& vertex_da
                 morph_length_90d = anm_lengths_r[ n[0] ] * FIXED_POINT_UNIT;
 
                 for( unsigned i = 0; i < 3; i++ ) {
-                    morph_triangle.points[i].position = morph_center + morph_length_90d * mapped_circle_quadrant[1][i];
-                    morph_triangle.points[i].normal = circle_direction;
+                    morph_triangle.points[i].position = morph_center + morph_length_90d * mapped_star_quadrant[1][i];
+                    morph_triangle.points[i].normal = star_direction;
                 }
 
                 morph_triangles.push_back( morph_triangle );
             }
 
             triangle.switchPoints();
-            circle_direction = -circle_direction;
+            star_direction = -star_direction;
             for( unsigned i = 0; i < 3; i++ ) {
-                triangle.points[i].normal = circle_direction;
+                triangle.points[i].normal = star_direction;
             }
             triangles.push_back( triangle );
 
@@ -423,8 +423,8 @@ int Data::Mission::ObjResource::Primitive::setCircle(const VertexData& vertex_da
                 morph_length_90d = anm_lengths_r[ n[0] ] * FIXED_POINT_UNIT;
 
                 for( unsigned i = 0; i < 3; i++ ) {
-                    morph_triangle.points[i].position = morph_center + morph_length_90d * mapped_circle_quadrant[1][2 - i];
-                    morph_triangle.points[i].normal = circle_direction;
+                    morph_triangle.points[i].position = morph_center + morph_length_90d * mapped_star_quadrant[1][2 - i];
+                    morph_triangle.points[i].normal = star_direction;
                 }
 
                 morph_triangles.push_back( morph_triangle );
@@ -1678,7 +1678,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
 
                     // TODO 3DAL is almost like 3DTA
 
-                    // c_3DAL_data[0] = reader3DAL.readU8(); // 3DQL index to primative type circle or zero.
+                    // c_3DAL_data[0] = reader3DAL.readU8(); // 3DQL index to primative type star or zero.
                     // c_3DAL_data[1] = reader3DAL.readU8(); // Speed value?
                     // c_3DAL_data[2] = reader3DAL.readU8(); // Red[0]
                     // c_3DAL_data[3] = reader3DAL.readU8(); // Green[0]
@@ -2367,7 +2367,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
 
         for( auto i = primitive_buffer.begin(); i != primitive_buffer.end(); i++ ) {
             if( (*i).type == PrimitiveType::STAR )
-                (*i).setCircle(vertex_data, triangle_buffer, morph_triangle_buffer, bones);
+                (*i).setStar(vertex_data, triangle_buffer, morph_triangle_buffer, bones);
             else if( (*i).type == PrimitiveType::TRIANGLE )
                 (*i).setTriangle(vertex_data, triangle_buffer, morph_triangle_buffer, bones);
             else if( (*i).type == PrimitiveType::QUAD )

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2210,8 +2210,10 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
 
         if((*i).face_type_offset <= 4)
             facer_polygon.primitive.star.vertex_count = 4;
-        else
+        else if((*i).face_type_offset <= 8)
             facer_polygon.primitive.star.vertex_count = 8;
+        else
+            facer_polygon.primitive.star.vertex_count = 12;
 
         triangle_amount += facer_polygon.primitive.star.vertex_count;
 

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -1676,16 +1676,17 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                     if(count != 1)
                         warning_log.output << "3DAL count = " << std::dec << count << ".\n";
 
-                    // TODO 3DAL is almost like 3DTA
+                    // 3DAL is almost like 3DTA
+                    face_color_override.push_back(VertexColorOverride());
 
-                    // c_3DAL_data[0] = reader3DAL.readU8(); // 3DQL index to primative type star or zero.
-                    // c_3DAL_data[1] = reader3DAL.readU8(); // Speed value?
-                    // c_3DAL_data[2] = reader3DAL.readU8(); // Red[0]
-                    // c_3DAL_data[3] = reader3DAL.readU8(); // Green[0]
-                    // c_3DAL_data[4] = reader3DAL.readU8(); // Blue[0]
-                    // c_3DAL_data[5] = reader3DAL.readU8(); // Red[1]
-                    // c_3DAL_data[6] = reader3DAL.readU8(); // Green[1]
-                    // c_3DAL_data[7] = reader3DAL.readU8(); // Blue[1]
+                    face_color_override.back().face_index = reader3DAL.readU8();                // 3DQL index to primative type star
+                    face_color_override.back().speed_factor = 1.0f; reader3DAL.readU8();        // TODO Decode the speed value.
+                    face_color_override.back().colors[0].r = reader3DAL.readU8() * (1. / 256.); //   Red[0]
+                    face_color_override.back().colors[0].g = reader3DAL.readU8() * (1. / 256.); // Green[0]
+                    face_color_override.back().colors[0].b = reader3DAL.readU8() * (1. / 256.); //  Blue[0]
+                    face_color_override.back().colors[1].r = reader3DAL.readU8() * (1. / 256.); //   Red[1]
+                    face_color_override.back().colors[1].g = reader3DAL.readU8() * (1. / 256.); // Green[1]
+                    face_color_override.back().colors[1].b = reader3DAL.readU8() * (1. / 256.); //  Blue[1]
                 }
             }
             else

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -1482,9 +1482,9 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
 
                     Primitive primitive;
 
-                    primitive.face_type_offset        = face_type_offset;
-                    primitive.face_type_r             = nullptr;
-                    primitive.vertex_color_override_r = nullptr;
+                    primitive.face_type_offset            = face_type_offset;
+                    primitive.face_type_r                 = nullptr;
+                    primitive.vertex_color_override_index = 0;
 
                     primitive.visual.uses_texture       = is_texture;
                     primitive.visual.normal_shading     = normal_shadows;
@@ -2071,7 +2071,7 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
 
             if(primitives.size() > face_color_override.face_index) {
                 if(primitives.at(face_color_override.face_index).type == PrimitiveType::STAR)
-                    primitives[face_color_override.face_index].vertex_color_override_r = &(*i);
+                    primitives[face_color_override.face_index].vertex_color_override_index = (i - this->face_color_overrides.begin()) + 1;
             }
         }
 
@@ -2213,6 +2213,18 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
                 facer_polygon.primitive.star.vertex_count = 12;
 
             triangle_amount += facer_polygon.primitive.star.vertex_count;
+
+            facer_polygon.primitive.star.time_index  = (*i).vertex_color_override_index;
+            facer_polygon.primitive.star.other_color = glm::vec3(1.);
+            facer_polygon.primitive.star.blink_rate  = 0;
+
+            if(facer_polygon.primitive.star.time_index != 0) {
+                const auto &face_color_override = face_color_overrides.at(facer_polygon.primitive.star.time_index - 1);
+
+                facer_polygon.color                      = face_color_override.colors[0];
+                facer_polygon.primitive.star.other_color = face_color_override.colors[1];
+                facer_polygon.primitive.star.blink_rate  = face_color_override.speed_factor;
+            }
 
             polys.push_back( facer_polygon );
         }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -438,7 +438,7 @@ int Data::Mission::ObjResource::Primitive::setCircle(const VertexData& vertex_da
         }
     }
 
-    return getTriangleAmount( PrimitiveType::CIRCLE );
+    return getTriangleAmount( PrimitiveType::STAR );
 }
 
 int Data::Mission::ObjResource::Primitive::setTriangle(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const {
@@ -1008,7 +1008,7 @@ int Data::Mission::ObjResource::Primitive::setLine(const VertexData& vertex_data
 
 size_t Data::Mission::ObjResource::Primitive::getTriangleAmount( PrimitiveType type ) {
     switch( type ) {
-        case PrimitiveType::CIRCLE:
+        case PrimitiveType::STAR:
             return 48;
         case PrimitiveType::TRIANGLE:
         case PrimitiveType::TRIANGLE_OTHER:
@@ -1544,8 +1544,8 @@ bool Data::Mission::ObjResource::parse( const ParseSettings &settings ) {
                             primitive.visual.is_reflective      = false;
                             primitive.visual.is_color_fade      = true;
 
-                            primitive.type = PrimitiveType::CIRCLE;
-                            face_circles.push_back( primitive );
+                            primitive.type = PrimitiveType::STAR;
+                            face_stars.push_back( primitive );
                             break;
                         default:
                         {
@@ -2286,7 +2286,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
 
         if(allowed_primitives.star) {
             // Add the stars.
-            for( auto i = face_circles.begin(); i != face_circles.end(); i++ )
+            for( auto i = face_stars.begin(); i != face_stars.end(); i++ )
                 primitive_buffer.push_back( (*i) );
         }
 
@@ -2328,7 +2328,7 @@ Utilities::ModelBuilder * Data::Mission::ObjResource::createMesh( bool exclude_m
         }
 
         for( auto i = primitive_buffer.begin(); i != primitive_buffer.end(); i++ ) {
-            if( (*i).type == PrimitiveType::CIRCLE )
+            if( (*i).type == PrimitiveType::STAR )
                 (*i).setCircle(vertex_data, triangle_buffer, morph_triangle_buffer, bones);
             else if( (*i).type == PrimitiveType::TRIANGLE )
                 (*i).setTriangle(vertex_data, triangle_buffer, morph_triangle_buffer, bones);

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2206,7 +2206,14 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
             }
         }
 
-        triangle_amount += 4;
+        facer_polygon.primitive.star.vertex_count = 0;
+
+        if((*i).face_type_offset <= 4)
+            facer_polygon.primitive.star.vertex_count = 4;
+        else
+            facer_polygon.primitive.star.vertex_count = 8;
+
+        triangle_amount += facer_polygon.primitive.star.vertex_count;
 
         polys.push_back( facer_polygon );
     }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2206,7 +2206,7 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
             }
         }
 
-        triangle_amount += 2;
+        triangle_amount += 4;
 
         polys.push_back( facer_polygon );
     }

--- a/src/Data/Mission/ObjResource.cpp
+++ b/src/Data/Mission/ObjResource.cpp
@@ -2206,7 +2206,7 @@ std::vector<Data::Mission::ObjResource::FacerPolygon> Data::Mission::ObjResource
             }
         }
 
-        triangle_amount += 8;
+        triangle_amount += 1;
 
         polys.push_back( facer_polygon );
     }

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -222,7 +222,7 @@ public:
         unsigned billboard: 1;
         unsigned line:      1;
     };
-    struct FacerPolygons {
+    struct FacerPolygon {
         enum Type {
             STAR,
             BILLBOARD,
@@ -246,6 +246,12 @@ public:
                 glm::u8vec2 coords[4];
             } line;
         } primitive;
+    };
+    struct AdvancedRendering {
+    private:
+
+    public:
+        AdvancedRendering(const Utilities::ModelBuilder &model_builder);
     };
 private:
     struct {
@@ -288,6 +294,9 @@ private:
      * @return A zero if either the opcode does not exist or the bytes per frame rating for the opcode.
      */
     static unsigned int getOpcodeBytesPerFrame( Bone::Opcode opcode );
+
+    std::vector<FacerPolygon> generateFacingPolygons(uint32_t index) const;
+
 public:
     ObjResource();
     virtual ~ObjResource();

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -215,6 +215,13 @@ public:
         uint32_t resource_id;
         std::string name;
     };
+    struct AllowedPrimitives {
+        unsigned star:      1;
+        unsigned triangle:  1;
+        unsigned quad:      1;
+        unsigned billboard: 1;
+        unsigned line:      1;
+    };
 private:
     struct {
         unsigned has_skeleton:     1;
@@ -281,7 +288,7 @@ public:
 
     virtual Utilities::ModelBuilder * createModel() const;
     
-    Utilities::ModelBuilder * createMesh( bool exclude_metadata, bool force_normal ) const;
+    Utilities::ModelBuilder * createMesh( bool exclude_metadata, bool force_normal, AllowedPrimitives allowed_primitives ) const;
     Utilities::ModelBuilder * createBoundingBoxes() const;
 };
 

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -315,7 +315,7 @@ public:
     const std::vector<FaceOverrideType>& getFaceOverrideTypes() const { return face_type_overrides; }
     const std::vector<glm::u8vec2>& getFaceOverrideData() const { return override_uvs; }
 
-    std::vector<FacerPolygon> generateFacingPolygons(unsigned &triangle_amount, uint32_t index) const;
+    std::vector<FacerPolygon> generateFacingPolygons(unsigned &triangle_amount, uint32_t index, glm::vec3 *sphere_position_r = nullptr, float *radius_r = nullptr) const;
 
     bool loadTextures( const std::vector<BMPResource*> &textures );
 

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -86,6 +86,11 @@ public:
 
         glm::u8vec4 getColor( Material material ) const;
     };
+    struct VertexColorOverride {
+        unsigned face_index;
+        float speed_factor;
+        glm::vec3 colors[2];
+    };
     struct Point {
         glm::vec3 position;
         glm::vec3 normal;
@@ -269,6 +274,7 @@ private:
     std::map<uint_fast16_t, FaceType> face_types;
     std::vector<FaceOverrideType>     face_type_overrides;
     std::vector<glm::u8vec2>          override_uvs;
+    std::vector<VertexColorOverride>  face_color_override;
 
     std::vector<Primitive> face_stars;
     std::vector<Primitive> face_triangles;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -274,13 +274,9 @@ private:
     std::map<uint_fast16_t, FaceType> face_types;
     std::vector<FaceOverrideType>     face_type_overrides;
     std::vector<glm::u8vec2>          override_uvs;
-    std::vector<VertexColorOverride>  face_color_override;
+    std::vector<VertexColorOverride>  face_color_overrides;
 
-    std::vector<Primitive> face_stars;
-    std::vector<Primitive> face_triangles;
-    std::vector<Primitive> face_quads;
-    std::vector<Primitive> face_billboards;
-    std::vector<Primitive> face_lines;
+    std::vector<Primitive> primitives;
 
     std::vector<Bone>         bones;
     unsigned int              max_bone_childern; // Holds the maxium childern amount.

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -249,7 +249,7 @@ public:
                 uint32_t vertex_count;
                 uint32_t time_index;
                 glm::vec3 other_color;
-                float blink_rate;
+                float blink_rate; // NOTE: Remove this.
             } star;
             struct {
                 Point point;
@@ -320,6 +320,7 @@ public:
 
     const std::vector<FaceOverrideType>& getFaceOverrideTypes() const { return face_type_overrides; }
     const std::vector<glm::u8vec2>& getFaceOverrideData() const { return override_uvs; }
+    const std::vector<VertexColorOverride>& getVertexColorOverrides() const { return face_color_overrides; }
 
     std::vector<FacerPolygon> generateFacingPolygons(unsigned &triangle_amount, uint32_t index) const;
     bool getBoundingSphereFacingPolygons(const std::vector<FacerPolygon> polygons, glm::vec3 &sphere_position, float &radius) const;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -33,7 +33,7 @@ public:
         MIX      = 2
     };
     enum PrimitiveType {
-        CIRCLE         = 0,
+        STAR           = 0,
         TRIANGLE_OTHER = 2,
         TRIANGLE       = 3,
         QUAD           = 4,
@@ -238,7 +238,7 @@ private:
     std::vector<FaceOverrideType>     face_type_overrides;
     std::vector<glm::u8vec2>          override_uvs;
 
-    std::vector<Primitive> face_circles;
+    std::vector<Primitive> face_stars;
     std::vector<Primitive> face_triangles;
     std::vector<Primitive> face_quads;
     std::vector<Primitive> face_billboards;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -321,7 +321,7 @@ public:
     const std::vector<glm::u8vec2>& getFaceOverrideData() const { return override_uvs; }
     const std::vector<VertexColorOverride>& getVertexColorOverrides() const { return face_color_overrides; }
 
-    std::vector<FacerPolygon> generateFacingPolygons(unsigned &triangle_amount, uint32_t index) const;
+    std::vector<FacerPolygon> generateFacingPolygons(unsigned &triangle_amount, unsigned &frame_stride) const;
     bool getBoundingSphereFacingPolygons(const std::vector<FacerPolygon> polygons, glm::vec3 &sphere_position, float &radius) const;
 
     bool loadTextures( const std::vector<BMPResource*> &textures );

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -223,6 +223,12 @@ public:
         unsigned line:      1;
     };
     struct FacerPolygon {
+        struct Point {
+            glm::vec3 position;
+            glm::u8vec4 weights;
+            glm::u8vec4 joints;
+        };
+
         enum Type {
             STAR,
             BILLBOARD,
@@ -233,25 +239,19 @@ public:
         float width;
         union {
             struct {
-                glm::vec3 position;
+                Point point;
             } star;
             struct {
-                glm::vec3 position;
+                Point point;
                 uint32_t bmp_id;
                 glm::u8vec2 coords[4];
             } billboard;
             struct {
-                glm::vec3 positions[2];
+                Point point[2];
                 uint32_t bmp_id;
                 glm::u8vec2 coords[4];
             } line;
         } primitive;
-    };
-    struct AdvancedRendering {
-    private:
-
-    public:
-        AdvancedRendering(const Utilities::ModelBuilder &model_builder);
     };
 private:
     struct {
@@ -295,8 +295,6 @@ private:
      */
     static unsigned int getOpcodeBytesPerFrame( Bone::Opcode opcode );
 
-    std::vector<FacerPolygon> generateFacingPolygons(uint32_t index) const;
-
 public:
     ObjResource();
     virtual ~ObjResource();
@@ -315,6 +313,8 @@ public:
 
     const std::vector<FaceOverrideType>& getFaceOverrideTypes() const { return face_type_overrides; }
     const std::vector<glm::u8vec2>& getFaceOverrideData() const { return override_uvs; }
+
+    std::vector<FacerPolygon> generateFacingPolygons(uint32_t index) const;
 
     bool loadTextures( const std::vector<BMPResource*> &textures );
 

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -222,6 +222,31 @@ public:
         unsigned billboard: 1;
         unsigned line:      1;
     };
+    struct FacerPolygons {
+        enum Type {
+            STAR,
+            BILLBOARD,
+            LINE
+        } type;
+        VisabilityMode visability_mode;
+        glm::vec3 color;
+        float width;
+        union {
+            struct {
+                glm::vec3 position;
+            } star;
+            struct {
+                glm::vec3 position;
+                uint32_t bmp_id;
+                glm::u8vec2 coords[4];
+            } billboard;
+            struct {
+                glm::vec3 positions[2];
+                uint32_t bmp_id;
+                glm::u8vec2 coords[4];
+            } line;
+        } primitive;
+    };
 private:
     struct {
         unsigned has_skeleton:     1;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -249,7 +249,6 @@ public:
                 uint32_t vertex_count;
                 uint32_t time_index;
                 glm::vec3 other_color;
-                float blink_rate; // NOTE: Remove this.
             } star;
             struct {
                 Point point;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -191,7 +191,7 @@ public:
         uint32_t getBmpID() const;
         bool isWithinBounds( uint32_t vertex_limit, uint32_t normal_limit ) const;
 
-        int setCircle(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
+        int setStar(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
         int setTriangle(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
         int setQuad(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;
         int setBillboard(const VertexData& vertex_data, std::vector<Triangle> &triangles, std::vector<MorphTriangle> &morph_triangles, const std::vector<Bone> &bones) const;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -190,6 +190,7 @@ public:
 
         uint16_t  face_type_offset;
         FaceType *face_type_r;
+        const VertexColorOverride *vertex_color_override_r;
 
         uint8_t v[4], n[4];
 

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -314,7 +314,7 @@ public:
     const std::vector<FaceOverrideType>& getFaceOverrideTypes() const { return face_type_overrides; }
     const std::vector<glm::u8vec2>& getFaceOverrideData() const { return override_uvs; }
 
-    std::vector<FacerPolygon> generateFacingPolygons(uint32_t index) const;
+    std::vector<FacerPolygon> generateFacingPolygons(unsigned &triangle_amount, uint32_t index) const;
 
     bool loadTextures( const std::vector<BMPResource*> &textures );
 

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -240,6 +240,7 @@ public:
         union {
             struct {
                 Point point;
+                uint32_t vertex_count;
             } star;
             struct {
                 Point point;

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -315,7 +315,8 @@ public:
     const std::vector<FaceOverrideType>& getFaceOverrideTypes() const { return face_type_overrides; }
     const std::vector<glm::u8vec2>& getFaceOverrideData() const { return override_uvs; }
 
-    std::vector<FacerPolygon> generateFacingPolygons(unsigned &triangle_amount, uint32_t index, glm::vec3 *sphere_position_r = nullptr, float *radius_r = nullptr) const;
+    std::vector<FacerPolygon> generateFacingPolygons(unsigned &triangle_amount, uint32_t index) const;
+    bool getBoundingSphereFacingPolygons(const std::vector<FacerPolygon> polygons, glm::vec3 &sphere_position, float &radius) const;
 
     bool loadTextures( const std::vector<BMPResource*> &textures );
 

--- a/src/Data/Mission/ObjResource.h
+++ b/src/Data/Mission/ObjResource.h
@@ -190,7 +190,7 @@ public:
 
         uint16_t  face_type_offset;
         FaceType *face_type_r;
-        const VertexColorOverride *vertex_color_override_r;
+        unsigned vertex_color_override_index;
 
         uint8_t v[4], n[4];
 
@@ -247,6 +247,9 @@ public:
             struct {
                 Point point;
                 uint32_t vertex_count;
+                uint32_t time_index;
+                glm::vec3 other_color;
+                float blink_rate;
             } star;
             struct {
                 Point point;

--- a/src/Graphics/SDL2/GLES2/Environment.cpp
+++ b/src/Graphics/SDL2/GLES2/Environment.cpp
@@ -248,12 +248,12 @@ int Environment::loadResources( const Data::Accessor &accessor ) {
 
             if( model_r != nullptr ) {
                 if( model_r->getNumJoints() > 0 )
-                    this->skeletal_model_draw_routine.inputModel( model_r, model_types[ i ]->getResourceID(), this->textures, model_types[ i ]->getFaceOverrideTypes(), model_types[ i ]->getFaceOverrideData() );
+                    this->skeletal_model_draw_routine.inputModel( model_r, *model_types[ i ], this->textures );
                 else
                 if( model_r->getNumMorphFrames() > 0)
-                    this->morph_model_draw_routine.inputModel( model_r, model_types[ i ]->getResourceID(), this->textures, model_types[ i ]->getFaceOverrideTypes(), model_types[ i ]->getFaceOverrideData() );
+                    this->morph_model_draw_routine.inputModel( model_r, *model_types[ i ], this->textures );
                 else
-                    this->static_model_draw_routine.inputModel( model_r, model_types[ i ]->getResourceID(), this->textures, model_types[ i ]->getFaceOverrideTypes(), model_types[ i ]->getFaceOverrideData() );
+                    this->static_model_draw_routine.inputModel( model_r, *model_types[ i ], this->textures );
             }
 
             model_r = model_types[ i ]->createBoundingBoxes();

--- a/src/Graphics/SDL2/GLES2/Internal/DynamicTriangleDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/DynamicTriangleDraw.cpp
@@ -314,11 +314,11 @@ Graphics::SDL2::GLES2::Internal::DynamicTriangleDraw::DynamicTriangleDraw() {
     vertex_array.addAttribute( "TEXCOORD_0", 2, GL_FLOAT, false, sizeof(Vertex), reinterpret_cast<void*>( offsetof(Vertex, coordinate) ) );
     vertex_array.addAttribute( "_METADATA",  2, GL_SHORT, false, sizeof(Vertex), reinterpret_cast<void*>( offsetof(Vertex, vertex_metadata) ) );
 
-    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec3 POSITION" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec3 NORMAL" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec4 COLOR_0" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 TEXCOORD_0" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 _METADATA" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::HIGH, "vec3 POSITION" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,  "vec3 NORMAL" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,  "vec4 COLOR_0" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,  "vec2 TEXCOORD_0" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,  "vec2 _METADATA" ) );
 
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec2 texture_coord_1" ) );
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec3 world_reflection" ) );

--- a/src/Graphics/SDL2/GLES2/Internal/DynamicTriangleDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/DynamicTriangleDraw.cpp
@@ -307,7 +307,7 @@ Graphics::SDL2::GLES2::Internal::DynamicTriangleDraw::Triangle Graphics::SDL2::G
     return triangle;
 }
 
-unsigned Graphics::SDL2::GLES2::Internal::DynamicTriangleDraw::Triangle::addCircle(
+unsigned Graphics::SDL2::GLES2::Internal::DynamicTriangleDraw::Triangle::addStar(
     DynamicTriangleDraw::Triangle *draw_triangles_r, size_t number_of_triangles,
     const glm::vec3 &camera_position, const glm::mat4 &matrix, const glm::vec3 &camera_right, const glm::vec3 &camera_up,
     const glm::vec3 &position, const glm::vec3 &color, float width, unsigned number_of_edges)

--- a/src/Graphics/SDL2/GLES2/Internal/DynamicTriangleDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/DynamicTriangleDraw.h
@@ -48,6 +48,11 @@ public:
 
         Triangle addTriangle( const glm::vec3 &camera_position ) const;
         Triangle addTriangle( const glm::vec3 &camera_position, const glm::mat4 &matrix ) const;
+
+        static unsigned addCircle(
+            DynamicTriangleDraw::Triangle *draw_triangles_r, size_t number_of_triangles,
+            const glm::vec3 &camera_position, const glm::mat4 &matrix, const glm::vec3 &camera_right, const glm::vec3 &camera_up,
+            const glm::vec3 &position, const glm::vec3 &color, float width, unsigned number_of_edges);
     };
     struct DrawCommand {
         // This holds transparent triangles

--- a/src/Graphics/SDL2/GLES2/Internal/DynamicTriangleDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/DynamicTriangleDraw.h
@@ -49,7 +49,7 @@ public:
         Triangle addTriangle( const glm::vec3 &camera_position ) const;
         Triangle addTriangle( const glm::vec3 &camera_position, const glm::mat4 &matrix ) const;
 
-        static unsigned addCircle(
+        static unsigned addStar(
             DynamicTriangleDraw::Triangle *draw_triangles_r, size_t number_of_triangles,
             const glm::vec3 &camera_position, const glm::mat4 &matrix, const glm::vec3 &camera_right, const glm::vec3 &camera_up,
             const glm::vec3 &position, const glm::vec3 &color, float width, unsigned number_of_edges);

--- a/src/Graphics/SDL2/GLES2/Internal/FontSystem.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/FontSystem.cpp
@@ -260,7 +260,7 @@ void Graphics::SDL2::GLES2::Internal::FontSystem::Text2D::draw( const VertexAttr
 Graphics::SDL2::GLES2::Internal::FontSystem::FontSystem( const std::vector<const Data::Mission::FontResource*> &font_resources ) {
     this->font_bank.reserve( font_resources.size() );
 
-    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec4 POSITION" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::HIGH,   "vec4 POSITION" ) );
     attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec2 TEXCOORD_0" ) );
     attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec4 COLOR_0" ) );
 

--- a/src/Graphics/SDL2/GLES2/Internal/Mesh.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Mesh.cpp
@@ -59,11 +59,11 @@ void Graphics::SDL2::GLES2::Internal::Mesh::setup( Utilities::ModelBuilder &mode
     }
 
     void * vertex_buffer_data = model.getBuffer( vertex_buffer_size );
-    bool bounds;
     
-    bounds = model.getBoundingSphere( this->culling_sphere_position, this->culling_sphere_radius );
-    
-    assert( bounds );
+    if(!model.getBoundingSphere( this->culling_sphere_position, this->culling_sphere_radius )) {
+        this->culling_sphere_position = glm::vec3(0);
+        this->culling_sphere_radius = 0.0f;
+    }
     
     morph_buffer_size = 0;
     model.getMorphBuffer( 0, morph_buffer_size );
@@ -217,4 +217,17 @@ bool Graphics::SDL2::GLES2::Internal::Mesh::getBoundingSphere( glm::vec3 &positi
     position = this->culling_sphere_position;
     radius   = this->culling_sphere_radius;
     return true;
+}
+
+void Graphics::SDL2::GLES2::Internal::Mesh::appendBoundingSphere( glm::vec3 position, float radius ) {
+    glm::vec3 normal = glm::normalize(this->culling_sphere_position - position);
+
+    glm::vec3 a = this->culling_sphere_position + normal * this->culling_sphere_radius;
+    glm::vec3 b = position + normal * radius;
+
+    glm::vec3 new_center = (a + b) * 0.5f;
+    float new_radius = glm::distance(a, b) * 0.5f;
+
+    this->culling_sphere_position = new_center;
+    this->culling_sphere_radius   = new_radius;
 }

--- a/src/Graphics/SDL2/GLES2/Internal/Mesh.h
+++ b/src/Graphics/SDL2/GLES2/Internal/Mesh.h
@@ -98,6 +98,8 @@ public:
      * @return true if a bounding sphere is generated.
      */
     bool getBoundingSphere( glm::vec3 &position, float &radius ) const;
+
+    void appendBoundingSphere( glm::vec3 position, float radius );
     
     std::string getVertexLayout() const { return vertex_array.getBindLayout(0); }
 };

--- a/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.cpp
@@ -21,7 +21,7 @@ void Graphics::SDL2::GLES2::Internal::MorphModelDraw::Animation::Dynamic::addTri
         
         if( delta_triangle_r != nullptr ) {
             for( unsigned t = 0; t < 3; t++ ) {
-                draw_triangles_r[ i ].vertices[ t ].position   += delta_triangle_r[ i ].vertices[ t ];
+                draw_triangles_r[ i ].vertices[ t ].position += delta_triangle_r[ i ].vertices[ t ];
             }
         }
 
@@ -188,11 +188,13 @@ int Graphics::SDL2::GLES2::Internal::MorphModelDraw::compileProgram() {
     }
 }
 
-int Graphics::SDL2::GLES2::Internal::MorphModelDraw::inputModel( Utilities::ModelBuilder *model_type_r, uint32_t obj_identifier, const std::map<uint32_t, Internal::Texture2D*>& textures, const std::vector<Data::Mission::ObjResource::FaceOverrideType>& face_override_animation, const std::vector<glm::u8vec2>& face_override_uvs ) {
-    auto ret = Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( model_type_r, obj_identifier, textures, face_override_animation, face_override_uvs );
+int Graphics::SDL2::GLES2::Internal::MorphModelDraw::inputModel( Utilities::ModelBuilder *model_type_r,  const Data::Mission::ObjResource& obj, const std::map<uint32_t, Internal::Texture2D*>& textures ) {
+    auto ret = Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( model_type_r, obj, textures );
     
     if( ret >= 0 )
     {
+        const uint32_t obj_identifier = obj.getResourceID();
+
         GLsizei transparent_count = 0;
 
         auto accessor = models_p.find( obj_identifier );

--- a/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.cpp
@@ -57,7 +57,7 @@ void Graphics::SDL2::GLES2::Internal::MorphModelDraw::Animation::Dynamic::addTri
             case Data::Mission::ObjResource::FacerPolygon::STAR:
                 glm::vec3 color = glm::mix(facer_polygon.color, facer_polygon.primitive.star.other_color, std::abs(this->star_timings_r->at(facer_polygon.primitive.star.time_index)));
 
-                index += DynamicTriangleDraw::Triangle::addCircle(
+                index += DynamicTriangleDraw::Triangle::addStar(
                     &draw_triangles_r[index], number_of_triangles - index,
                     this->camera_position, this->transform, this->camera_right, this->camera_up,
                     facer_polygon.primitive.star.point.position, color, facer_polygon.width, facer_polygon.primitive.star.vertex_count);

--- a/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.cpp
@@ -132,7 +132,8 @@ const GLchar* Graphics::SDL2::GLES2::Internal::MorphModelDraw::default_vertex_sh
     "   texture_coord_1 += AnimatedUVFrames[ int( clamp( _METADATA[1] - 1., 0., float(ANIMATED_UV_FRAME_VEC_AMOUNT) ) ) ] * float( _METADATA[1] != 0. );\n"
     "   texture_coord_1 += TextureTranslation;\n"
     "   in_color = COLOR_0;\n"
-    "   gl_Position = Transform * vec4(current_position, 1.0);\n"
+    "   MAKE_FULL_POSITION(current_position);\n"
+    "   gl_Position = Transform * full_position;\n"
     "}\n";
 Graphics::SDL2::GLES2::Internal::MorphModelDraw::MorphModelDraw() {
     // These inputs are for the morph attributes

--- a/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.h
@@ -26,6 +26,11 @@ public:
             unsigned int frame_index;
             std::vector<glm::vec2> *uv_frame_buffer_r;
             glm::vec2 texture_offset;
+            std::vector<float> *star_timings_r;
+            std::vector<Data::Mission::ObjResource::FacerPolygon> *facer_polygons_info_r;
+            unsigned facer_triangles_amount;
+            unsigned facer_polygons_stride;
+            glm::vec3 camera_right, camera_up;
 
             virtual void addTriangles( const std::vector<DynamicTriangleDraw::Triangle> &triangles, DynamicTriangleDraw::DrawCommand &triangles_draw ) const;
         };
@@ -34,7 +39,7 @@ public:
         unsigned triangles_per_frame;
         std::vector<DeltaTriangle> frame_data; // [Delta Frame 1], [Delta Frame 2], ..., [Delta Frame end]
     public:
-        
+
         Animation( Utilities::ModelBuilder *model_type_r, GLsizei transparent_count );
         
         const DeltaTriangle *const getFrame( unsigned frame_index ) const;

--- a/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/MorphModelDraw.h
@@ -82,16 +82,15 @@ public:
      */
     int compileProgram();
     
+
     /**
      * This handles the loading of the models.
-     * @param model_type Holds the model information.
-     * @param resource_cobj The id associated with the model.
+     * @param model_type_r Holds the model information.
+     * @param obj The model builder's source. Holds metadata needed for rendering the model.
      * @param textures The accessor of the textures available for the models.
-     * @param face_override_animation UV animation information info.
-     * @param face_override_uvs UV override information.
      * @return 1 for success, or -1 for failure.
      */
-    int inputModel( Utilities::ModelBuilder *model_type, uint32_t obj_identifier, const std::map<uint32_t, Internal::Texture2D*>& textures, const std::vector<Data::Mission::ObjResource::FaceOverrideType>& face_override_animation, const std::vector<glm::u8vec2>& face_override_uvs );
+    int inputModel( Utilities::ModelBuilder *model_type_r,  const Data::Mission::ObjResource& obj, const std::map<uint32_t, Internal::Texture2D*>& textures );
 
     void clearModels();
 

--- a/src/Graphics/SDL2/GLES2/Internal/Shader.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/Shader.cpp
@@ -119,6 +119,7 @@ void Graphics::SDL2::GLES2::Internal::Shader::setShader( TYPE type, const GLchar
         
         if( (opengl_profile & SDL_GL_CONTEXT_PROFILE_ES) != 0 ) {
             this->generated_shader += glsl_es2_version;
+            this->generated_shader += "#define MAKE_FULL_POSITION(pos) highp vec4 full_position = vec4(pos.xyz, 1.0)\n";
             for( auto i = attributes.begin(); i != attributes.end(); i++ ) {
                 this->generated_shader += (*i).getEntryES2();
             }
@@ -128,6 +129,7 @@ void Graphics::SDL2::GLES2::Internal::Shader::setShader( TYPE type, const GLchar
         }
         else {
             this->generated_shader += glsl_2_version;
+            this->generated_shader += "#define MAKE_FULL_POSITION(pos) vec4 full_position = vec4(pos.xyz, 1.0)\n";
             for( auto i = attributes.begin(); i != attributes.end(); i++ ) {
                 this->generated_shader += (*i).getEntry2();
             }

--- a/src/Graphics/SDL2/GLES2/Internal/Shader.h
+++ b/src/Graphics/SDL2/GLES2/Internal/Shader.h
@@ -27,9 +27,9 @@ public:
     class Type {
     public:
         enum PRECISION {
-            LOW,
-            MEDIUM,
-            HIGH,
+            LOW,    // Int: (-2^8,  2^8)  Float: (-2,       2) FP: 2^( -8)
+            MEDIUM, // Int: (-2^10, 2^10) Float: (-2^14, 2^14) FP: 2^(-10)
+            HIGH,   // Int: (-2^16, 2^16) Float: (-2^62, 2^62) FP: 2^(-16)
             ALL
         };
     protected:

--- a/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
@@ -105,8 +105,8 @@ const GLchar* Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::default_vertex
     "}\n";
 Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::SkeletalModelDraw() {
     // These attributes are for the skelatal animation.
-    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec4 JOINTS_0" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec3 WEIGHTS_0" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec4 JOINTS_0" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec3 WEIGHTS_0" ) );
 }
 
 Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::~SkeletalModelDraw() {

--- a/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
@@ -100,7 +100,8 @@ const GLchar* Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::default_vertex
     "   texture_coord_1 += AnimatedUVFrames[ int( clamp( _METADATA[1] - 1., 0., float(ANIMATED_UV_FRAME_VEC_AMOUNT) ) ) ] * float( _METADATA[1] != 0. );\n"
     "   texture_coord_1 += TextureTranslation;\n"
     "   in_color = COLOR_0;\n"
-    "   gl_Position = Transform * vec4(current_position.xyz, 1.0);\n"
+    "   MAKE_FULL_POSITION(current_position);\n"
+    "   gl_Position = Transform * full_position;\n"
     "}\n";
 Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::SkeletalModelDraw() {
     // These attributes are for the skelatal animation.

--- a/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
@@ -89,7 +89,7 @@ void Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::SkeletalAnimation::Dyna
 
                 position = position * (1.f / position.w);
 
-                index += DynamicTriangleDraw::Triangle::addCircle(
+                index += DynamicTriangleDraw::Triangle::addStar(
                     &draw_triangles_r[index], number_of_triangles - index,
                     this->camera_position, this->transform, this->camera_right, this->camera_up,
                     glm::vec3(position.x, position.y, position.z), color, facer_polygon.width, facer_polygon.primitive.star.vertex_count);

--- a/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
@@ -68,6 +68,34 @@ void Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::SkeletalAnimation::Dyna
 
         draw_triangles_r[ i ] = draw_triangles_r[ i ].addTriangle( this->camera_position );
     }
+
+    number_of_triangles = triangles_draw.getTriangles( this->facer_triangles_amount, &draw_triangles_r );
+
+    size_t index = 0;
+    glm::vec4 position;
+
+    for( size_t i = 0; i < this->facer_polygons_stride; i++) {
+        const auto &facer_polygon = this->facer_polygons_info_r->at(i);
+
+        switch( facer_polygon.type ) {
+            case Data::Mission::ObjResource::FacerPolygon::STAR:
+                glm::vec3 color = glm::mix(facer_polygon.color, facer_polygon.primitive.star.other_color, std::abs(this->star_timings_r->at(facer_polygon.primitive.star.time_index)));
+
+                position = matrices_r[ facer_polygon.primitive.star.point.joints.x ] * glm::vec4(facer_polygon.primitive.star.point.position, 1);
+
+                position.w = 1;
+
+                position = transform * position;
+
+                position = position * (1.f / position.w);
+
+                index += DynamicTriangleDraw::Triangle::addCircle(
+                    &draw_triangles_r[index], number_of_triangles - index,
+                    this->camera_position, this->transform, this->camera_right, this->camera_up,
+                    glm::vec3(position.x, position.y, position.z), color, facer_polygon.width, facer_polygon.primitive.star.vertex_count);
+                break;
+        }
+    }
 }
 
 const GLchar* Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::default_vertex_shader =
@@ -250,6 +278,8 @@ void Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::draw( Graphics::SDL2::G
 
     SkeletalAnimation::Dynamic dynamic;
     dynamic.camera_position = camera.getPosition();
+    dynamic.camera_right = glm::vec3(view[0][0], view[1][0], view[2][0]);
+    dynamic.camera_up    = glm::vec3(view[0][1], view[1][1], view[2][1]);
 
     // Traverse the models.
     for( auto d = models_p.begin(); d != models_p.end(); d++ ) // Go through every model that has an instance.
@@ -304,6 +334,10 @@ void Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::draw( Graphics::SDL2::G
                     dynamic.current_frame = current_frame;
                     dynamic.uv_frame_buffer_r = &this->uv_frame_buffer;
                     dynamic.texture_offset = texture_offset;
+                    dynamic.star_timings_r = &(*instance)->star_timings;
+                    dynamic.facer_polygons_info_r  = &(*d).second->facer_polygons_info;
+                    dynamic.facer_triangles_amount =  (*d).second->facer_triangles_amount;
+                    dynamic.facer_polygons_stride  =  (*d).second->facer_polygons_stride;
                     dynamic.addTriangles( (*d).second->transparent_triangles, camera.transparent_triangles );
                 }
             }

--- a/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.cpp
@@ -140,11 +140,13 @@ int Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::compileProgram() {
     }
 }
 
-int Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::inputModel( Utilities::ModelBuilder *model_type_r, uint32_t obj_identifier, const std::map<uint32_t, Internal::Texture2D*>& textures, const std::vector<Data::Mission::ObjResource::FaceOverrideType>& face_override_animation, const std::vector<glm::u8vec2>& face_override_uvs ) {
-    auto ret = Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( model_type_r, obj_identifier, textures, face_override_animation, face_override_uvs );
+int Graphics::SDL2::GLES2::Internal::SkeletalModelDraw::inputModel( Utilities::ModelBuilder *model_type_r, const Data::Mission::ObjResource& obj, const std::map<uint32_t, Internal::Texture2D*>& textures) {
+    auto ret = Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( model_type_r, obj, textures );
     
     if( ret >= 0 )
     {
+        const uint32_t obj_identifier = obj.getResourceID();
+
         if( model_animation_p[ obj_identifier ] != nullptr )
             delete model_animation_p[ obj_identifier ];
         

--- a/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.h
@@ -79,11 +79,12 @@ public:
 
     /**
      * This handles the loading of the models.
-     * @param These are the models to load.
-     * @param This is the amount of models to load.
+     * @param model_type_r Holds the model information.
+     * @param obj The model builder's source. Holds metadata needed for rendering the model.
+     * @param textures The accessor of the textures available for the models.
      * @return 1 for success, or -1 for failure.
      */
-    int inputModel( Utilities::ModelBuilder *model_type, uint32_t obj_identifier, const std::map<uint32_t, Internal::Texture2D*>& textures, const std::vector<Data::Mission::ObjResource::FaceOverrideType>& face_override_animation, const std::vector<glm::u8vec2>& face_override_uvs );
+    int inputModel( Utilities::ModelBuilder *model_type_r, const Data::Mission::ObjResource& obj, const std::map<uint32_t, Internal::Texture2D*>& textures );
 
     void clearModels();
 

--- a/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/SkeletalModelDraw.h
@@ -27,6 +27,11 @@ protected:
             unsigned int current_frame;
             std::vector<glm::vec2> *uv_frame_buffer_r;
             glm::vec2 texture_offset;
+            std::vector<float> *star_timings_r;
+            std::vector<Data::Mission::ObjResource::FacerPolygon> *facer_polygons_info_r;
+            unsigned facer_triangles_amount;
+            unsigned facer_polygons_stride;
+            glm::vec3 camera_right, camera_up;
 
             virtual void addTriangles( const std::vector<DynamicTriangleDraw::Triangle> &triangles, DynamicTriangleDraw::DrawCommand &triangles_draw ) const;
         };

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -75,9 +75,9 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
             draw_triangles_r[ index ].vertices[x].coordinate = glm::vec2(0, 0);
             draw_triangles_r[ index ].vertices[x].vertex_metadata = glm::i16vec2(0, 0);
         }
-        draw_triangles_r[ index ].vertices[0].color = glm::vec4((*i).color.x, (*i).color.y, (*i).color.z, 1);
-        draw_triangles_r[ index ].vertices[1].color = glm::vec4(0, 0, 0, 0);
-        draw_triangles_r[ index ].vertices[2].color = glm::vec4(0, 0, 0, 0);
+        draw_triangles_r[ index ].vertices[0].color = glm::vec4((*i).color.x, (*i).color.y, (*i).color.z, 0.5) * 2.0f;
+        draw_triangles_r[ index ].vertices[1].color = glm::vec4((*i).color.x, (*i).color.y, (*i).color.z, 0.0) * 2.0f;
+        draw_triangles_r[ index ].vertices[2].color = draw_triangles_r[ index ].vertices[1].color;
 
         draw_triangles_r[ index ].setup( 0, this->camera_position, DynamicTriangleDraw::PolygonType::ADDITION );
 

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -69,7 +69,7 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
             case Data::Mission::ObjResource::FacerPolygon::STAR:
                 glm::vec3 color = glm::mix(facer_polygon.color, facer_polygon.primitive.star.other_color, std::abs(this->star_timings_r->at(facer_polygon.primitive.star.time_index)));
 
-                index += DynamicTriangleDraw::Triangle::addCircle(
+                index += DynamicTriangleDraw::Triangle::addStar(
                     &draw_triangles_r[index], number_of_triangles - index,
                     this->camera_position, this->transform, this->camera_right, this->camera_up,
                     facer_polygon.primitive.star.point.position, color, facer_polygon.width, facer_polygon.primitive.star.vertex_count);

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -65,10 +65,12 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
     for( auto i = this->facer_polygons_info_r->begin(); i != this->facer_polygons_info_r->end(); i++) {
         switch( (*i).type ) {
             case Data::Mission::ObjResource::FacerPolygon::STAR:
+                glm::vec3 color = glm::mix((*i).color, (*i).primitive.star.other_color, std::abs(this->star_timings_r->at((*i).primitive.star.time_index)));
+
                 index += DynamicTriangleDraw::Triangle::addCircle(
                     &draw_triangles_r[index], number_of_triangles - index,
                     this->camera_position, this->transform, this->camera_right, this->camera_up,
-                    (*i).primitive.star.point.position, (*i).color, (*i).width, (*i).primitive.star.vertex_count);
+                    (*i).primitive.star.point.position, color, (*i).width, (*i).primitive.star.vertex_count);
                 break;
         }
     }
@@ -561,6 +563,15 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::advanceTime( float second
     for( auto model_type = models_p.begin(); model_type != models_p.end(); model_type++ ) {
         for( auto instance = (*model_type).second->instances_r.begin(); instance != (*model_type).second->instances_r.end(); instance++ ) {
             (*instance)->addTextureTransformTimelineSeconds( seconds_passed );
+
+            for( size_t i = 1; i < (*instance)->star_timings.size(); i++ ) {
+                auto &value = (*instance)->star_timings[i];
+
+                value += 4. * seconds_passed;
+
+                if(value > 1.)
+                    value -= 2.;
+            }
         }
     }
 }

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -83,6 +83,14 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
         draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + camera_up;
         draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position - camera_right;
         index++;
+        draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
+        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position - camera_right;
+        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position - camera_up;
+        index++;
+        draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
+        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position - camera_up;
+        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + camera_right;
+        index++;
     }
 }
 

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -69,15 +69,16 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
             draw_triangles_r[ index ].vertices[x].coordinate = glm::vec2(0, 0);
             draw_triangles_r[ index ].vertices[x].vertex_metadata = glm::i16vec2(0, 0);
         }
-        draw_triangles_r[ index ].vertices[1].position += glm::vec3((*i).width,          0, 0);
-        draw_triangles_r[ index ].vertices[2].position += glm::vec3(         0, (*i).width, 0);
         draw_triangles_r[ index ].vertices[0].color     = glm::vec4((*i).color.x, (*i).color.y, (*i).color.z, 1);
         draw_triangles_r[ index ].vertices[1].color     = glm::vec4(0, 0, 0, 0);
         draw_triangles_r[ index ].vertices[2].color     = glm::vec4(0, 0, 0, 0);
 
         draw_triangles_r[ index ].setup( 0, this->camera_position, DynamicTriangleDraw::PolygonType::ADDITION );
 
-        draw_triangles_r[ index ] = draw_triangles_r[ index ].addTriangle( this->camera_position, transform ); index++;
+        draw_triangles_r[ index ] = draw_triangles_r[ index ].addTriangle( this->camera_position, transform );
+        draw_triangles_r[ index ].vertices[2].position += camera_up;
+        draw_triangles_r[ index ].vertices[1].position += camera_right;
+        index++;
     }
 }
 
@@ -457,6 +458,8 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::draw( Graphics::SDL2::GLE
 
     Dynamic dynamic;
     dynamic.camera_position = camera.getPosition();
+    dynamic.camera_right = glm::vec3(view[0][0], view[1][0], view[2][0]);
+    dynamic.camera_up    = glm::vec3(view[0][1], view[1][1], view[2][1]);
 
     // Traverse the models.
     for( auto d = model_array_p.begin(); d != model_array_p.end(); d++ ) // Go through every model that has an instance.

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -236,11 +236,13 @@ bool Graphics::SDL2::GLES2::Internal::StaticModelDraw::containsBBModel( uint32_t
         return false;
 }
 
-int Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( Utilities::ModelBuilder *model_type_r, uint32_t obj_identifier, const std::map<uint32_t, Internal::Texture2D*>& textures, const std::vector<Data::Mission::ObjResource::FaceOverrideType>& face_override_animation, const std::vector<glm::u8vec2>& face_override_uvs ) {
+int Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( Utilities::ModelBuilder *model_type_r, const Data::Mission::ObjResource& obj, const std::map<uint32_t, Internal::Texture2D*>& textures ) {
     int state = 0;
 
     if( model_type_r->getNumVertices() > 0 )
     {
+        const uint32_t obj_identifier = obj.getResourceID();
+
         VertexAttributeArray vertex_array;
 
         vertex_array.addAttribute("NORMAL", 3, glm::vec4(1.0f, 0.0f, 0.0f, 0.0f));
@@ -265,10 +267,10 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( Utilities::Mod
             transparent_count += material.count - transparent_index;
         }
         models_p[ obj_identifier ]->transparent_triangles.reserve( transparent_count );
-        models_p[ obj_identifier ]->uv_animation_data = face_override_uvs;
-        models_p[ obj_identifier ]->uv_animation_info = face_override_animation;
+        models_p[ obj_identifier ]->uv_animation_data = obj.getFaceOverrideData();
+        models_p[ obj_identifier ]->uv_animation_info = obj.getFaceOverrideTypes();
 
-        const size_t face_override_amount = 4 * face_override_animation.size();
+        const size_t face_override_amount = 4 * obj.getFaceOverrideTypes().size();
 
         if(uv_frame_buffer.size() < std::max(face_override_amount, UV_FRAME_BUFFER_SIZE_LIMIT) )
             uv_frame_buffer.resize( std::max(face_override_amount, UV_FRAME_BUFFER_SIZE_LIMIT) );

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -63,65 +63,9 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
     size_t index = 0;
 
     for( auto i = this->facer_polygons_info_r->begin(); i != this->facer_polygons_info_r->end(); i++) {
-        const float UNIT_45_DEGREES = 0.707106781187; // M_SQRT2 / 2.0;
-        const float UNIT_30_DEGREES = 0.866025403785; // M_SQRT3 / 2.0;
-
-        glm::vec2 circle_8[8] = { { 0, 1}, { UNIT_45_DEGREES, UNIT_45_DEGREES}, { 1, 0}, { UNIT_45_DEGREES,-UNIT_45_DEGREES}, { 0,-1}, {-UNIT_45_DEGREES,-UNIT_45_DEGREES}, {-1, 0}, {-UNIT_45_DEGREES, UNIT_45_DEGREES} };
-        glm::vec2 circle_12[12] = { { 0, 1}, { 0.5, UNIT_30_DEGREES}, { UNIT_30_DEGREES, 0.5}, { 1, 0}, { UNIT_30_DEGREES,-0.5}, { 0.5,-UNIT_30_DEGREES}, { 0,-1}, {-0.5,-UNIT_30_DEGREES}, {-UNIT_30_DEGREES,-0.5}, {-1, 0}, {-UNIT_30_DEGREES, 0.5}, {-0.5, UNIT_30_DEGREES} };
-
-        for(int x = 0; x < 3; x++) {
-            draw_triangles_r[ index ].vertices[x].position   = (*i).primitive.star.point.position;
-            draw_triangles_r[ index ].vertices[x].normal     = glm::vec3(0, 1, 0);
-            draw_triangles_r[ index ].vertices[x].coordinate = glm::vec2(0, 0);
-            draw_triangles_r[ index ].vertices[x].vertex_metadata = glm::i16vec2(0, 0);
-        }
-        draw_triangles_r[ index ].vertices[0].color = glm::vec4((*i).color.x, (*i).color.y, (*i).color.z, 0.5) * 2.0f;
-        draw_triangles_r[ index ].vertices[1].color = glm::vec4((*i).color.x, (*i).color.y, (*i).color.z, 0.0) * 2.0f;
-        draw_triangles_r[ index ].vertices[2].color = draw_triangles_r[ index ].vertices[1].color;
-
-        draw_triangles_r[ index ].setup( 0, this->camera_position, DynamicTriangleDraw::PolygonType::ADDITION );
-
-        draw_triangles_r[ index ] = draw_triangles_r[ index ].addTriangle( this->camera_position, transform );
-
-        if((*i).primitive.star.vertex_count == 4) {
-            for(int t = 0; t < 4; t++) {
-                if(t != 0)
-                    draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
-
-                const int cur_circle_index = t * 2;
-                const int next_circle_index = ((t + 1) * 2) % 8;
-
-                draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_8[next_circle_index].x * (*i).width) + (camera_up * circle_8[next_circle_index].y * (*i).width);
-                draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_8[ cur_circle_index].x * (*i).width) + (camera_up * circle_8[ cur_circle_index].y * (*i).width);
-                index++;
-            }
-        }
-        else if((*i).primitive.star.vertex_count == 8) {
-            for(int t = 0; t < 8; t++) {
-                if(t != 0)
-                    draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
-
-                const int cur_circle_index = t;
-                const int next_circle_index = (t + 1) % 8;
-
-                draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_8[next_circle_index].x * (*i).width) + (camera_up * circle_8[next_circle_index].y * (*i).width);
-                draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_8[ cur_circle_index].x * (*i).width) + (camera_up * circle_8[ cur_circle_index].y * (*i).width);
-                index++;
-            }
-        }
-        else {
-            for(int t = 0; t < 12; t++) {
-                if(t != 0)
-                    draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
-
-                const int cur_circle_index = t;
-                const int next_circle_index = (t + 1) % 12;
-
-                draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_12[next_circle_index].x * (*i).width) + (camera_up * circle_12[next_circle_index].y * (*i).width);
-                draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_12[ cur_circle_index].x * (*i).width) + (camera_up * circle_12[ cur_circle_index].y * (*i).width);
-                index++;
-            }
-        }
+        index += DynamicTriangleDraw::Triangle::addCircle( &draw_triangles_r[index], number_of_triangles - index,
+                                                           this->camera_position, transform, camera_right, camera_up,
+                                                           (*i).primitive.star.point.position, (*i).color, (*i).width, (*i).primitive.star.vertex_count);
     }
 }
 

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -285,7 +285,11 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( Utilities::Mod
 
     unsigned facer_polygons_amount = 0;
 
-    models_p[ obj_identifier ]->star_timing_amount = obj.getVertexColorOverrides().size() + 1;
+    models_p[ obj_identifier ]->star_timing_speed.resize(obj.getVertexColorOverrides().size() + 1, 0.f);
+    for( unsigned i = 0; i < obj.getVertexColorOverrides().size(); i++ ) {
+        models_p[ obj_identifier ]->star_timing_speed[1 + i] = obj.getVertexColorOverrides()[i].speed_factor;
+    }
+
     models_p[ obj_identifier ]->transparent_triangles.reserve( transparent_count );
     models_p[ obj_identifier ]->facer_polygons_info   = obj.generateFacingPolygons(facer_polygons_amount, 0);
     models_p[ obj_identifier ]->facer_polygons_amount = facer_polygons_amount;
@@ -524,7 +528,7 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::allocateObjModel( uint32_t
             model_instance.culling_sphere_radius = 1.0f;
         }
 
-        model_instance.star_timings.resize(models_p[ obj_identifier ]->star_timing_amount, 0.f);
+        model_instance.star_timings.resize(models_p[ obj_identifier ]->star_timing_speed.size(), 0.f);
 
         // Finally added the instance.
         model_array_r->instances_r.insert( &model_instance );
@@ -564,10 +568,10 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::advanceTime( float second
         for( auto instance = (*model_type).second->instances_r.begin(); instance != (*model_type).second->instances_r.end(); instance++ ) {
             (*instance)->addTextureTransformTimelineSeconds( seconds_passed );
 
-            for( size_t i = 1; i < (*instance)->star_timings.size(); i++ ) {
+            for( size_t i = 0; i < (*instance)->star_timings.size(); i++ ) {
                 auto &value = (*instance)->star_timings[i];
 
-                value += 4. * seconds_passed;
+                value += (*model_type).second->star_timing_speed[i] * seconds_passed;
 
                 if(value > 1.)
                     value -= 2.;

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -67,6 +67,7 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
         const float UNIT_30_DEGREES = 0.866025403785; // M_SQRT3 / 2.0;
 
         glm::vec2 circle_8[8] = { { 0, 1}, { UNIT_45_DEGREES, UNIT_45_DEGREES}, { 1, 0}, { UNIT_45_DEGREES,-UNIT_45_DEGREES}, { 0,-1}, {-UNIT_45_DEGREES,-UNIT_45_DEGREES}, {-1, 0}, {-UNIT_45_DEGREES, UNIT_45_DEGREES} };
+        glm::vec2 circle_12[12] = { { 0, 1}, { 0.5, UNIT_30_DEGREES}, { UNIT_30_DEGREES, 0.5}, { 1, 0}, { UNIT_30_DEGREES,-0.5}, { 0.5,-UNIT_30_DEGREES}, { 0,-1}, {-0.5,-UNIT_30_DEGREES}, {-UNIT_30_DEGREES,-0.5}, {-1, 0}, {-UNIT_30_DEGREES, 0.5}, {-0.5, UNIT_30_DEGREES} };
 
         for(int x = 0; x < 3; x++) {
             draw_triangles_r[ index ].vertices[x].position   = (*i).primitive.star.point.position;
@@ -95,7 +96,7 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
                 index++;
             }
         }
-        else {
+        else if((*i).primitive.star.vertex_count == 8) {
             for(int t = 0; t < 8; t++) {
                 if(t != 0)
                     draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
@@ -105,6 +106,19 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
 
                 draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_8[next_circle_index].x * (*i).width) + (camera_up * circle_8[next_circle_index].y * (*i).width);
                 draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_8[ cur_circle_index].x * (*i).width) + (camera_up * circle_8[ cur_circle_index].y * (*i).width);
+                index++;
+            }
+        }
+        else {
+            for(int t = 0; t < 12; t++) {
+                if(t != 0)
+                    draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
+
+                const int cur_circle_index = t;
+                const int next_circle_index = (t + 1) % 12;
+
+                draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_12[next_circle_index].x * (*i).width) + (camera_up * circle_12[next_circle_index].y * (*i).width);
+                draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_12[ cur_circle_index].x * (*i).width) + (camera_up * circle_12[ cur_circle_index].y * (*i).width);
                 index++;
             }
         }

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -76,20 +76,20 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
         draw_triangles_r[ index ].setup( 0, this->camera_position, DynamicTriangleDraw::PolygonType::ADDITION );
 
         draw_triangles_r[ index ] = draw_triangles_r[ index ].addTriangle( this->camera_position, transform );
-        draw_triangles_r[ index ].vertices[1].position += camera_right;
-        draw_triangles_r[ index ].vertices[2].position += camera_up;
+        draw_triangles_r[ index ].vertices[1].position += (camera_right * (*i).width);
+        draw_triangles_r[ index ].vertices[2].position += (camera_up * (*i).width);
         index++;
         draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
-        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + camera_up;
-        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position - camera_right;
+        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + (camera_up * (*i).width);
+        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position - (camera_right * (*i).width);
         index++;
         draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
-        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position - camera_right;
-        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position - camera_up;
+        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position - (camera_right * (*i).width);
+        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position - (camera_up * (*i).width);
         index++;
         draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
-        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position - camera_up;
-        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + camera_right;
+        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position - (camera_up * (*i).width);
+        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * (*i).width);
         index++;
     }
 }

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -76,8 +76,12 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
         draw_triangles_r[ index ].setup( 0, this->camera_position, DynamicTriangleDraw::PolygonType::ADDITION );
 
         draw_triangles_r[ index ] = draw_triangles_r[ index ].addTriangle( this->camera_position, transform );
-        draw_triangles_r[ index ].vertices[2].position += camera_up;
         draw_triangles_r[ index ].vertices[1].position += camera_right;
+        draw_triangles_r[ index ].vertices[2].position += camera_up;
+        index++;
+        draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
+        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + camera_up;
+        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position - camera_right;
         index++;
     }
 }

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -267,9 +267,14 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( Utilities::Mod
 
             transparent_count += material.count - transparent_index;
         }
+
+        unsigned facer_polygons_amount = 0;
+
         models_p[ obj_identifier ]->transparent_triangles.reserve( transparent_count );
-        models_p[ obj_identifier ]->uv_animation_data = obj.getFaceOverrideData();
-        models_p[ obj_identifier ]->uv_animation_info = obj.getFaceOverrideTypes();
+        models_p[ obj_identifier ]->facer_polygons_info = obj.generateFacingPolygons(facer_polygons_amount, 0);
+        models_p[ obj_identifier ]->facer_polygons_amount = facer_polygons_amount;
+        models_p[ obj_identifier ]->uv_animation_data   = obj.getFaceOverrideData();
+        models_p[ obj_identifier ]->uv_animation_info   = obj.getFaceOverrideTypes();
 
         const size_t face_override_amount = 4 * obj.getFaceOverrideTypes().size();
 
@@ -472,6 +477,8 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::draw( Graphics::SDL2::GLE
                 
                 dynamic.texture_offset = texture_offset;
                 dynamic.uv_frame_buffer_r = &this->uv_frame_buffer;
+                dynamic.facer_polygons_info_r = &(*d).second->facer_polygons_info;
+                dynamic.facer_polygons_amount =  (*d).second->facer_polygons_amount;
                 dynamic.transform = camera_3D_model_transform;
                 dynamic.addTriangles( (*d).second->transparent_triangles, camera.transparent_triangles );
             }

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -110,11 +110,11 @@ const GLchar* Graphics::SDL2::GLES2::Internal::StaticModelDraw::default_fragment
 Graphics::SDL2::GLES2::Internal::StaticModelDraw::StaticModelDraw() {
     shiney_texture_r = nullptr;
 
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec3 POSITION" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec3 NORMAL" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec4 COLOR_0" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec2 TEXCOORD_0" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec2 _METADATA" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec3 POSITION" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec3 NORMAL" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec4 COLOR_0" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 TEXCOORD_0" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 _METADATA" ) );
 
     varyings.push_back( Shader::Varying( Shader::Type::LOW,    "vec4 in_color" ) );
     varyings.push_back( Shader::Varying( Shader::Type::LOW,    "vec3 world_reflection" ) );

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -283,6 +283,7 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputModel( Utilities::Mod
 
     unsigned facer_polygons_amount = 0;
 
+    models_p[ obj_identifier ]->star_timing_amount = obj.getVertexColorOverrides().size() + 1;
     models_p[ obj_identifier ]->transparent_triangles.reserve( transparent_count );
     models_p[ obj_identifier ]->facer_polygons_info   = obj.generateFacingPolygons(facer_polygons_amount, 0);
     models_p[ obj_identifier ]->facer_polygons_amount = facer_polygons_amount;
@@ -496,6 +497,7 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::draw( Graphics::SDL2::GLE
                 mesh_r->drawOpaque( 0, diffusive_texture_uniform_id );
                 
                 dynamic.texture_offset = texture_offset;
+                dynamic.star_timings_r = &(*instance)->star_timings;
                 dynamic.uv_frame_buffer_r = &this->uv_frame_buffer;
                 dynamic.facer_polygons_info_r = &(*d).second->facer_polygons_info;
                 dynamic.facer_polygons_amount =  (*d).second->facer_polygons_amount;
@@ -519,6 +521,8 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::allocateObjModel( uint32_t
             model_instance.culling_sphere_position = glm::vec3( 0, 0, 0 );
             model_instance.culling_sphere_radius = 1.0f;
         }
+
+        model_instance.star_timings.resize(models_p[ obj_identifier ]->star_timing_amount, 0.f);
 
         // Finally added the instance.
         model_array_r->instances_r.insert( &model_instance );

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -69,9 +69,9 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
             draw_triangles_r[ index ].vertices[x].coordinate = glm::vec2(0, 0);
             draw_triangles_r[ index ].vertices[x].vertex_metadata = glm::i16vec2(0, 0);
         }
-        draw_triangles_r[ index ].vertices[0].color     = glm::vec4((*i).color.x, (*i).color.y, (*i).color.z, 1);
-        draw_triangles_r[ index ].vertices[1].color     = glm::vec4(0, 0, 0, 0);
-        draw_triangles_r[ index ].vertices[2].color     = glm::vec4(0, 0, 0, 0);
+        draw_triangles_r[ index ].vertices[0].color = glm::vec4((*i).color.x, (*i).color.y, (*i).color.z, 1);
+        draw_triangles_r[ index ].vertices[1].color = glm::vec4(0, 0, 0, 0);
+        draw_triangles_r[ index ].vertices[2].color = glm::vec4(0, 0, 0, 0);
 
         draw_triangles_r[ index ].setup( 0, this->camera_position, DynamicTriangleDraw::PolygonType::ADDITION );
 

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -63,6 +63,11 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
     size_t index = 0;
 
     for( auto i = this->facer_polygons_info_r->begin(); i != this->facer_polygons_info_r->end(); i++) {
+        const float UNIT_45_DEGREES = 0.707106781187; // M_SQRT2 / 2.0;
+        const float UNIT_30_DEGREES = 0.866025403785; // M_SQRT3 / 2.0;
+
+        glm::vec2 circle_8[8] = { { 0, 1}, { UNIT_45_DEGREES, UNIT_45_DEGREES}, { 1, 0}, { UNIT_45_DEGREES,-UNIT_45_DEGREES}, { 0,-1}, {-UNIT_45_DEGREES,-UNIT_45_DEGREES}, {-1, 0}, {-UNIT_45_DEGREES, UNIT_45_DEGREES} };
+
         for(int x = 0; x < 3; x++) {
             draw_triangles_r[ index ].vertices[x].position   = (*i).primitive.star.point.position;
             draw_triangles_r[ index ].vertices[x].normal     = glm::vec3(0, 1, 0);
@@ -76,21 +81,33 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
         draw_triangles_r[ index ].setup( 0, this->camera_position, DynamicTriangleDraw::PolygonType::ADDITION );
 
         draw_triangles_r[ index ] = draw_triangles_r[ index ].addTriangle( this->camera_position, transform );
-        draw_triangles_r[ index ].vertices[1].position += (camera_right * (*i).width);
-        draw_triangles_r[ index ].vertices[2].position += (camera_up * (*i).width);
-        index++;
-        draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
-        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + (camera_up * (*i).width);
-        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position - (camera_right * (*i).width);
-        index++;
-        draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
-        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position - (camera_right * (*i).width);
-        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position - (camera_up * (*i).width);
-        index++;
-        draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
-        draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position - (camera_up * (*i).width);
-        draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * (*i).width);
-        index++;
+
+        if((*i).primitive.star.vertex_count == 4) {
+            for(int t = 0; t < 4; t++) {
+                if(t != 0)
+                    draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
+
+                const int cur_circle_index = t * 2;
+                const int next_circle_index = ((t + 1) * 2) % 8;
+
+                draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_8[next_circle_index].x * (*i).width) + (camera_up * circle_8[next_circle_index].y * (*i).width);
+                draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_8[ cur_circle_index].x * (*i).width) + (camera_up * circle_8[ cur_circle_index].y * (*i).width);
+                index++;
+            }
+        }
+        else {
+            for(int t = 0; t < 8; t++) {
+                if(t != 0)
+                    draw_triangles_r[ index ] = draw_triangles_r[ index - 1 ];
+
+                const int cur_circle_index = t;
+                const int next_circle_index = (t + 1) % 8;
+
+                draw_triangles_r[ index ].vertices[1].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_8[next_circle_index].x * (*i).width) + (camera_up * circle_8[next_circle_index].y * (*i).width);
+                draw_triangles_r[ index ].vertices[2].position = draw_triangles_r[ index ].vertices[0].position + (camera_right * circle_8[ cur_circle_index].x * (*i).width) + (camera_up * circle_8[ cur_circle_index].y * (*i).width);
+                index++;
+            }
+        }
     }
 }
 

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -63,9 +63,14 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
     size_t index = 0;
 
     for( auto i = this->facer_polygons_info_r->begin(); i != this->facer_polygons_info_r->end(); i++) {
-        index += DynamicTriangleDraw::Triangle::addCircle( &draw_triangles_r[index], number_of_triangles - index,
-                                                           this->camera_position, transform, camera_right, camera_up,
-                                                           (*i).primitive.star.point.position, (*i).color, (*i).width, (*i).primitive.star.vertex_count);
+        switch( (*i).type ) {
+            case Data::Mission::ObjResource::FacerPolygon::STAR:
+                index += DynamicTriangleDraw::Triangle::addCircle(
+                    &draw_triangles_r[index], number_of_triangles - index,
+                    this->camera_position, this->transform, this->camera_right, this->camera_up,
+                    (*i).primitive.star.point.position, (*i).color, (*i).width, (*i).primitive.star.vertex_count);
+                break;
+        }
     }
 }
 

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -87,7 +87,8 @@ const GLchar* Graphics::SDL2::GLES2::Internal::StaticModelDraw::default_vertex_s
     "   texture_coord_1 += AnimatedUVFrames[ int( clamp( _METADATA[1] - 1., 0., float(ANIMATED_UV_FRAME_VEC_AMOUNT) ) ) ] * float( _METADATA[1] != 0. );\n"
     "   texture_coord_1 += TextureTranslation;\n"
     "   in_color = COLOR_0;\n"
-    "   gl_Position = Transform * vec4(POSITION.xyz, 1.0);\n"
+    "   MAKE_FULL_POSITION(POSITION);\n"
+    "   gl_Position = Transform * full_position;\n"
     "}\n";
 const GLchar* Graphics::SDL2::GLES2::Internal::StaticModelDraw::default_fragment_shader =
     "uniform sampler2D Texture;\n"
@@ -109,11 +110,11 @@ const GLchar* Graphics::SDL2::GLES2::Internal::StaticModelDraw::default_fragment
 Graphics::SDL2::GLES2::Internal::StaticModelDraw::StaticModelDraw() {
     shiney_texture_r = nullptr;
 
-    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec3 POSITION" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec3 NORMAL" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec4 COLOR_0" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 TEXCOORD_0" ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 _METADATA" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec3 POSITION" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec3 NORMAL" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec4 COLOR_0" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec2 TEXCOORD_0" ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW, "vec2 _METADATA" ) );
 
     varyings.push_back( Shader::Varying( Shader::Type::LOW,    "vec4 in_color" ) );
     varyings.push_back( Shader::Varying( Shader::Type::LOW,    "vec3 world_reflection" ) );

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -57,6 +57,28 @@ void Graphics::SDL2::GLES2::Internal::StaticModelDraw::Dynamic::addTriangles(
 
         draw_triangles_r[ i ] = draw_triangles_r[ i ].addTriangle( this->camera_position, transform );
     }
+
+    number_of_triangles = triangles_draw.getTriangles( this->facer_polygons_amount, &draw_triangles_r );
+
+    size_t index = 0;
+
+    for( auto i = this->facer_polygons_info_r->begin(); i != this->facer_polygons_info_r->end(); i++) {
+        for(int x = 0; x < 3; x++) {
+            draw_triangles_r[ index ].vertices[x].position   = (*i).primitive.star.point.position;
+            draw_triangles_r[ index ].vertices[x].normal     = glm::vec3(0, 1, 0);
+            draw_triangles_r[ index ].vertices[x].coordinate = glm::vec2(0, 0);
+            draw_triangles_r[ index ].vertices[x].vertex_metadata = glm::i16vec2(0, 0);
+        }
+        draw_triangles_r[ index ].vertices[1].position += glm::vec3((*i).width,          0, 0);
+        draw_triangles_r[ index ].vertices[2].position += glm::vec3(         0, (*i).width, 0);
+        draw_triangles_r[ index ].vertices[0].color     = glm::vec4((*i).color.x, (*i).color.y, (*i).color.z, 1);
+        draw_triangles_r[ index ].vertices[1].color     = glm::vec4(0, 0, 0, 0);
+        draw_triangles_r[ index ].vertices[2].color     = glm::vec4(0, 0, 0, 0);
+
+        draw_triangles_r[ index ].setup( 0, this->camera_position, DynamicTriangleDraw::PolygonType::ADDITION );
+
+        draw_triangles_r[ index ] = draw_triangles_r[ index ].addTriangle( this->camera_position, transform ); index++;
+    }
 }
 
 const size_t Graphics::SDL2::GLES2::Internal::StaticModelDraw::UV_FRAME_BUFFER_SIZE_LIMIT = 8 * 4;

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.cpp
@@ -415,6 +415,8 @@ int Graphics::SDL2::GLES2::Internal::StaticModelDraw::inputBoundingBoxes( Utilit
 
         bounding_boxes_p[ obj_identifier ] = new ModelArray( &program );
         bounding_boxes_p[ obj_identifier ]->mesh.setup( *model_type_r, textures, &vertex_array );
+        bounding_boxes_p[ obj_identifier ]->facer_triangles_amount = 0;
+        bounding_boxes_p[ obj_identifier ]->facer_polygons_stride  = 0;
 
         state =  1;
     }

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
@@ -37,9 +37,10 @@ public:
     class Dynamic : public Mesh::DynamicNormal {
     public:
         glm::vec2 texture_offset;
+        std::vector<glm::vec2> *uv_frame_buffer_r;
         std::vector<Data::Mission::ObjResource::FacerPolygon> *facer_polygons_info_r;
         unsigned facer_polygons_amount;
-        std::vector<glm::vec2> *uv_frame_buffer_r;
+        glm::vec3 camera_right, camera_up;
 
         virtual void addTriangles( const std::vector<DynamicTriangleDraw::Triangle> &triangles, DynamicTriangleDraw::DrawCommand &triangles_draw ) const;
     };

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
@@ -140,23 +140,21 @@ public:
 
     /**
      * This handles the loading of the models.
-     * @param model_type Holds the model information.
-     * @param resource_cobj The id associated with the model.
+     * @param model_type_r Holds the model information.
+     * @param obj The model builder's source. Holds metadata needed for rendering the model.
      * @param textures The accessor of the textures available for the models.
-     * @param face_override_animation UV animation information info.
-     * @param face_override_uvs UV override information.
      * @return 1 for success, or -1 for failure.
      */
-    int inputModel( Utilities::ModelBuilder *model_type, uint32_t resource_cobj, const std::map<uint32_t, Internal::Texture2D*>& textures, const std::vector<Data::Mission::ObjResource::FaceOverrideType>& face_override_animation, const std::vector<glm::u8vec2>& face_override_uvs );
+    int inputModel( Utilities::ModelBuilder *model_type_r, const Data::Mission::ObjResource& obj, const std::map<uint32_t, Internal::Texture2D*>& textures );
 
     /**
      * This handles the loading of the models.
-     * @param model_type Holds the model information.
+     * @param model_type_r Holds the model information.
      * @param resource_cobj The id associated with the model.
      * @param textures The accessor of the textures available for the models. Only nothing texture is used.
      * @return 1 for success, or -1 for failure.
      */
-    int inputBoundingBoxes( Utilities::ModelBuilder *model_type, uint32_t resource_cobj, const std::map<uint32_t, Internal::Texture2D*>& textures );
+    int inputBoundingBoxes( Utilities::ModelBuilder *model_type_r, uint32_t resource_cobj, const std::map<uint32_t, Internal::Texture2D*>& textures );
 
     void clearModels();
 

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
@@ -31,17 +31,19 @@ public:
         std::vector<Data::Mission::ObjResource::FacerPolygon>     facer_polygons_info;
         std::vector<DynamicTriangleDraw::Triangle>              transparent_triangles;
         std::set<GLES2::ModelInstance*> instances_r; // The list of all instances that will be drawn.
-        unsigned facer_polygons_amount;
+        unsigned facer_triangles_amount;
+        unsigned facer_polygons_stride;
 
         void bindUVAnimation(GLuint animated_uv_frames_id, unsigned int time, std::vector<glm::vec2>& uv_frame_buffer) const;
     };
     class Dynamic : public Mesh::DynamicNormal {
     public:
         glm::vec2 texture_offset;
-        std::vector<float> *star_timings_r;
         std::vector<glm::vec2> *uv_frame_buffer_r;
+        std::vector<float> *star_timings_r;
         std::vector<Data::Mission::ObjResource::FacerPolygon> *facer_polygons_info_r;
-        unsigned facer_polygons_amount;
+        unsigned facer_triangles_amount;
+        unsigned facer_polygons_stride;
         glm::vec3 camera_right, camera_up;
 
         virtual void addTriangles( const std::vector<DynamicTriangleDraw::Triangle> &triangles, DynamicTriangleDraw::DrawCommand &triangles_draw ) const;

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
@@ -26,15 +26,19 @@ public:
         
         Mesh mesh;
         std::vector<glm::u8vec2> uv_animation_data;
-        std::vector<Data::Mission::ObjResource::FaceOverrideType> uv_animation_info;
-        std::vector<DynamicTriangleDraw::Triangle> transparent_triangles;
+        std::vector<Data::Mission::ObjResource::FaceOverrideType>   uv_animation_info;
+        std::vector<Data::Mission::ObjResource::FacerPolygon>     facer_polygons_info;
+        std::vector<DynamicTriangleDraw::Triangle>              transparent_triangles;
         std::set<GLES2::ModelInstance*> instances_r; // The list of all instances that will be drawn.
+        unsigned facer_polygons_amount;
 
         void bindUVAnimation(GLuint animated_uv_frames_id, unsigned int time, std::vector<glm::vec2>& uv_frame_buffer) const;
     };
     class Dynamic : public Mesh::DynamicNormal {
     public:
         glm::vec2 texture_offset;
+        std::vector<Data::Mission::ObjResource::FacerPolygon> *facer_polygons_info_r;
+        unsigned facer_polygons_amount;
         std::vector<glm::vec2> *uv_frame_buffer_r;
 
         virtual void addTriangles( const std::vector<DynamicTriangleDraw::Triangle> &triangles, DynamicTriangleDraw::DrawCommand &triangles_draw ) const;

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
@@ -25,6 +25,7 @@ public:
         ModelArray( Program *program ) : mesh( program ) {}
         
         Mesh mesh;
+        size_t star_timing_amount;
         std::vector<glm::u8vec2> uv_animation_data;
         std::vector<Data::Mission::ObjResource::FaceOverrideType>   uv_animation_info;
         std::vector<Data::Mission::ObjResource::FacerPolygon>     facer_polygons_info;
@@ -37,6 +38,7 @@ public:
     class Dynamic : public Mesh::DynamicNormal {
     public:
         glm::vec2 texture_offset;
+        std::vector<float> *star_timings_r;
         std::vector<glm::vec2> *uv_frame_buffer_r;
         std::vector<Data::Mission::ObjResource::FacerPolygon> *facer_polygons_info_r;
         unsigned facer_polygons_amount;

--- a/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
+++ b/src/Graphics/SDL2/GLES2/Internal/StaticModelDraw.h
@@ -25,7 +25,7 @@ public:
         ModelArray( Program *program ) : mesh( program ) {}
         
         Mesh mesh;
-        size_t star_timing_amount;
+        std::vector<float> star_timing_speed;
         std::vector<glm::u8vec2> uv_animation_data;
         std::vector<Data::Mission::ObjResource::FaceOverrideType>   uv_animation_info;
         std::vector<Data::Mission::ObjResource::FacerPolygon>     facer_polygons_info;

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -117,10 +117,10 @@ Graphics::SDL2::GLES2::Internal::World::World() {
     this->glow_time = 0;
     setPolygonTypeBlink( 111, 1.0f );
 
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,  "vec4 " + Utilities::ModelBuilder::POSITION_COMPONENT_NAME ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,  "vec2 " + Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,  "vec3 " + Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::HIGH, "vec4 " + Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec4 " + Utilities::ModelBuilder::POSITION_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 " + Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec3 " + Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::HIGH,   "vec4 " + Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME ) );
 
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec3 vertex_colors" ) );
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec2 texture_coord_1" ) );

--- a/src/Graphics/SDL2/GLES2/Internal/World.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/World.cpp
@@ -98,7 +98,8 @@ const GLchar* Graphics::SDL2::GLES2::Internal::World::default_vertex_shader =
     "   texture_coord_1 = tex_coord_pos + AnimatedUVDestination * DISPLACEMENT;\n"
     "   texture_coord_1 = fract( texture_coord_1 ) + vec2( float( texture_coord_1.x == 1. ), float( texture_coord_1.y == 1. ) );\n"
 
-    "   gl_Position = Transform * vec4(POSITION.xyz, 1.0);\n"
+    "   MAKE_FULL_POSITION(POSITION);\n"
+    "   gl_Position = Transform * full_position;\n"
     "}\n";
 
 const GLchar* Graphics::SDL2::GLES2::Internal::World::default_fragment_shader =
@@ -116,10 +117,10 @@ Graphics::SDL2::GLES2::Internal::World::World() {
     this->glow_time = 0;
     setPolygonTypeBlink( 111, 1.0f );
 
-    attributes.push_back( Shader::Attribute( Shader::Type::MEDIUM, "vec4 " + Utilities::ModelBuilder::POSITION_COMPONENT_NAME ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec2 " + Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::LOW,    "vec3 " + Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME ) );
-    attributes.push_back( Shader::Attribute( Shader::Type::HIGH,   "vec4 " + Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,  "vec4 " + Utilities::ModelBuilder::POSITION_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,  "vec2 " + Utilities::ModelBuilder::TEX_COORD_0_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::LOW,  "vec3 " + Utilities::ModelBuilder::COLORS_0_COMPONENT_NAME ) );
+    attributes.push_back( Shader::Attribute( Shader::Type::HIGH, "vec4 " + Data::Mission::TilResource::TILE_TYPE_COMPONENT_NAME ) );
 
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec3 vertex_colors" ) );
     varyings.push_back( Shader::Varying( Shader::Type::LOW, "vec2 texture_coord_1" ) );

--- a/src/Graphics/SDL2/GLES2/ModelInstance.h
+++ b/src/Graphics/SDL2/GLES2/ModelInstance.h
@@ -16,6 +16,7 @@ class ModelInstance : public Graphics::ModelInstance {
 public:
     Internal::StaticModelDraw::ModelArray *array_r;
     Internal::StaticModelDraw::ModelArray *bb_array_r;
+    std::vector<float> star_timings;
     glm::vec3 culling_sphere_position;
     float culling_sphere_radius;
     


### PR DESCRIPTION
* Circles had been renamed to stars.
* Stars now look like the stars found on Future Cop rather than using on placeholders.
* Fixed precision bugs with OpenGL ES 2.
* Star vertex color animations had been implemented.