### PR TITLE
Mouse Menu Controls; Crash Without Game Data Fix

### DIFF
--- a/src/Controls/CursorInputSet.h
+++ b/src/Controls/CursorInputSet.h
@@ -20,7 +20,9 @@ public:
         RIGHT_BUTTON,
         MOTION_X,
         MOTION_Y,
-        WHEEL_X, // This most likely will not be available on most mouses.
+        POSITION_X,
+        POSITION_Y,
+        WHEEL_X,
         WHEEL_Y,
         TOTAL_BUTTONS
     };

--- a/src/Controls/SDL2/CursorInputSet.cpp
+++ b/src/Controls/SDL2/CursorInputSet.cpp
@@ -11,6 +11,8 @@ Controls::CursorInputSet::CursorInputSet( std::string name_param ) : InputSetInt
     this->states[ Inputs::RIGHT_BUTTON  ].declare( "RIGHT_BUTTON",  &changed );
     this->states[ Inputs::MOTION_X      ].declare( "MOTION_X",      &changed );
     this->states[ Inputs::MOTION_Y      ].declare( "MOTION_Y",      &changed );
+    this->states[ Inputs::POSITION_X    ].declare( "POSITION_X",    &changed );
+    this->states[ Inputs::POSITION_Y    ].declare( "POSITION_Y",    &changed );
     this->states[ Inputs::WHEEL_X       ].declare( "WHEEL_X",       &changed );
     this->states[ Inputs::WHEEL_Y       ].declare( "WHEEL_Y",       &changed );
 }

--- a/src/Controls/SDL2/System.cpp
+++ b/src/Controls/SDL2/System.cpp
@@ -136,6 +136,16 @@ bool UpdateCursor( Controls::CursorInputSet &cursor, SDL_Event sdl_event ) {
         input_internal_p->changed = true;
         input_internal_p->state = static_cast<float>(sdl_event.motion.yrel);
 
+        input_p = cursor.getInput( Controls::CursorInputSet::POSITION_X );
+        input_internal_p = reinterpret_cast<Controls::SDL2::Input*>( input_p->getInternalData() );
+        input_internal_p->changed = true;
+        input_internal_p->state = static_cast<float>(sdl_event.motion.x);
+
+        input_p = cursor.getInput( Controls::CursorInputSet::POSITION_Y );
+        input_internal_p = reinterpret_cast<Controls::SDL2::Input*>( input_p->getInternalData() );
+        input_internal_p->changed = true;
+        input_internal_p->state = static_cast<float>(sdl_event.motion.y);
+
         *input_internal_p->global_change = true;
 
         return true;
@@ -449,20 +459,28 @@ int Controls::System::allocateCursor() {
             input_internal_r->sdl_event.type = SDL_MOUSEBUTTONDOWN;
             input_internal_r->sdl_event.button.button = SDL_BUTTON_RIGHT;
 
-            input_internal_r = reinterpret_cast<Controls::SDL2::Input*>( this->cursor_p->getInput( Controls::CursorInputSet::Inputs::WHEEL_X )->getInternalData() );
-            input_internal_r->sdl_event.type = SDL_MOUSEWHEEL;
-            input_internal_r->axis = Controls::SDL2::Input::Axis::X;
-
-            input_internal_r = reinterpret_cast<Controls::SDL2::Input*>( this->cursor_p->getInput( Controls::CursorInputSet::Inputs::WHEEL_Y )->getInternalData() );
-            input_internal_r->sdl_event.type = SDL_MOUSEWHEEL;
-            input_internal_r->axis = Controls::SDL2::Input::Axis::Y;
-
             input_internal_r = reinterpret_cast<Controls::SDL2::Input*>( this->cursor_p->getInput( Controls::CursorInputSet::Inputs::MOTION_X )->getInternalData() );
             input_internal_r->sdl_event.type = SDL_MOUSEMOTION;
             input_internal_r->axis = Controls::SDL2::Input::Axis::X;
 
             input_internal_r = reinterpret_cast<Controls::SDL2::Input*>( this->cursor_p->getInput( Controls::CursorInputSet::Inputs::MOTION_Y )->getInternalData() );
             input_internal_r->sdl_event.type = SDL_MOUSEMOTION;
+            input_internal_r->axis = Controls::SDL2::Input::Axis::Y;
+
+            input_internal_r = reinterpret_cast<Controls::SDL2::Input*>( this->cursor_p->getInput( Controls::CursorInputSet::Inputs::POSITION_X )->getInternalData() );
+            input_internal_r->sdl_event.type = SDL_MOUSEMOTION;
+            input_internal_r->axis = Controls::SDL2::Input::Axis::X;
+
+            input_internal_r = reinterpret_cast<Controls::SDL2::Input*>( this->cursor_p->getInput( Controls::CursorInputSet::Inputs::POSITION_Y )->getInternalData() );
+            input_internal_r->sdl_event.type = SDL_MOUSEMOTION;
+            input_internal_r->axis = Controls::SDL2::Input::Axis::Y;
+
+            input_internal_r = reinterpret_cast<Controls::SDL2::Input*>( this->cursor_p->getInput( Controls::CursorInputSet::Inputs::WHEEL_X )->getInternalData() );
+            input_internal_r->sdl_event.type = SDL_MOUSEWHEEL;
+            input_internal_r->axis = Controls::SDL2::Input::Axis::X;
+
+            input_internal_r = reinterpret_cast<Controls::SDL2::Input*>( this->cursor_p->getInput( Controls::CursorInputSet::Inputs::WHEEL_Y )->getInternalData() );
+            input_internal_r->sdl_event.type = SDL_MOUSEWHEEL;
             input_internal_r->axis = Controls::SDL2::Input::Axis::Y;
 
             return 1;

--- a/src/Graphics/SDL2/GLES2/Internal/FontSystem.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/FontSystem.cpp
@@ -54,9 +54,8 @@ const GLchar* Graphics::SDL2::GLES2::Internal::FontSystem::default_fragment_shad
     "{\n"
     "    float visable = texture2D(Texture, texture_coord).r;\n"
     "    if( visable < 0.03125 )\n"
-    "        gl_FragColor = vec4(0, 0, 0, 1);\n"
-    "    else\n"
-    "        gl_FragColor = vertex_color;\n"
+    "        discard;\n"
+    "    gl_FragColor = vertex_color;\n"
     "}\n";
 
 const GLchar* Graphics::SDL2::GLES2::Internal::FontSystem::getDefaultVertexShader() {

--- a/src/Graphics/SDL2/GLES2/Internal/FontSystem.cpp
+++ b/src/Graphics/SDL2/GLES2/Internal/FontSystem.cpp
@@ -213,14 +213,18 @@ int Graphics::SDL2::GLES2::Internal::FontSystem::Text2D::addText( const std::str
 
                 char_vertex_buffer_r += 6;
 
-                this->pen_span_max.x = std::max<float>(this->pen_span_max.x,  lower_font.x );
-                this->pen_span_max.y = std::max<float>(this->pen_span_max.y, -lower_font.y );
-                this->pen_span_max.x = std::max<float>(this->pen_span_max.x,  higher_font.x );
-                this->pen_span_max.y = std::max<float>(this->pen_span_max.y, -higher_font.y );
-                this->pen_span_min.x = std::min<float>(this->pen_span_min.x,  lower_font.x );
-                this->pen_span_min.y = std::min<float>(this->pen_span_min.y, -lower_font.y );
-                this->pen_span_min.x = std::min<float>(this->pen_span_min.x,  higher_font.x );
-                this->pen_span_min.y = std::min<float>(this->pen_span_min.y, -higher_font.y );
+                // TODO Detect if character is completly transparent rather than relying upon this method.
+                // The issue of this method is that if the charset is different from ascii this would produce unpredictable results.
+                if(!isspace(*character)) {
+                    this->pen_span_max.x = std::max<float>(this->pen_span_max.x,  lower_font.x );
+                    this->pen_span_max.y = std::max<float>(this->pen_span_max.y, -lower_font.y );
+                    this->pen_span_max.x = std::max<float>(this->pen_span_max.x,  higher_font.x );
+                    this->pen_span_max.y = std::max<float>(this->pen_span_max.y, -higher_font.y );
+                    this->pen_span_min.x = std::min<float>(this->pen_span_min.x,  lower_font.x );
+                    this->pen_span_min.y = std::min<float>(this->pen_span_min.y, -lower_font.y );
+                    this->pen_span_min.x = std::min<float>(this->pen_span_min.x,  higher_font.x );
+                    this->pen_span_min.y = std::min<float>(this->pen_span_min.y, -higher_font.y );
+                }
             }
             else
                 std::cout << "invalid = " << (uint32_t)character[0] << std::endl;

--- a/src/Graphics/SDL2/GLES2/Internal/FontSystem.h
+++ b/src/Graphics/SDL2/GLES2/Internal/FontSystem.h
@@ -89,9 +89,9 @@ public:
          */
         int addText( const std::string &text, float scale, char centering = 'l' );
 
-        glm::vec2 addedTextStart() const { return pen_span_max; }
+        glm::vec2 addedTextStart() const { return pen_span_min; }
 
-        glm::vec2 addedTextEnd() const { return pen_span_min; }
+        glm::vec2 addedTextEnd() const { return pen_span_max; }
 
         /**
          * This clears all the text on the Text2D, and sets the font type of the font.

--- a/src/Graphics/SDL2/GLES2/Internal/FontSystem.h
+++ b/src/Graphics/SDL2/GLES2/Internal/FontSystem.h
@@ -38,6 +38,8 @@ public:
 
         glm::vec2 pen_position;
         uint32_t  pen_color;
+
+        glm::vec2 pen_span_min, pen_span_max;
     public:
         Text2D( Font *fontR );
         virtual ~Text2D();
@@ -53,7 +55,7 @@ public:
          * @note The pen starts out with white, you can change the color.
          * @param pen_color Indexes 0-3 are red, green, blue, alpha.
          */
-        void setPenColor( const uint8_t *pen_color);
+        void setPenColor( const uint8_t *pen_color_r);
 
         /**
          * @note The pen's position starts at (0,0).
@@ -86,6 +88,10 @@ public:
          * @return the text amount that was added to the text, or a negative one if the max_text is reached, or negative two if max_text is zero.
          */
         int addText( const std::string &text, float scale, char centering = 'l' );
+
+        glm::vec2 addedTextStart() const { return pen_span_max; }
+
+        glm::vec2 addedTextEnd() const { return pen_span_min; }
 
         /**
          * This clears all the text on the Text2D, and sets the font type of the font.

--- a/src/Graphics/SDL2/GLES2/Text2DBuffer.cpp
+++ b/src/Graphics/SDL2/GLES2/Text2DBuffer.cpp
@@ -312,6 +312,11 @@ int Graphics::SDL2::GLES2::Text2DBuffer::print( const std::string &text ) {
             // Try to add the filtered_text.
             add_text_state = this->current_text_2D_r->addText( filtered_text, this->scale_font, this->center_mode );
 
+            this->start.x = std::max<float>(this->start.x, this->current_text_2D_r->addedTextStart().x );
+            this->start.y = std::max<float>(this->start.y, this->current_text_2D_r->addedTextStart().y );
+            this->end.x   = std::min<float>(this->end.x,   this->current_text_2D_r->addedTextEnd().x );
+            this->end.y   = std::min<float>(this->end.y,   this->current_text_2D_r->addedTextEnd().y );
+
             // Just in case of errors.
             if( add_text_state == -1 || add_text_state == -2 )
             {
@@ -337,6 +342,11 @@ int Graphics::SDL2::GLES2::Text2DBuffer::print( const std::string &text ) {
                     // Attempt to add the filtered_text again.
                     add_text_state = this->current_text_2D_r->addText( filtered_text, this->scale_font );
 
+                    this->start.x = std::max<float>(this->start.x, this->current_text_2D_r->addedTextStart().x );
+                    this->start.y = std::max<float>(this->start.y, this->current_text_2D_r->addedTextStart().y );
+                    this->end.x   = std::min<float>(this->end.x,   this->current_text_2D_r->addedTextEnd().x );
+                    this->end.y   = std::min<float>(this->end.y,   this->current_text_2D_r->addedTextEnd().y );
+
                     if( add_text_state >= 0 )
                         return add_text_state;
                     else
@@ -358,6 +368,19 @@ int Graphics::SDL2::GLES2::Text2DBuffer::print( const std::string &text ) {
     }
     else
         return -1;
+}
+
+void Graphics::SDL2::GLES2::Text2DBuffer::beginBox() {
+    this->start = glm::vec2(-std::numeric_limits<float>::max());
+    this->end   = glm::vec2( std::numeric_limits<float>::max());
+}
+
+glm::vec2 Graphics::SDL2::GLES2::Text2DBuffer::getBoxStart() const {
+    return this->start;
+}
+
+glm::vec2 Graphics::SDL2::GLES2::Text2DBuffer::getBoxEnd() const {
+    return this->end;
 }
 
 int Graphics::SDL2::GLES2::Text2DBuffer::reset() {

--- a/src/Graphics/SDL2/GLES2/Text2DBuffer.cpp
+++ b/src/Graphics/SDL2/GLES2/Text2DBuffer.cpp
@@ -312,10 +312,10 @@ int Graphics::SDL2::GLES2::Text2DBuffer::print( const std::string &text ) {
             // Try to add the filtered_text.
             add_text_state = this->current_text_2D_r->addText( filtered_text, this->scale_font, this->center_mode );
 
-            this->start.x = std::max<float>(this->start.x, this->current_text_2D_r->addedTextStart().x );
-            this->start.y = std::max<float>(this->start.y, this->current_text_2D_r->addedTextStart().y );
-            this->end.x   = std::min<float>(this->end.x,   this->current_text_2D_r->addedTextEnd().x );
-            this->end.y   = std::min<float>(this->end.y,   this->current_text_2D_r->addedTextEnd().y );
+            this->start.x = std::min<float>(this->start.x, this->current_text_2D_r->addedTextStart().x );
+            this->start.y = std::min<float>(this->start.y, this->current_text_2D_r->addedTextStart().y );
+            this->end.x   = std::max<float>(this->end.x,   this->current_text_2D_r->addedTextEnd().x );
+            this->end.y   = std::max<float>(this->end.y,   this->current_text_2D_r->addedTextEnd().y );
 
             // Just in case of errors.
             if( add_text_state == -1 || add_text_state == -2 )
@@ -342,10 +342,10 @@ int Graphics::SDL2::GLES2::Text2DBuffer::print( const std::string &text ) {
                     // Attempt to add the filtered_text again.
                     add_text_state = this->current_text_2D_r->addText( filtered_text, this->scale_font );
 
-                    this->start.x = std::max<float>(this->start.x, this->current_text_2D_r->addedTextStart().x );
-                    this->start.y = std::max<float>(this->start.y, this->current_text_2D_r->addedTextStart().y );
-                    this->end.x   = std::min<float>(this->end.x,   this->current_text_2D_r->addedTextEnd().x );
-                    this->end.y   = std::min<float>(this->end.y,   this->current_text_2D_r->addedTextEnd().y );
+                    this->start.x = std::min<float>(this->start.x, this->current_text_2D_r->addedTextStart().x );
+                    this->start.y = std::min<float>(this->start.y, this->current_text_2D_r->addedTextStart().y );
+                    this->end.x   = std::max<float>(this->end.x,   this->current_text_2D_r->addedTextEnd().x );
+                    this->end.y   = std::max<float>(this->end.y,   this->current_text_2D_r->addedTextEnd().y );
 
                     if( add_text_state >= 0 )
                         return add_text_state;
@@ -371,8 +371,8 @@ int Graphics::SDL2::GLES2::Text2DBuffer::print( const std::string &text ) {
 }
 
 void Graphics::SDL2::GLES2::Text2DBuffer::beginBox() {
-    this->start = glm::vec2(-std::numeric_limits<float>::max());
-    this->end   = glm::vec2( std::numeric_limits<float>::max());
+    this->start = glm::vec2( std::numeric_limits<float>::max());
+    this->end   = glm::vec2(-std::numeric_limits<float>::max());
 }
 
 glm::vec2 Graphics::SDL2::GLES2::Text2DBuffer::getBoxStart() const {

--- a/src/Graphics/SDL2/GLES2/Text2DBuffer.h
+++ b/src/Graphics/SDL2/GLES2/Text2DBuffer.h
@@ -50,6 +50,10 @@ public:
     virtual int setCenterMode( enum CenterMode );
     virtual int print( const std::string &text );
 
+    virtual void beginBox();
+    virtual glm::vec2 getBoxStart() const;
+    virtual glm::vec2 getBoxEnd() const;
+
     /**
      * Restart the whole font buffer clearing the data.
      * @return How many font buffers were NOT cleared successfully, or a negative number indicating an error.

--- a/src/Graphics/Text2DBuffer.cpp
+++ b/src/Graphics/Text2DBuffer.cpp
@@ -3,7 +3,7 @@
 #include "Environment.h"
 #include "SDL2/GLES2/Text2DBuffer.h"
 
-Graphics::Text2DBuffer::Text2DBuffer() : start(-std::numeric_limits<float>::max()), end(std::numeric_limits<float>::max()) {
+Graphics::Text2DBuffer::Text2DBuffer() : start(std::numeric_limits<float>::max()), end(-std::numeric_limits<float>::max()) {
 }
 
 Graphics::Text2DBuffer* Graphics::Text2DBuffer::alloc( Graphics::Environment &env_r ) {

--- a/src/Graphics/Text2DBuffer.cpp
+++ b/src/Graphics/Text2DBuffer.cpp
@@ -3,7 +3,7 @@
 #include "Environment.h"
 #include "SDL2/GLES2/Text2DBuffer.h"
 
-Graphics::Text2DBuffer::Text2DBuffer() {
+Graphics::Text2DBuffer::Text2DBuffer() : start(-std::numeric_limits<float>::max()), end(std::numeric_limits<float>::max()) {
 }
 
 Graphics::Text2DBuffer* Graphics::Text2DBuffer::alloc( Graphics::Environment &env_r ) {

--- a/src/Graphics/Text2DBuffer.h
+++ b/src/Graphics/Text2DBuffer.h
@@ -14,6 +14,8 @@ class Environment;
 class Text2DBuffer {
 protected:
     Text2DBuffer();
+
+    glm::vec2 start, end;
 public:
     enum CenterMode {
         LEFT,
@@ -48,6 +50,10 @@ public:
     virtual int setColor( const glm::vec4 &color ) = 0;
     virtual int setCenterMode( enum CenterMode ) = 0;
     virtual int print( const std::string &text ) = 0;
+
+    virtual void beginBox() = 0;
+    virtual glm::vec2 getBoxStart() const = 0;
+    virtual glm::vec2 getBoxEnd() const = 0;
 
     /**
      * Restart the whole font buffer clearing the data.

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -158,10 +158,5 @@ void MainMenu::update( MainProgram &main_program, std::chrono::microseconds delt
         }
     }
 
-    for( size_t i = 0; i < this->items.size(); i++ ) {
-        if( this->current_item_index != i )
-            this->items[i]->drawNeutral( main_program );
-        else
-            this->items[i]->drawSelected( main_program );
-    }
+    drawAllItems( main_program );
 }

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -148,11 +148,13 @@ void MainMenu::update( MainProgram &main_program, std::chrono::microseconds delt
 
         text_2d_buffer_r->setFont( this->spec_detail_font );
         text_2d_buffer_r->setPosition( this->info_position );
+        text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::CenterMode::RIGHT );
         text_2d_buffer_r->print( FUTURE_COP_MIT_VERSION );
 
         if( main_program.global_r == nullptr || main_program.resource_r == nullptr ) {
             text_2d_buffer_r->setFont( this->prime_font );
             text_2d_buffer_r->setPosition( this->warning_position );
+            text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::CenterMode::MIDDLE );
             text_2d_buffer_r->setColor( glm::vec4( 1, 0, 0, 1 ) );
             text_2d_buffer_r->print( "Not all resources are found!" );
         }

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -146,14 +146,16 @@ void MainMenu::update( MainProgram &main_program, std::chrono::microseconds delt
             text_2d_buffer_r->print( "MIT" );
         }
 
-        if( main_program.global_r == nullptr || main_program.resource_r == nullptr ) {
-            text_2d_buffer_r->setFont( this->prime_font );
-            text_2d_buffer_r->setPosition( this->warning_position );
-        }
-
         text_2d_buffer_r->setFont( this->spec_detail_font );
         text_2d_buffer_r->setPosition( this->info_position );
         text_2d_buffer_r->print( FUTURE_COP_MIT_VERSION );
+
+        if( main_program.global_r == nullptr || main_program.resource_r == nullptr ) {
+            text_2d_buffer_r->setFont( this->prime_font );
+            text_2d_buffer_r->setPosition( this->warning_position );
+            text_2d_buffer_r->setColor( glm::vec4( 1, 0, 0, 1 ) );
+            text_2d_buffer_r->print( "Not all resources are found!" );
+        }
     }
 
     for( size_t i = 0; i < this->items.size(); i++ ) {

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -71,57 +71,53 @@ void MainMenu::load( MainProgram &main_program ) {
 
     const Graphics::Text2DBuffer::CenterMode right_mode = Graphics::Text2DBuffer::CenterMode::RIGHT;
 
-    Graphics::Text2DBuffer::Font title_font;
-    Graphics::Text2DBuffer::Font prime_font;
     Graphics::Text2DBuffer::Font selected_font;
-    Graphics::Text2DBuffer::Font spec_detail_font;
 
     const unsigned step = 2. / 30. * static_cast<float>( scale.y );
 
-    if( !main_program.text_2d_buffer_r->selectFont( title_font, 1.5 * step, 2. * step ) )
-        title_font = {1, 4.0};
+    if( !main_program.text_2d_buffer_r->selectFont( this->title_font, 1.5 * step, 2. * step ) )
+        this->title_font = {1, 4.0};
 
-    if( !main_program.text_2d_buffer_r->selectFont( prime_font, 0.8 * step, 0.9 * step - 1 ) )
-        prime_font = {1, 2.0};
+    if( !main_program.text_2d_buffer_r->selectFont( this->prime_font, 0.8 * step, 0.9 * step - 1 ) )
+        this->prime_font = {1, 2.0};
 
     if( !main_program.text_2d_buffer_r->selectFont( selected_font, 0.9 * step, step ) )
         selected_font = {1, 2.25};
 
-    if( !main_program.text_2d_buffer_r->selectFont( spec_detail_font, 1, 14 ) )
-        spec_detail_font = 1;
+    if( !main_program.text_2d_buffer_r->selectFont( this->spec_detail_font, 1, 14 ) )
+        this->spec_detail_font = 1;
 
     this->items.clear();
 
     if( !this->is_game_on ) {
-        this->items.emplace_back( new Menu::TextButton( "Map Spectator",       glm::vec2( center, scale.y - 7 * step ), 5, 0, 1, 0, &item_click_map_spectator,       prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "View Game Models",    glm::vec2( center, scale.y - 6 * step ), 0, 1, 2, 1, &item_click_view_game_models,    prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "Announcement Player", glm::vec2( center, scale.y - 5 * step ), 1, 2, 3, 2, &item_click_player_announcement, prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "Sound Player",        glm::vec2( center, scale.y - 4 * step ), 2, 3, 4, 3, &item_click_player_sound,        prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "Options",             glm::vec2( center, scale.y - 3 * step ), 3, 4, 5, 4, &item_click_options,             prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "Exit to OS",          glm::vec2( center, scale.y - 2 * step ), 4, 5, 0, 5, &item_click_exit_game,           prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Map Spectator",       glm::vec2( center, scale.y - 7 * step ), 5, 0, 1, 0, &item_click_map_spectator,       this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "View Game Models",    glm::vec2( center, scale.y - 6 * step ), 0, 1, 2, 1, &item_click_view_game_models,    this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Announcement Player", glm::vec2( center, scale.y - 5 * step ), 1, 2, 3, 2, &item_click_player_announcement, this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Sound Player",        glm::vec2( center, scale.y - 4 * step ), 2, 3, 4, 3, &item_click_player_sound,        this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Options",             glm::vec2( center, scale.y - 3 * step ), 3, 4, 5, 4, &item_click_options,             this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Exit to OS",          glm::vec2( center, scale.y - 2 * step ), 4, 5, 0, 5, &item_click_exit_game,           this->prime_font, selected_font ) );
 
-        if( main_program.text_2d_buffer_r->getLineLength( title_font, "Future Cop: MIT" ) > scale.x ) {
-            this->items.emplace_back( new Menu::TextButton( "Future Cop:",  glm::vec2( center, 3 * step ), 0, 0, 0, 0, &Menu::null_item_click, title_font, title_font ) );
-            this->items.emplace_back( new Menu::TextButton( "MIT",          glm::vec2( center, 5 * step ), 0, 0, 0, 0, &Menu::null_item_click, title_font, title_font ) );
-        }
-        else
-            this->items.emplace_back( new Menu::TextButton( "Future Cop: MIT",  glm::vec2( center, 3 * step ), 0, 0, 0, 0, &Menu::null_item_click, title_font, title_font ) );
+        this->top_title_position    = glm::vec2( center, 3 * step );
+        this->bottom_title_position = glm::vec2( center, 2 * step );
+
+        if( main_program.text_2d_buffer_r->getLineLength( this->title_font, "Future Cop: MIT" ) > scale.x )
+            this->bottom_title_position = glm::vec2( center, 5 * step );
 
         // If any resource is missing I am sure the user would want to know about it.
-        if( main_program.global_r == nullptr || main_program.resource_r == nullptr )
-            this->items.emplace_back( new Menu::TextButton( "Not all resources are found",  glm::vec2( center, 7 * step ), 0, 0, 0, 0, &Menu::null_item_click, prime_font, prime_font ) );
+        this->warning_position = glm::vec2( center, 7 * step );
 
-        this->items.emplace_back( new Menu::TextButton( FUTURE_COP_MIT_VERSION, glm::vec2( scale.x, scale.y - 14), 0, 0, 0, 0, &Menu::null_item_click, spec_detail_font, spec_detail_font, right_mode ) );
+        this->info_position = glm::vec2( scale.x, scale.y - 14);
+
         this->current_item_index = 0;
     }
     else {
-        this->items.emplace_back( new Menu::TextButton( "Back to Session",     glm::vec2( center, scale.y - 9 * step ), 6, 0, 1, 0, &item_click_menu_done,           prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "Map Spectator",       glm::vec2( center, scale.y - 7 * step ), 0, 1, 2, 1, &item_click_map_spectator,       prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "View Game Models",    glm::vec2( center, scale.y - 6 * step ), 1, 2, 3, 2, &item_click_view_game_models,    prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "Announcement Player", glm::vec2( center, scale.y - 5 * step ), 2, 3, 4, 3, &item_click_player_announcement, prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "Sound Player",        glm::vec2( center, scale.y - 4 * step ), 3, 4, 5, 4, &item_click_player_sound,        prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "Options",             glm::vec2( center, scale.y - 3 * step ), 4, 5, 6, 5, &item_click_options,             prime_font, selected_font ) );
-        this->items.emplace_back( new Menu::TextButton( "Exit to OS",          glm::vec2( center, scale.y - 2 * step ), 5, 6, 0, 6, &item_click_exit_game,           prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Back to Session",     glm::vec2( center, scale.y - 9 * step ), 6, 0, 1, 0, &item_click_menu_done,           this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Map Spectator",       glm::vec2( center, scale.y - 7 * step ), 0, 1, 2, 1, &item_click_map_spectator,       this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "View Game Models",    glm::vec2( center, scale.y - 6 * step ), 1, 2, 3, 2, &item_click_view_game_models,    this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Announcement Player", glm::vec2( center, scale.y - 5 * step ), 2, 3, 4, 3, &item_click_player_announcement, this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Sound Player",        glm::vec2( center, scale.y - 4 * step ), 3, 4, 5, 4, &item_click_player_sound,        this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Options",             glm::vec2( center, scale.y - 3 * step ), 4, 5, 6, 5, &item_click_options,             this->prime_font, selected_font ) );
+        this->items.emplace_back( new Menu::TextButton( "Exit to OS",          glm::vec2( center, scale.y - 2 * step ), 5, 6, 0, 6, &item_click_exit_game,           this->prime_font, selected_font ) );
         this->current_item_index = 0;
     }
 }
@@ -132,6 +128,33 @@ void MainMenu::unload( MainProgram &main_program ) {
 
 void MainMenu::update( MainProgram &main_program, std::chrono::microseconds delta ) {
     Menu::update( main_program, delta );
+
+    const auto text_2d_buffer_r = main_program.text_2d_buffer_r;
+
+    if( !this->is_game_on ) {
+        text_2d_buffer_r->setColor( glm::vec4( 1 ) );
+        text_2d_buffer_r->setFont( this->title_font );
+        text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::CenterMode::MIDDLE );
+        text_2d_buffer_r->setPosition( this->top_title_position );
+
+        if( this->top_title_position.y > this->bottom_title_position.y )
+            text_2d_buffer_r->print( "Future Cop: MIT" );
+        else {
+            text_2d_buffer_r->print( "Future Cop:" );
+
+            text_2d_buffer_r->setPosition( this->bottom_title_position );
+            text_2d_buffer_r->print( "MIT" );
+        }
+
+        if( main_program.global_r == nullptr || main_program.resource_r == nullptr ) {
+            text_2d_buffer_r->setFont( this->prime_font );
+            text_2d_buffer_r->setPosition( this->warning_position );
+        }
+
+        text_2d_buffer_r->setFont( this->spec_detail_font );
+        text_2d_buffer_r->setPosition( this->info_position );
+        text_2d_buffer_r->print( FUTURE_COP_MIT_VERSION );
+    }
 
     for( size_t i = 0; i < this->items.size(); i++ ) {
         if( this->current_item_index != i )

--- a/src/MainMenu.h
+++ b/src/MainMenu.h
@@ -10,6 +10,12 @@ public:
 
     bool is_game_on;
 
+    Graphics::Text2DBuffer::Font title_font;
+    Graphics::Text2DBuffer::Font prime_font;
+    Graphics::Text2DBuffer::Font spec_detail_font;
+
+    glm::vec2 top_title_position, bottom_title_position, warning_position, info_position;
+
     virtual ~MainMenu();
 
     virtual void load( MainProgram &main_program );

--- a/src/MainProgram.h
+++ b/src/MainProgram.h
@@ -64,6 +64,9 @@ public:
     glm::vec2 camera_rotation;
     float     camera_distance;
 
+    bool mouse_clicked;
+    glm::vec2 mouse_position;
+
     bool play_loop;
 
 protected:

--- a/src/MapSelectorMenu.cpp
+++ b/src/MapSelectorMenu.cpp
@@ -50,14 +50,13 @@ void MapSelectorMenu::load( MainProgram &main_program ) {
     const unsigned line_height = static_cast<float>( scale.y ) / static_cast<float>( Data::Manager::AMOUNT_OF_IFF_IDS + 3);
     this->error_line_height = 0.025 * static_cast<float>( scale.y );
 
-    Graphics::Text2DBuffer::Font title_font;
     Graphics::Text2DBuffer::Font prime_font;
     Graphics::Text2DBuffer::Font selected_font;
 
-    if( !main_program.text_2d_buffer_r->selectFont( title_font, line_height, line_height * 2 - 1 ) ) {
-        title_font = 1;
+    if( !main_program.text_2d_buffer_r->selectFont( this->title_font, line_height, line_height * 2 - 1 ) ) {
+        this->title_font = 1;
 
-        main_program.text_2d_buffer_r->scaleFont( title_font, line_height - 1 );
+        main_program.text_2d_buffer_r->scaleFont( this->title_font, line_height - 1 );
     }
 
     if( !main_program.text_2d_buffer_r->selectFont( prime_font, 0.7 * line_height, 0.9 * line_height ) ) {
@@ -115,8 +114,6 @@ void MapSelectorMenu::load( MainProgram &main_program ) {
     this->missing_resource = {};
     this->missing_global   = {};
 
-    this->items.emplace_back( new Menu::TextButton( this->name, glm::vec2( center, 0 ), title, title, title, title, &Menu::null_item_click, title_font, title_font ) );
-
     this->current_item_index = 0;
 }
 
@@ -128,6 +125,12 @@ void MapSelectorMenu::update( MainProgram &main_program, std::chrono::microsecon
     Menu::update( main_program, delta );
 
     const auto text_2d_buffer_r = main_program.text_2d_buffer_r;
+
+    text_2d_buffer_r->setColor( glm::vec4( 1 ) );
+    text_2d_buffer_r->setFont( this->title_font );
+    text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::CenterMode::MIDDLE );
+    text_2d_buffer_r->setPosition( glm::vec2( main_program.getWindowScale().x / 2, 0 ) );
+        text_2d_buffer_r->print( this->name );
 
     if( !this->missing_resource.empty() ) {
         text_2d_buffer_r->setFont( this->error_font );

--- a/src/MapSelectorMenu.cpp
+++ b/src/MapSelectorMenu.cpp
@@ -170,15 +170,19 @@ void MapSelectorMenu::update( MainProgram &main_program, std::chrono::microsecon
         }
     }
 
-    for( size_t i = this->items.size(); i != 0; i-- ) {
-        if( this->items[i - 1]->hasBox() ) {
-            if(
-                this->items[i - 1]->start.x < main_program.mouse_position.x && this->items[i - 1]->end.x > main_program.mouse_position.x &&
-                this->items[i - 1]->start.y < main_program.mouse_position.y && this->items[i - 1]->end.y > main_program.mouse_position.y
-            ) {
-                this->current_item_index = i - 1;
-                break;
+    for( size_t i = 0; i < this->items.size(); i++ ) {
+        if( this->items[i]->hasBox() &&
+            this->items[i]->start.x < main_program.mouse_position.x && this->items[i]->end.x > main_program.mouse_position.x &&
+            this->items[i]->start.y < main_program.mouse_position.y && this->items[i]->end.y > main_program.mouse_position.y
+        ) {
+            this->current_item_index = i;
+
+            if(main_program.mouse_clicked) {
+                this->timer = std::chrono::microseconds( 1000 );
+                this->items[i]->item_click_r->onPress( main_program, this, this->items[i].get() );
             }
+
+            break;
         }
     }
 

--- a/src/MapSelectorMenu.cpp
+++ b/src/MapSelectorMenu.cpp
@@ -114,6 +114,8 @@ void MapSelectorMenu::load( MainProgram &main_program ) {
     this->missing_resource = {};
     this->missing_global   = {};
 
+    this->title_position = glm::vec2( center, 0 );
+
     this->current_item_index = 0;
 }
 
@@ -129,8 +131,8 @@ void MapSelectorMenu::update( MainProgram &main_program, std::chrono::microsecon
     text_2d_buffer_r->setColor( glm::vec4( 1 ) );
     text_2d_buffer_r->setFont( this->title_font );
     text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::CenterMode::MIDDLE );
-    text_2d_buffer_r->setPosition( glm::vec2( main_program.getWindowScale().x / 2, 0 ) );
-        text_2d_buffer_r->print( this->name );
+    text_2d_buffer_r->setPosition( this->title_position );
+    text_2d_buffer_r->print( this->name );
 
     if( !this->missing_resource.empty() ) {
         text_2d_buffer_r->setFont( this->error_font );
@@ -167,22 +169,6 @@ void MapSelectorMenu::update( MainProgram &main_program, std::chrono::microsecon
                 text_2d_buffer_r->setPosition( glm::vec2( this->placement.x, placement + (3 + i) * this->error_line_height) );
                 text_2d_buffer_r->print( this->missing_global[i] );
             }
-        }
-    }
-
-    for( size_t i = 0; i < this->items.size(); i++ ) {
-        if( this->items[i]->hasBox() &&
-            this->items[i]->start.x < main_program.mouse_position.x && this->items[i]->end.x > main_program.mouse_position.x &&
-            this->items[i]->start.y < main_program.mouse_position.y && this->items[i]->end.y > main_program.mouse_position.y
-        ) {
-            this->current_item_index = i;
-
-            if(main_program.mouse_clicked) {
-                this->timer = std::chrono::microseconds( 1000 );
-                this->items[i]->item_click_r->onPress( main_program, this, this->items[i].get() );
-            }
-
-            break;
         }
     }
 

--- a/src/MapSelectorMenu.cpp
+++ b/src/MapSelectorMenu.cpp
@@ -172,10 +172,5 @@ void MapSelectorMenu::update( MainProgram &main_program, std::chrono::microsecon
         }
     }
 
-    for( size_t i = 0; i < this->items.size(); i++ ) {
-        if( this->current_item_index != i )
-            this->items[i]->drawNeutral( main_program );
-        else
-            this->items[i]->drawSelected( main_program );
-    }
+    drawAllItems( main_program );
 }

--- a/src/MapSelectorMenu.cpp
+++ b/src/MapSelectorMenu.cpp
@@ -171,8 +171,11 @@ void MapSelectorMenu::update( MainProgram &main_program, std::chrono::microsecon
         if( this->items[i - 1]->hasBox() ) {
             if(
                 this->items[i - 1]->start.x < main_program.mouse_position.x && this->items[i - 1]->end.x > main_program.mouse_position.x &&
-                this->items[i - 1]->start.y < main_program.mouse_position.y && this->items[i - 1]->end.y > main_program.mouse_position.y)
+                this->items[i - 1]->start.y < main_program.mouse_position.y && this->items[i - 1]->end.y > main_program.mouse_position.y
+            ) {
                 this->current_item_index = i - 1;
+                break;
+            }
         }
     }
 

--- a/src/MapSelectorMenu.cpp
+++ b/src/MapSelectorMenu.cpp
@@ -84,7 +84,7 @@ void MapSelectorMenu::load( MainProgram &main_program ) {
         }
     }
 
-    const Graphics::Text2DBuffer::CenterMode left_mode  = Graphics::Text2DBuffer::CenterMode::LEFT;
+    const auto left_mode  = Graphics::Text2DBuffer::CenterMode::LEFT;
 
     for( size_t i = 0; i < Data::Manager::AMOUNT_OF_IFF_IDS; i++ ) {
         const std::string map_name = *Data::Manager::map_iffs[i];
@@ -164,6 +164,15 @@ void MapSelectorMenu::update( MainProgram &main_program, std::chrono::microsecon
                 text_2d_buffer_r->setPosition( glm::vec2( this->placement.x, placement + (3 + i) * this->error_line_height) );
                 text_2d_buffer_r->print( this->missing_global[i] );
             }
+        }
+    }
+
+    for( size_t i = this->items.size(); i != 0; i-- ) {
+        if( this->items[i - 1]->hasBox() ) {
+            if(
+                this->items[i - 1]->start.x < main_program.mouse_position.x && this->items[i - 1]->end.x > main_program.mouse_position.x &&
+                this->items[i - 1]->start.y < main_program.mouse_position.y && this->items[i - 1]->end.y > main_program.mouse_position.y)
+                this->current_item_index = i - 1;
         }
     }
 

--- a/src/MapSelectorMenu.h
+++ b/src/MapSelectorMenu.h
@@ -16,6 +16,9 @@ public:
 
     Graphics::Text2DBuffer::Font title_font;
     Graphics::Text2DBuffer::Font error_font;
+
+    glm::vec2 title_position;
+
     float missing_line_length;
     std::vector<std::string> missing_resource;
     std::vector<std::string> missing_global;

--- a/src/MapSelectorMenu.h
+++ b/src/MapSelectorMenu.h
@@ -14,6 +14,7 @@ public:
     std::string name;
     GameState *game_r;
 
+    Graphics::Text2DBuffer::Font title_font;
     Graphics::Text2DBuffer::Font error_font;
     float missing_line_length;
     std::vector<std::string> missing_resource;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -29,8 +29,6 @@ Menu::TextButton::TextButton( std::string p_name, glm::vec2 p_position, unsigned
 {}
 
 void Menu::TextButton::drawNeutral( MainProgram &main_program ) const {
-    main_program.text_2d_buffer_r->beginBox();
-
     if( main_program.text_2d_buffer_r->setFont( font ) == -3 )
         main_program.text_2d_buffer_r->setFont( 1 );
 
@@ -39,14 +37,9 @@ void Menu::TextButton::drawNeutral( MainProgram &main_program ) const {
     main_program.text_2d_buffer_r->setCenterMode( this->center_mode );
 
     main_program.text_2d_buffer_r->print( this->name );
-
-    *const_cast<glm::vec2*>(&start) = main_program.text_2d_buffer_r->getBoxStart();
-    *const_cast<glm::vec2*>(&end)   = main_program.text_2d_buffer_r->getBoxEnd();
 }
 
 void Menu::TextButton::drawSelected( MainProgram &main_program ) const {
-    main_program.text_2d_buffer_r->beginBox();
-
     if( main_program.text_2d_buffer_r->setFont( selected_font ) == -3 )
         main_program.text_2d_buffer_r->setFont( 1 );
 
@@ -55,9 +48,6 @@ void Menu::TextButton::drawSelected( MainProgram &main_program ) const {
     main_program.text_2d_buffer_r->setCenterMode( this->center_mode );
 
     main_program.text_2d_buffer_r->print( this->name );
-
-    *const_cast<glm::vec2*>(&start) = main_program.text_2d_buffer_r->getBoxStart();
-    *const_cast<glm::vec2*>(&end)   = main_program.text_2d_buffer_r->getBoxEnd();
 }
 
 void Menu::load( MainProgram &main_program ) {
@@ -152,5 +142,19 @@ void Menu::update( MainProgram &main_program, std::chrono::microseconds delta ) 
             this->current_item_index = current_item_r->left_index;
             return;
         }
+    }
+}
+
+void Menu::drawAllItems( MainProgram &main_program ) {
+    for( size_t i = 0; i < this->items.size(); i++ ) {
+        main_program.text_2d_buffer_r->beginBox();
+
+        if( this->current_item_index != i )
+            this->items[i]->drawNeutral( main_program );
+        else
+            this->items[i]->drawSelected( main_program );
+
+        this->items[i]->start = main_program.text_2d_buffer_r->getBoxStart();
+        this->items[i]->end   = main_program.text_2d_buffer_r->getBoxEnd();
     }
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -63,7 +63,7 @@ void Menu::TextButton::drawSelected( MainProgram &main_program ) const {
     main_program.text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::LEFT );
 
     if( main_program.mouse_clicked ) {
-        main_program.text_2d_buffer_r->setPosition( main_program.text_2d_buffer_r->getBoxStart() );
+        main_program.text_2d_buffer_r->setPosition( main_program.text_2d_buffer_r->getBoxEnd() );
         main_program.text_2d_buffer_r->print( "2" );
     }
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -2,14 +2,6 @@
 
 #include "MainProgram.h"
 
-namespace {
-class NullItemClick : public Menu::ItemClick {
-public:
-    virtual void onPress( MainProgram&, Menu*, Menu::Item* ) {}
-};
-
-}
-
 void Menu::ItemClickSwitchMenu::onPress( MainProgram &main_program, Menu* menu_r, Menu::Item* item_r ) {
     main_program.switchMenu( this->menu_switch_r );
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -47,6 +47,8 @@ void Menu::TextButton::drawNeutral( MainProgram &main_program ) const {
     main_program.text_2d_buffer_r->setColor( glm::vec4( 1, 1, 1, 1 ) );
     main_program.text_2d_buffer_r->setPosition( this->position );
     main_program.text_2d_buffer_r->setCenterMode( this->center_mode );
+
+    main_program.text_2d_buffer_r->beginBox();
     main_program.text_2d_buffer_r->print( this->name );
 
     if( !hasBox() ) {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -29,6 +29,8 @@ Menu::TextButton::TextButton( std::string p_name, glm::vec2 p_position, unsigned
 {}
 
 void Menu::TextButton::drawNeutral( MainProgram &main_program ) const {
+    main_program.text_2d_buffer_r->beginBox();
+
     if( main_program.text_2d_buffer_r->setFont( font ) == -3 )
         main_program.text_2d_buffer_r->setFont( 1 );
 
@@ -36,16 +38,15 @@ void Menu::TextButton::drawNeutral( MainProgram &main_program ) const {
     main_program.text_2d_buffer_r->setPosition( this->position );
     main_program.text_2d_buffer_r->setCenterMode( this->center_mode );
 
-    main_program.text_2d_buffer_r->beginBox();
     main_program.text_2d_buffer_r->print( this->name );
 
-    if( !hasBox() ) {
-        *const_cast<glm::vec2*>(&start) = main_program.text_2d_buffer_r->getBoxStart();
-        *const_cast<glm::vec2*>(&end)   = main_program.text_2d_buffer_r->getBoxEnd();
-    }
+    *const_cast<glm::vec2*>(&start) = main_program.text_2d_buffer_r->getBoxStart();
+    *const_cast<glm::vec2*>(&end)   = main_program.text_2d_buffer_r->getBoxEnd();
 }
 
 void Menu::TextButton::drawSelected( MainProgram &main_program ) const {
+    main_program.text_2d_buffer_r->beginBox();
+
     if( main_program.text_2d_buffer_r->setFont( selected_font ) == -3 )
         main_program.text_2d_buffer_r->setFont( 1 );
 
@@ -53,13 +54,10 @@ void Menu::TextButton::drawSelected( MainProgram &main_program ) const {
     main_program.text_2d_buffer_r->setPosition( this->position );
     main_program.text_2d_buffer_r->setCenterMode( this->center_mode );
 
-    main_program.text_2d_buffer_r->beginBox();
     main_program.text_2d_buffer_r->print( this->name );
 
-    if( !hasBox() ) {
-        *const_cast<glm::vec2*>(&start) = main_program.text_2d_buffer_r->getBoxStart();
-        *const_cast<glm::vec2*>(&end)   = main_program.text_2d_buffer_r->getBoxEnd();
-    }
+    *const_cast<glm::vec2*>(&start) = main_program.text_2d_buffer_r->getBoxStart();
+    *const_cast<glm::vec2*>(&end)   = main_program.text_2d_buffer_r->getBoxEnd();
 }
 
 void Menu::load( MainProgram &main_program ) {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -62,16 +62,18 @@ void Menu::TextButton::drawSelected( MainProgram &main_program ) const {
 
     main_program.text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::LEFT );
 
-    main_program.text_2d_buffer_r->setPosition( main_program.text_2d_buffer_r->getBoxStart() );
-    main_program.text_2d_buffer_r->print( "2" );
-
-    main_program.text_2d_buffer_r->setPosition( main_program.text_2d_buffer_r->getBoxEnd() );
-    main_program.text_2d_buffer_r->print( "1" );
+    if( main_program.mouse_clicked ) {
+        main_program.text_2d_buffer_r->setPosition( main_program.text_2d_buffer_r->getBoxStart() );
+        main_program.text_2d_buffer_r->print( "2" );
+    }
 }
 
 void Menu::load( MainProgram &main_program ) {
     this->timer = std::chrono::microseconds( 0 );
     this->current_item_index = 0;
+
+    main_program.mouse_clicked = false;
+    main_program.mouse_position = glm::vec2(0);
 }
 
 void Menu::update( MainProgram &main_program, std::chrono::microseconds delta ) {
@@ -128,9 +130,19 @@ void Menu::update( MainProgram &main_program, std::chrono::microseconds delta ) 
         }
     }
 
-    if( main_program.control_cursor_r->isChanged() )
-    {
-        auto input_r = main_program.control_cursor_r->getInput( Controls::CursorInputSet::Inputs::POSITION_X );
+    if( !main_program.control_cursor_r->isChanged() )
+        main_program.mouse_clicked = false;
+    else {
+        auto input_r = main_program.control_cursor_r->getInput( Controls::CursorInputSet::Inputs::LEFT_BUTTON );
+        if( input_r->isChanged() && input_r->getState() < 0.5 )
+            main_program.mouse_clicked = true;
+        else
+            main_program.mouse_clicked = false;
+
+        input_r = main_program.control_cursor_r->getInput( Controls::CursorInputSet::Inputs::POSITION_X );
+        main_program.mouse_position.x = input_r->getState();
+
         input_r = main_program.control_cursor_r->getInput( Controls::CursorInputSet::Inputs::POSITION_Y );
+        main_program.mouse_position.y = input_r->getState();
     }
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -29,7 +29,8 @@ Menu::Item::Item() {
 }
 
 Menu::Item::Item( std::string p_name, glm::vec2 p_position, unsigned p_up_index, unsigned p_right_index, unsigned p_down_index, unsigned p_left_index, ItemClick *p_item_click_r ) :
-    name( p_name ), position( p_position ), up_index( p_up_index ), right_index( p_right_index ), down_index( p_down_index ), left_index( p_left_index ), item_click_r( p_item_click_r )
+    name( p_name ), position( p_position ), up_index( p_up_index ), right_index( p_right_index ), down_index( p_down_index ), left_index( p_left_index ), item_click_r( p_item_click_r ),
+    start(std::numeric_limits<float>::max()), end(-std::numeric_limits<float>::max())
 {}
 
 Menu::TextButton::TextButton() : Item(), font( 1 ), selected_font( 2 ), center_mode( Graphics::Text2DBuffer::CenterMode::MIDDLE ) {
@@ -47,6 +48,11 @@ void Menu::TextButton::drawNeutral( MainProgram &main_program ) const {
     main_program.text_2d_buffer_r->setPosition( this->position );
     main_program.text_2d_buffer_r->setCenterMode( this->center_mode );
     main_program.text_2d_buffer_r->print( this->name );
+
+    if( !hasBox() ) {
+        *const_cast<glm::vec2*>(&start) = main_program.text_2d_buffer_r->getBoxStart();
+        *const_cast<glm::vec2*>(&end)   = main_program.text_2d_buffer_r->getBoxEnd();
+    }
 }
 
 void Menu::TextButton::drawSelected( MainProgram &main_program ) const {
@@ -60,11 +66,9 @@ void Menu::TextButton::drawSelected( MainProgram &main_program ) const {
     main_program.text_2d_buffer_r->beginBox();
     main_program.text_2d_buffer_r->print( this->name );
 
-    main_program.text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::LEFT );
-
-    if( main_program.mouse_clicked ) {
-        main_program.text_2d_buffer_r->setPosition( main_program.text_2d_buffer_r->getBoxEnd() );
-        main_program.text_2d_buffer_r->print( "2" );
+    if( !hasBox() ) {
+        *const_cast<glm::vec2*>(&start) = main_program.text_2d_buffer_r->getBoxStart();
+        *const_cast<glm::vec2*>(&end)   = main_program.text_2d_buffer_r->getBoxEnd();
     }
 }
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -56,7 +56,17 @@ void Menu::TextButton::drawSelected( MainProgram &main_program ) const {
     main_program.text_2d_buffer_r->setColor( glm::vec4( 1, 1, 0, 1 ) );
     main_program.text_2d_buffer_r->setPosition( this->position );
     main_program.text_2d_buffer_r->setCenterMode( this->center_mode );
+
+    main_program.text_2d_buffer_r->beginBox();
     main_program.text_2d_buffer_r->print( this->name );
+
+    main_program.text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::LEFT );
+
+    main_program.text_2d_buffer_r->setPosition( main_program.text_2d_buffer_r->getBoxStart() );
+    main_program.text_2d_buffer_r->print( "2" );
+
+    main_program.text_2d_buffer_r->setPosition( main_program.text_2d_buffer_r->getBoxEnd() );
+    main_program.text_2d_buffer_r->print( "1" );
 }
 
 void Menu::load( MainProgram &main_program ) {
@@ -116,5 +126,11 @@ void Menu::update( MainProgram &main_program, std::chrono::microseconds delta ) 
             this->current_item_index = current_item_r->left_index;
             return;
         }
+    }
+
+    if( main_program.control_cursor_r->isChanged() )
+    {
+        auto input_r = main_program.control_cursor_r->getInput( Controls::CursorInputSet::Inputs::POSITION_X );
+        input_r = main_program.control_cursor_r->getInput( Controls::CursorInputSet::Inputs::POSITION_Y );
     }
 }

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -25,11 +25,9 @@ public:
         virtual void onPress( MainProgram&, Menu*, Item* );
     };
 
-    static ItemClick &null_item_click;
-
     struct Item {
         Item();
-        Item( std::string name, glm::vec2 position, unsigned up_index, unsigned right_index, unsigned down_index, unsigned left_index, ItemClick *item_click_r = &null_item_click );
+        Item( std::string name, glm::vec2 position, unsigned up_index, unsigned right_index, unsigned down_index, unsigned left_index, ItemClick *item_click_r );
         virtual ~Item() {};
 
         std::string name;
@@ -57,7 +55,7 @@ public:
         Graphics::Text2DBuffer::CenterMode center_mode;
 
         TextButton();
-        TextButton( std::string name, glm::vec2 position, unsigned up_index, unsigned right_index, unsigned down_index, unsigned left_index, ItemClick *item_click_r = &null_item_click, Graphics::Text2DBuffer::Font font = 1, Graphics::Text2DBuffer::Font selected_font = 2, Graphics::Text2DBuffer::CenterMode center_mode = Graphics::Text2DBuffer::CenterMode::MIDDLE );
+        TextButton( std::string name, glm::vec2 position, unsigned up_index, unsigned right_index, unsigned down_index, unsigned left_index, ItemClick *item_click_r, Graphics::Text2DBuffer::Font font = 1, Graphics::Text2DBuffer::Font selected_font = 2, Graphics::Text2DBuffer::CenterMode center_mode = Graphics::Text2DBuffer::CenterMode::MIDDLE );
 
         virtual void drawNeutral(  MainProgram &main_program ) const;
         virtual void drawSelected( MainProgram &main_program ) const;

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -39,9 +39,17 @@ public:
         unsigned down_index;
         unsigned left_index;
         ItemClick *item_click_r;
+        glm::vec2 start, end;
 
         virtual void drawNeutral(  MainProgram &main_program ) const = 0;
         virtual void drawSelected( MainProgram &main_program ) const = 0;
+
+        bool hasBox() const {
+            if(start.x > end.x)
+                return false;
+            else
+                return true;
+        }
     };
     struct TextButton : public Item {
         Graphics::Text2DBuffer::Font font;

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -73,6 +73,8 @@ public:
     virtual void unload( MainProgram &main_program ) = 0;
 
     virtual void update( MainProgram &main_program, std::chrono::microseconds delta );
+
+    virtual void drawAllItems( MainProgram &main_program );
 };
 
 #endif // FC_MENU_H

--- a/src/OptionsMenu.cpp
+++ b/src/OptionsMenu.cpp
@@ -265,10 +265,5 @@ void OptionsMenu::update( MainProgram &main_program, std::chrono::microseconds d
 
     updatePlatfromStatus( main_program, this->shorten_platform, *this->items[id_windows], *this->items[id_mac], *this->items[id_playstation] );
 
-    for( size_t i = 0; i < this->items.size(); i++ ) {
-        if( this->current_item_index != i )
-            this->items[i]->drawNeutral( main_program );
-        else
-            this->items[i]->drawSelected( main_program );
-    }
+    drawAllItems( main_program );
 }

--- a/src/OptionsMenu.cpp
+++ b/src/OptionsMenu.cpp
@@ -47,10 +47,12 @@ void updatePlatfromStatus( MainProgram &main_program, bool shorten, Menu::Item& 
     }
 }
 
-void updateResolutionStatus( MainProgram &main_program, Menu::Item& resolution ) {
-    resolution.name = std::to_string( main_program.options.getVideoWidth() );
-    resolution.name += "x";
-    resolution.name += std::to_string( main_program.options.getVideoHeight() );
+std::string updateResolutionStatus( MainProgram &main_program ) {
+    std::string video_name = std::to_string( main_program.options.getVideoWidth() );
+    video_name += "x";
+    video_name += std::to_string( main_program.options.getVideoHeight() );
+
+    return video_name;
 }
 
 class ItemClickSaveAndExit : public Menu::ItemClick {
@@ -116,21 +118,22 @@ public:
 item_click_increment_resolution(  1 ),
 item_click_decrement_resolution( -1 );
 
-const unsigned id_resolution           =  0;
-const unsigned id_window_status        =  1;
-const unsigned id_reconfigure_controls =  2;
-const unsigned id_current_platform     =  3;
-const unsigned id_save_exit            =  4;
-const unsigned id_exit                 =  5;
+const unsigned id_window_status        = 0;
+const unsigned id_reconfigure_controls = 1;
+const unsigned id_save_exit            = 2;
+const unsigned id_exit                 = 3;
 
-const unsigned id_windows              =  6;
-const unsigned id_mac                  =  7;
-const unsigned id_playstation          =  8;
+const unsigned id_windows              = 4;
+const unsigned id_mac                  = 5;
+const unsigned id_playstation          = 6;
 
-const unsigned id_dec_res              =  9;
-const unsigned id_add_res              = 10;
-const unsigned id_display_res          = 11;
+const unsigned id_dec_res              = 7;
+const unsigned id_add_res              = 8;
 }
+
+const std::string OptionsMenu::RESOLUTION_NAME = "Resolution:";
+const std::string OptionsMenu::PLATFORM_NAME   = "Platform:";
+
 OptionsMenu::~OptionsMenu() {
 
 }
@@ -141,17 +144,15 @@ void OptionsMenu::load( MainProgram &main_program ) {
     glm::u32vec2 scale = main_program.getWindowScale();
     uint32_t center = scale.x / 2;
 
-    Graphics::Text2DBuffer::Font prime_font;
     Graphics::Text2DBuffer::Font selected_font;
-    Graphics::Text2DBuffer::Font title_font;
 
     const unsigned smaller_step = 0.05 * static_cast<float>( scale.y );
     const unsigned step = 0.055 * static_cast<float>( scale.y );
 
-    if( !main_program.text_2d_buffer_r->selectFont( prime_font, 0.9 * smaller_step, smaller_step ) ) {
-        prime_font = 1;
+    if( !main_program.text_2d_buffer_r->selectFont( this->prime_font, 0.9 * smaller_step, smaller_step ) ) {
+        this->prime_font = 1;
 
-        main_program.text_2d_buffer_r->scaleFont( prime_font, smaller_step );
+        main_program.text_2d_buffer_r->scaleFont( this->prime_font, smaller_step );
     }
 
     if( !main_program.text_2d_buffer_r->selectFont( selected_font, smaller_step, step ) ) {
@@ -160,23 +161,26 @@ void OptionsMenu::load( MainProgram &main_program ) {
         main_program.text_2d_buffer_r->scaleFont( selected_font, step - 1 );
     }
 
-    if( !main_program.text_2d_buffer_r->selectFont( title_font, step, 2 * step ) ) {
+    if( !main_program.text_2d_buffer_r->selectFont( this->title_font, step, 2 * step ) ) {
         selected_font = 1;
 
-        main_program.text_2d_buffer_r->scaleFont( title_font, 2 * step - 1 );
+        main_program.text_2d_buffer_r->scaleFont( this->title_font, 2 * step - 1 );
     }
 
-    const Graphics::Text2DBuffer::CenterMode left_mode  = Graphics::Text2DBuffer::CenterMode::LEFT;
-    const Graphics::Text2DBuffer::CenterMode right_mode = Graphics::Text2DBuffer::CenterMode::RIGHT;
+    const auto left_mode  = Graphics::Text2DBuffer::CenterMode::LEFT;
+    const auto right_mode = Graphics::Text2DBuffer::CenterMode::RIGHT;
 
     this->items.clear();
 
-    this->items.emplace_back( new Menu::TextButton( "Resolution: ",                   glm::vec2( 0,       2 * smaller_step ),          id_resolution,           id_resolution,           id_resolution,       id_resolution,       &Menu::null_item_click,          prime_font, selected_font, left_mode ) );
-    this->items.emplace_back( new Menu::TextButton( windowStatusName( main_program ), glm::vec2( scale.x, 3 * smaller_step ),             id_dec_res,        id_window_status, id_reconfigure_controls,              id_window_status,    &item_click_window_status,       prime_font, selected_font, right_mode ) );
-    this->items.emplace_back( new Menu::TextButton( "Reconfigure Controls",           glm::vec2( 0,       4 * smaller_step ),       id_window_status, id_reconfigure_controls,                  id_mac,       id_reconfigure_controls,    &item_click_reconfigure_controls,    prime_font, selected_font, left_mode ) );
-    this->items.emplace_back( new Menu::TextButton( "Platform: ",                     glm::vec2( 0,       5 * smaller_step ),    id_current_platform,     id_current_platform,     id_current_platform, id_current_platform, &Menu::null_item_click,          prime_font, selected_font, left_mode ) );
-    this->items.emplace_back( new Menu::TextButton( "Save to Config File and Exit",  glm::vec2( center,  scale.y - 3 * smaller_step ),        id_mac,            id_save_exit,                 id_exit,             id_save_exit,        &item_click_save_and_exit,       prime_font, selected_font ) );
-    this->items.emplace_back( new Menu::TextButton( "Exit without Saving",           glm::vec2( center,  scale.y - 2 * smaller_step ),   id_save_exit,                id_exit,              id_dec_res,          id_exit,             &MainMenu::item_click_main_menu, prime_font, selected_font ) );
+    this-> resolution_position = glm::vec2( 0, 2 * smaller_step );
+
+    this->items.emplace_back( new Menu::TextButton( windowStatusName( main_program ), glm::vec2( scale.x, 3 * smaller_step ),             id_dec_res,        id_window_status, id_reconfigure_controls,              id_window_status,    &item_click_window_status,       this->prime_font, selected_font, right_mode ) );
+    this->items.emplace_back( new Menu::TextButton( "Reconfigure Controls",           glm::vec2( 0,       4 * smaller_step ),       id_window_status, id_reconfigure_controls,                  id_mac,       id_reconfigure_controls,    &item_click_reconfigure_controls,    this->prime_font, selected_font, left_mode ) );
+
+    this->platform_position = glm::vec2( 0, 5 * smaller_step );
+
+    this->items.emplace_back( new Menu::TextButton( "Save to Config File and Exit",  glm::vec2( center,  scale.y - 3 * smaller_step ),        id_mac,            id_save_exit,                 id_exit,             id_save_exit,        &item_click_save_and_exit,       this->prime_font, selected_font ) );
+    this->items.emplace_back( new Menu::TextButton( "Exit without Saving",           glm::vec2( center,  scale.y - 2 * smaller_step ),   id_save_exit,                id_exit,              id_dec_res,          id_exit,             &MainMenu::item_click_main_menu, this->prime_font, selected_font ) );
 
     this->selected_resolution = 0;
 
@@ -192,40 +196,41 @@ void OptionsMenu::load( MainProgram &main_program ) {
     // This code is to shorten the platform names. This is so the Playstation version of the game fits in the screen.
     this->shorten_platform = false;
 
-    if( main_program.text_2d_buffer_r->getLineLength( prime_font, this->items[id_current_platform]->name + "*" + WINDOWS[this->shorten_platform] + "**" + MACINTOSH[this->shorten_platform] + "**" + PLAYSTATION[this->shorten_platform] + "*" ) > scale.x )
+    if( main_program.text_2d_buffer_r->getLineLength( this->prime_font, PLATFORM_NAME + "*" + WINDOWS[this->shorten_platform] + "**" + MACINTOSH[this->shorten_platform] + "**" + PLAYSTATION[this->shorten_platform] + "*" ) > scale.x )
         this->shorten_platform = true;
 
     // For the Platform selection use
-    auto line_length = main_program.text_2d_buffer_r->getLineLength( prime_font, this->items[id_current_platform]->name );
+    auto line_length = main_program.text_2d_buffer_r->getLineLength( this->prime_font, PLATFORM_NAME );
 
-    this->items.emplace_back( new Menu::TextButton( WINDOWS[this->shorten_platform],     glm::vec2( line_length, this->items[id_current_platform]->position.y ), id_window_status, id_mac,         id_save_exit, id_windows,  &item_click_switch_to_windows,    prime_font, selected_font, left_mode ) );
+    this->items.emplace_back( new Menu::TextButton( WINDOWS[this->shorten_platform],     glm::vec2( line_length, this->platform_position.y ), id_window_status, id_mac,         id_save_exit, id_windows,  &item_click_switch_to_windows,    this->prime_font, selected_font, left_mode ) );
 
-    line_length += main_program.text_2d_buffer_r->getLineLength( prime_font, WINDOWS[this->shorten_platform] );
-    auto end_length = scale.x - main_program.text_2d_buffer_r->getLineLength( prime_font, PLAYSTATION[this->shorten_platform] );
+    line_length += main_program.text_2d_buffer_r->getLineLength( this->prime_font, WINDOWS[this->shorten_platform] );
+    auto end_length = scale.x - main_program.text_2d_buffer_r->getLineLength( this->prime_font, PLAYSTATION[this->shorten_platform] );
 
-    this->items.emplace_back( new Menu::TextButton( MACINTOSH[this->shorten_platform],   glm::vec2( (end_length + line_length) / 2, this->items[id_current_platform]->position.y ), id_window_status, id_playstation, id_save_exit, id_windows, &item_click_switch_to_macintosh,   prime_font, selected_font ) );
+    this->items.emplace_back( new Menu::TextButton( MACINTOSH[this->shorten_platform],   glm::vec2( (end_length + line_length) / 2, this->platform_position.y ), id_window_status, id_playstation, id_save_exit, id_windows, &item_click_switch_to_macintosh,   this->prime_font, selected_font ) );
 
-    this->items.emplace_back( new Menu::TextButton( PLAYSTATION[this->shorten_platform], glm::vec2( scale.x, this->items[id_current_platform]->position.y ), id_window_status, id_playstation, id_save_exit, id_mac,     &item_click_switch_to_playstation, prime_font, selected_font, right_mode ) );
+    this->items.emplace_back( new Menu::TextButton( PLAYSTATION[this->shorten_platform], glm::vec2( scale.x, this->platform_position.y ), id_window_status, id_playstation, id_save_exit, id_mac,     &item_click_switch_to_playstation, this->prime_font, selected_font, right_mode ) );
 
-    line_length = main_program.text_2d_buffer_r->getLineLength( prime_font, this->items[id_resolution]->name );
+    line_length = main_program.text_2d_buffer_r->getLineLength( this->prime_font, RESOLUTION_NAME );
 
-    this->items.emplace_back( new Menu::TextButton( "Dec",       glm::vec2( line_length, this->items[id_resolution]->position.y ), id_exit,        id_add_res,     id_window_status, id_dec_res,     &item_click_decrement_resolution, prime_font, selected_font, left_mode ) );
+    this->items.emplace_back( new Menu::TextButton( "Dec",       glm::vec2( line_length, resolution_position.y ), id_exit,        id_add_res,     id_window_status, id_dec_res,     &item_click_decrement_resolution, this->prime_font, selected_font, left_mode ) );
     line_length += main_program.text_2d_buffer_r->getLineLength( selected_font, this->items[id_dec_res]->name );
 
-    this->items.emplace_back( new Menu::TextButton( "Add",       glm::vec2( scale.x, this->items[id_resolution]->position.y ), id_exit,        id_add_res,     id_window_status, id_dec_res,     &item_click_increment_resolution, prime_font, selected_font, right_mode ) );
+    this->items.emplace_back( new Menu::TextButton( "Add",       glm::vec2( scale.x, resolution_position.y ), id_exit,        id_add_res,     id_window_status, id_dec_res,     &item_click_increment_resolution, this->prime_font, selected_font, right_mode ) );
 
-    end_length = scale.x - main_program.text_2d_buffer_r->getLineLength( prime_font, "Add" );
+    end_length = scale.x - main_program.text_2d_buffer_r->getLineLength( this->prime_font, "Add" );
 
-    this->items.emplace_back( new Menu::TextButton( "????x????", glm::vec2( (end_length + line_length) / 2, this->items[id_resolution]->position.y), id_display_res, id_display_res, id_display_res,   id_display_res, &Menu::null_item_click,           prime_font, selected_font ) );
+    resolution_display_position = glm::vec2( (end_length + line_length) / 2, resolution_position.y);
 
     updatePlatfromStatus( main_program, this->shorten_platform, *this->items[id_windows], *this->items[id_mac], *this->items[id_playstation] );
 
-    this->items.emplace_back( new Menu::TextButton( "Options", glm::vec2( center, 0 ), id_resolution, id_resolution, id_resolution, id_resolution, &Menu::null_item_click, title_font, title_font ) );
-    this->items.emplace_back( new Menu::TextButton( "Current Window Status:", glm::vec2( 0, this->items[id_window_status]->position.y ), id_resolution, id_resolution, id_resolution, id_resolution, &Menu::null_item_click, prime_font, prime_font, left_mode ) );
+    title_position = glm::vec2( center, 0 );
+
+    window_status_position = glm::vec2( 0, this->items[id_window_status]->position.y );
 
     this->current_item_index = id_dec_res;
 
-    updateResolutionStatus( main_program, *this->items[id_display_res] );
+    updateResolutionStatus( main_program );
 }
 
 void OptionsMenu::unload( MainProgram &main_program ) {
@@ -235,9 +240,30 @@ void OptionsMenu::unload( MainProgram &main_program ) {
 void OptionsMenu::update( MainProgram &main_program, std::chrono::microseconds delta ) {
     Menu::update( main_program, delta );
 
-    updatePlatfromStatus( main_program, this->shorten_platform, *this->items[id_windows], *this->items[id_mac], *this->items[id_playstation] );
+    const auto text_2d_buffer_r = main_program.text_2d_buffer_r;
 
-    updateResolutionStatus( main_program, *this->items[id_display_res] );
+    text_2d_buffer_r->setColor( glm::vec4( 1 ) );
+    text_2d_buffer_r->setFont( this->title_font );
+    text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::CenterMode::MIDDLE );
+    text_2d_buffer_r->setPosition( this->title_position );
+    text_2d_buffer_r->print( "Options" );
+
+    text_2d_buffer_r->setFont( this->prime_font );
+    text_2d_buffer_r->setPosition( this->resolution_display_position );
+    text_2d_buffer_r->print( updateResolutionStatus( main_program ) );
+
+    text_2d_buffer_r->setCenterMode( Graphics::Text2DBuffer::CenterMode::LEFT );
+
+    text_2d_buffer_r->setPosition( this->window_status_position );
+    text_2d_buffer_r->print( "Current Window Status:" );
+
+    text_2d_buffer_r->setPosition( this->platform_position );
+    text_2d_buffer_r->print( PLATFORM_NAME );
+
+    text_2d_buffer_r->setPosition( this->resolution_position );
+    text_2d_buffer_r->print( RESOLUTION_NAME );
+
+    updatePlatfromStatus( main_program, this->shorten_platform, *this->items[id_windows], *this->items[id_mac], *this->items[id_playstation] );
 
     for( size_t i = 0; i < this->items.size(); i++ ) {
         if( this->current_item_index != i )

--- a/src/OptionsMenu.h
+++ b/src/OptionsMenu.h
@@ -5,11 +5,23 @@
 
 class OptionsMenu : public Menu {
 private:
+    static const std::string RESOLUTION_NAME;
+    static const std::string PLATFORM_NAME;
+
 public:
     static OptionsMenu options_menu;
 
     unsigned selected_resolution;
     bool shorten_platform;
+
+    Graphics::Text2DBuffer::Font title_font;
+    Graphics::Text2DBuffer::Font prime_font;
+
+    glm::vec2 title_position;
+    glm::vec2 resolution_position;
+    glm::vec2 window_status_position;
+    glm::vec2 platform_position;
+    glm::vec2 resolution_display_position;
 
     virtual ~OptionsMenu();
 

--- a/src/Sound/OpenAL/Environment.cpp
+++ b/src/Sound/OpenAL/Environment.cpp
@@ -124,25 +124,27 @@ int Environment::loadResources( const Data::Accessor &accessor ) {
 
     auto tos_resource_r = accessor.getConstTOS( 1 );
 
-    for( const uint32_t tos_offset: tos_resource_r->getOffsets()) {
-        const Data::Accessor *swvr_accessor_r = accessor.getSWVRAccessor(tos_offset);
+    if(tos_resource_r != nullptr) {
+        for( const uint32_t tos_offset: tos_resource_r->getOffsets()) {
+            const Data::Accessor *swvr_accessor_r = accessor.getSWVRAccessor(tos_offset);
 
-        // assert(swvr_accessor_r != nullptr);
+            // assert(swvr_accessor_r != nullptr);
 
-        if(swvr_accessor_r != nullptr) {
-            auto snds_r = swvr_accessor_r->getConstSNDS(1);
+            if(swvr_accessor_r != nullptr) {
+                auto snds_r = swvr_accessor_r->getConstSNDS(1);
 
-            if(snds_r == nullptr)
-                continue;
+                if(snds_r == nullptr)
+                    continue;
 
-            const Data::Mission::WAVResource *const sound_r = snds_r->soundAccessor();
+                const Data::Mission::WAVResource *const sound_r = snds_r->soundAccessor();
 
-            tos_to_swvr[tos_offset] = Internal::SoundBuffer();
+                tos_to_swvr[tos_offset] = Internal::SoundBuffer();
 
-            ALenum current_error_state = tos_to_swvr[tos_offset].allocate(*sound_r);
+                ALenum current_error_state = tos_to_swvr[tos_offset].allocate(*sound_r);
 
-            if(current_error_state != AL_NO_ERROR) {
-                error_state = current_error_state;
+                if(current_error_state != AL_NO_ERROR) {
+                    error_state = current_error_state;
+                }
             }
         }
     }


### PR DESCRIPTION
New Features
* Mouse position is read now.
* Axis Aligned Bounding Boxes are determined while constructing a buffer for the triangles.
* Using the bounding boxes, the mouse position and other stuff, I upgraded the menu class to handle mouse clicks.
* Removed NullClick code, because they proved to be useless.

Bug Fixes
* No resource segmentation fault fixed. The FCopMIT executable should warn the user rather than crashing.

How the bug is found. While debugging the menu with the mouse controls, I tested the no resources case, and discovered a segmentation fault! It was the fault of the announcement handling code. Now, this project will warn you rather than simply crashing.