### PR TITLE
PSX SWVR Support; Placeholder VAG Resources; An Annoucement Bug Fix

### DIFF
--- a/src/AnnouncementPlayer.cpp
+++ b/src/AnnouncementPlayer.cpp
@@ -46,9 +46,8 @@ void AnnouncementPlayer::load( MainProgram &main_program ) {
         if(swvr_accessor_r != nullptr) {
             auto snds_array_r = swvr_accessor_r->getAllConstSNDS();
 
-            assert(!snds_array_r.empty());
-
-            this->announcements.push_back(snds_array_r[0]);
+            if(!snds_array_r.empty())
+                this->announcements.push_back(snds_array_r[0]);
         }
     }
 }

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -361,8 +361,8 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
         size_t resources_amount = 0;
         MSICResource *msic_p = nullptr;
         Utilities::Buffer *msic_data_p;
-        UnkResource *mdec_p = nullptr;
-        Utilities::Buffer *mdec_data_p;
+        UnkResource *vagm_p = nullptr;
+        Utilities::Buffer *vagm_data_p;
 
         default_settings.endian = Utilities::Buffer::Endian::NO_SWAP;
 
@@ -516,16 +516,16 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                             }
 
                             // Followed by what are seemly 0x10 byte blocks.
-                            if( mdec_p == nullptr ) {
-                                mdec_p = new UnkResource(PS1_VAGM_TAG, ".vag", true);
-                                mdec_p->setIndexNumber( 0 );
-                                mdec_p->setResourceID( 1 );
-                                mdec_p->getSWVREntry() = swvr_entry;
-                                mdec_p->setOffset( file_offset );
+                            if( vagm_p == nullptr ) {
+                                vagm_p = new UnkResource(PS1_VAGM_TAG, "vag", true);
+                                vagm_p->setIndexNumber( 0 );
+                                vagm_p->setResourceID( 1 );
+                                vagm_p->getSWVREntry() = swvr_entry;
+                                vagm_p->setOffset( file_offset );
 
-                                mdec_data_p = new Utilities::Buffer();
+                                vagm_data_p = new Utilities::Buffer();
                             }
-                            block_chunk_reader.addToBuffer(*mdec_data_p, DATA_SIZE - 20);
+                            block_chunk_reader.addToBuffer(*vagm_data_p, DATA_SIZE - 20);
                         }
                         else if(TYPE_ID == PS1_VAGB_TAG) {
                             const auto TOTAL_CHUNKS  = block_chunk_reader.readU16( default_settings.endian );
@@ -759,14 +759,14 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
         }
 
         // Then write the MISC file.
-        if( mdec_p != nullptr )
+        if( vagm_p != nullptr )
         {
             // This gives msic_data_p to msic so there is no need to delete it.
-            mdec_p->setMemory( mdec_data_p );
-            mdec_p->parse( default_settings );
+            vagm_p->setMemory( vagm_data_p );
+            vagm_p->parse( default_settings );
 
             // msic_p->setMemory( nullptr );
-            addResource( mdec_p );
+            addResource( vagm_p );
         }
 
         Data::Accessor accessor;

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -741,8 +741,6 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                             }
                         }
 
-                        error_log.output << "SWVR " << swvr_entry.name << "\n";
-
                         // Then write the voice file.
                         if( vagb_p != nullptr )
                         {

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -20,6 +20,9 @@
 #include "WAVResource.h"
 #include "ObjResource.h"
 #include "UnkResource.h"
+#include "VAGBResource.h"
+#include "VAGMResource.h"
+#include "VKBResource.h"
 #include "RPNSResource.h"
 
 #include "ACT/Unknown.h"
@@ -87,7 +90,7 @@ namespace {
         { Data::Mission::SNDSResource::IDENTIFIER_TAG, new Data::Mission::SNDSResource() },
         { Data::Mission::FUNResource::IDENTIFIER_TAG, new Data::Mission::FUNResource() },
         { 0x43766b68, new Data::Mission::UnkResource( 0x43766b68, "vkh" ) }, // PS1 Missions.
-        { 0x43766b62, new Data::Mission::UnkResource( 0x43766b68, "vkb" ) },
+        { Data::Mission::VKBResource::IDENTIFIER_TAG, new Data::Mission::VKBResource() },
         { 0x43747273, new Data::Mission::UnkResource( 0x43747273, "trs" ) }, // PS1 Global.
         { 0x436d6463, new Data::Mission::UnkResource( 0x436d6463, "mdc" ) },
         { 0x4374696e, new Data::Mission::UnkResource( 0x4374696e, "tin" ) },
@@ -361,9 +364,9 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
         size_t resources_amount = 0;
         MSICResource *msic_p = nullptr;
         Utilities::Buffer *msic_data_p;
-        UnkResource *vagm_p = nullptr;
+        VAGMResource *vagm_p = nullptr;
         Utilities::Buffer *vagm_data_p;
-        UnkResource *vagb_p = nullptr;
+        VAGBResource *vagb_p = nullptr;
         Utilities::Buffer *vagb_data_p;
         UnkResource *mdec_p = nullptr;
         Utilities::Buffer *mdec_data_p;
@@ -521,7 +524,7 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
 
                             // Followed by what are seemly 0x10 byte blocks.
                             if( vagm_p == nullptr ) {
-                                vagm_p = new UnkResource(PS1_VAGM_TAG, "vag", true);
+                                vagm_p = new VAGMResource();
                                 vagm_p->setIndexNumber( 0 );
                                 vagm_p->setResourceID( 1 );
                                 vagm_p->getSWVREntry() = swvr_entry;
@@ -542,7 +545,7 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
 
                             // Followed by what are seemly 0x10 byte blocks.
                             if( vagb_p == nullptr ) {
-                                vagb_p = new UnkResource(PS1_VAGB_TAG, "vag", true);
+                                vagb_p = new VAGBResource();
                                 vagb_p->setIndexNumber( 0 );
                                 vagb_p->setResourceID( 1 );
                                 vagb_p->getSWVREntry() = swvr_entry;

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -464,6 +464,15 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                     {
                         header_enum_numbers_r = &ps_header_enum_numbers;
 
+                        switch(TYPE_ID) {
+                            case PS1_VAGM_TAG:
+                                error_log.output << "VAGM\n";
+                            case PS1_CANM_TAG:
+                                error_log.output << "CANM\n";
+                            case PS1_VAGB_TAG:
+                                error_log.output << "VAGB\n";
+                        }
+
                         const auto METADATA = block_chunk_reader.readU32( default_settings.endian );
 
                         if(TYPE_ID == PS1_VAGM_TAG && METADATA != 0) {
@@ -650,6 +659,8 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                                     << "  SWVR name \"" << swvr_entry.name << "\" probably invalid.\n";
                             }
                         }
+
+                        error_log.output << "SWVR " << swvr_entry.name << "\n";
                     }
                     break;
                 default:

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -475,20 +475,6 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                     {
                         header_enum_numbers_r = &ps_header_enum_numbers;
 
-                        switch(TYPE_ID) {
-                            case PS1_VAGM_TAG:
-                                error_log.output << "VAGM ";
-                                break;
-                            case PS1_CANM_TAG:
-                                error_log.output << "CANM ";
-                                break;
-                            case PS1_VAGB_TAG:
-                                error_log.output << "VAGB ";
-                                break;
-                        }
-                        error_log.output << "0x" << std::hex << CHUNK_SIZE << "\n";
-
-
                         const auto METADATA = block_chunk_reader.readU32( default_settings.endian );
 
                         if(TYPE_ID == PS1_VAGM_TAG && METADATA != 0) {

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -501,6 +501,20 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                         }
                         else if(TYPE_ID != MATCHING_TAG_DATA)
                             error_log.output << "MATCHING_TAG_DATA is 0x" << std::hex << TYPE_ID << " vs 0x" << MATCHING_TAG_DATA << ".\n";
+
+                        if(TYPE_ID == PS1_VAGM_TAG) {
+                            const auto TOTAL_COUNT = block_chunk_reader.readU16( default_settings.endian );
+                            const auto INDEX = block_chunk_reader.readU16( default_settings.endian );
+                            const auto MAGIC_NUMBER = block_chunk_reader.readU32( default_settings.endian );
+
+                            if(INDEX >= TOTAL_COUNT || MAGIC_NUMBER != 0x2fc0) {
+                                error_log.output << "PS1_VAGM_TAG TOTAL_COUNT is 0x" << std::hex << TOTAL_COUNT << ".\n";
+                                error_log.output << "PS1_VAGM_TAG INDEX is 0x" << std::hex << INDEX << ".\n";
+                                error_log.output << "PS1_VAGM_TAG MAGIC_NUMBER is 0x" << std::hex << MAGIC_NUMBER << ".\n";
+                            }
+
+                            // Followed by what is seemly 0x10 byte blocks.
+                        }
                     }
 
                     break;

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -513,7 +513,18 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                                 error_log.output << "PS1_VAGM_TAG MAGIC_NUMBER is 0x" << std::hex << MAGIC_NUMBER << ".\n";
                             }
 
-                            // Followed by what is seemly 0x10 byte blocks.
+                            // Followed by what are seemly 0x10 byte blocks.
+                        }
+                        else if(TYPE_ID == PS1_VAGB_TAG) {
+                            const auto TOTAL_CHUNKS  = block_chunk_reader.readU16( default_settings.endian );
+                            const auto CURRENT_CHUNK = block_chunk_reader.readU16( default_settings.endian );
+
+                            if(TOTAL_CHUNKS < CURRENT_CHUNK) {
+                                error_log.output << "\tPS1_VAGB_TAG TOTAL_CHUNKS is 0x" << std::hex << TOTAL_CHUNKS << ".\n";
+                                error_log.output << "\tPS1_VAGB_TAG CURRENT_CHUNK is 0x" << std::hex << CURRENT_CHUNK << ".\n";
+                            }
+
+                            // Followed by what are seemly 0x10 byte blocks.
                         }
                     }
 

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -361,6 +361,8 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
         size_t resources_amount = 0;
         MSICResource *msic_p = nullptr;
         Utilities::Buffer *msic_data_p;
+        UnkResource *mdec_p = nullptr;
+        Utilities::Buffer *mdec_data_p;
 
         default_settings.endian = Utilities::Buffer::Endian::NO_SWAP;
 
@@ -514,7 +516,16 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                             }
 
                             // Followed by what are seemly 0x10 byte blocks.
-                            // block_chunk_reader.addToBuffer(*msic_data_p, DATA_SIZE);
+                            if( mdec_p == nullptr ) {
+                                mdec_p = new UnkResource(PS1_VAGM_TAG, ".vag", true);
+                                mdec_p->setIndexNumber( 0 );
+                                mdec_p->setResourceID( 1 );
+                                mdec_p->getSWVREntry() = swvr_entry;
+                                mdec_p->setOffset( file_offset );
+
+                                mdec_data_p = new Utilities::Buffer();
+                            }
+                            block_chunk_reader.addToBuffer(*mdec_data_p, DATA_SIZE - 20);
                         }
                         else if(TYPE_ID == PS1_VAGB_TAG) {
                             const auto TOTAL_CHUNKS  = block_chunk_reader.readU16( default_settings.endian );
@@ -745,6 +756,17 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
             
             // msic_p->setMemory( nullptr );
             addResource( msic_p );
+        }
+
+        // Then write the MISC file.
+        if( mdec_p != nullptr )
+        {
+            // This gives msic_data_p to msic so there is no need to delete it.
+            mdec_p->setMemory( mdec_data_p );
+            mdec_p->parse( default_settings );
+
+            // msic_p->setMemory( nullptr );
+            addResource( mdec_p );
         }
 
         Data::Accessor accessor;

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -61,6 +61,7 @@ namespace {
     const uint32_t PS1_VAGB_TAG = 0x56414742; // Dynamic size
     // which is { 0x56, 0x41, 0x47, 0x4D } or { 'V', 'A', 'G', 'M' } or "VAGM"
     const uint32_t PS1_VAGM_TAG = 0x5641474D; // Dynamic size
+    const uint32_t PS1_MDEC_TAG = 0x4D444543;
 
     const std::map<uint32_t, Data::Mission::Resource*> file_type_list {
         { Data::Mission::ACTResource::IDENTIFIER_TAG, new Data::Mission::ACT::Unknown() },
@@ -472,6 +473,20 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                         } else if(TYPE_ID == PS1_VAGB_TAG && METADATA != 2) {
                             warning_log.output << "VAGB is " << std::dec << METADATA << " not two.\n";
                         }
+
+                        const auto ZERO = block_chunk_reader.readU32( default_settings.endian );
+
+                        if( ZERO != 0 )
+                            error_log.output << "ZERO for PS1 SWVR is " << std::dec << ZERO << " not zero.\n";
+
+                        const auto MATCHING_TAG_DATA = block_chunk_reader.readU32( default_settings.endian );
+
+                        if(TYPE_ID == PS1_CANM_TAG) {
+                            if(MATCHING_TAG_DATA != PS1_MDEC_TAG)
+                                error_log.output << "PS1_CANM_TAG is 0x" << std::hex << TYPE_ID << " while 0x" << MATCHING_TAG_DATA << " is not MDEC.\n";
+                        }
+                        else if(TYPE_ID != MATCHING_TAG_DATA)
+                            error_log.output << "MATCHING_TAG_DATA is 0x" << std::hex << TYPE_ID << " vs 0x" << MATCHING_TAG_DATA << ".\n";
                     }
 
                     break;

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -514,6 +514,7 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                             }
 
                             // Followed by what are seemly 0x10 byte blocks.
+                            // block_chunk_reader.addToBuffer(*msic_data_p, DATA_SIZE);
                         }
                         else if(TYPE_ID == PS1_VAGB_TAG) {
                             const auto TOTAL_CHUNKS  = block_chunk_reader.readU16( default_settings.endian );
@@ -525,6 +526,11 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
                             }
 
                             // Followed by what are seemly 0x10 byte blocks.
+                        }
+                        else {
+                            // CANM and MDEC CHUNK_SIZE = 0x4228, 0x5428, 0x5a28, 0x5bf4, 0x5c78, 0x5fa0, 0x5fc4, 0x5fc8, 0x5fdc
+
+                            // All that I know is that this is MDEC data.
                         }
                     }
 

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -457,10 +457,23 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
 
                     block_chunk_reader.addToBuffer(*msic_data_p, DATA_SIZE);
                     break;
+                case PS1_VAGM_TAG:
                 case PS1_CANM_TAG:
                 case PS1_VAGB_TAG:
-                case PS1_VAGM_TAG:
-                    header_enum_numbers_r = &ps_header_enum_numbers;
+                    {
+                        header_enum_numbers_r = &ps_header_enum_numbers;
+
+                        const auto METADATA = block_chunk_reader.readU32( default_settings.endian );
+
+                        if(TYPE_ID == PS1_VAGM_TAG && METADATA != 0) {
+                            warning_log.output << "VAGM is " << std::dec << METADATA << " not zero.\n";
+                        } else if(TYPE_ID == PS1_CANM_TAG && METADATA != 1) {
+                            warning_log.output << "CANM is " << std::dec << METADATA << " not one.\n";
+                        } else if(TYPE_ID == PS1_VAGB_TAG && METADATA != 2) {
+                            warning_log.output << "VAGB is " << std::dec << METADATA << " not two.\n";
+                        }
+                    }
+
                     break;
                 case SHOC_TAG:
                     {

--- a/src/Data/Mission/IFF.cpp
+++ b/src/Data/Mission/IFF.cpp
@@ -466,12 +466,17 @@ int Data::Mission::IFF::open( const std::string &file_path ) {
 
                         switch(TYPE_ID) {
                             case PS1_VAGM_TAG:
-                                error_log.output << "VAGM\n";
+                                error_log.output << "VAGM ";
+                                break;
                             case PS1_CANM_TAG:
-                                error_log.output << "CANM\n";
+                                error_log.output << "CANM ";
+                                break;
                             case PS1_VAGB_TAG:
-                                error_log.output << "VAGB\n";
+                                error_log.output << "VAGB ";
+                                break;
                         }
+                        error_log.output << "0x" << std::hex << CHUNK_SIZE << "\n";
+
 
                         const auto METADATA = block_chunk_reader.readU32( default_settings.endian );
 

--- a/src/Data/Mission/VAGBResource.cpp
+++ b/src/Data/Mission/VAGBResource.cpp
@@ -1,0 +1,38 @@
+#include "VAGBResource.h"
+
+namespace Data {
+namespace Mission {
+
+const std::string VAGBResource::FILE_EXTENSION = "vagb";
+const uint32_t VAGBResource::IDENTIFIER_TAG = 0x56414742; // which is { 0x56, 0x41, 0x47, 0x42 } or { 'V', 'A', 'G', 'B' } or "VAGB"
+
+VAGBResource::VAGBResource() {}
+
+VAGBResource::VAGBResource( const VAGBResource &obj ) : Resource( obj ), sound( obj.sound ) {}
+
+std::string VAGBResource::getFileExtension() const {
+    return FILE_EXTENSION;
+}
+
+uint32_t VAGBResource::getResourceTagID() const {
+    return IDENTIFIER_TAG;
+}
+
+bool VAGBResource::noResourceID() const {
+    return true;
+}
+
+bool VAGBResource::parse( const ParseSettings &settings ) {
+    return true;
+}
+
+int VAGBResource::write( const std::string& file_path, const IFFOptions &iff_options ) const {
+    return 0;
+}
+
+Resource * VAGBResource::duplicate() const {
+    return new VAGBResource( *this );
+}
+
+}
+}

--- a/src/Data/Mission/VAGBResource.h
+++ b/src/Data/Mission/VAGBResource.h
@@ -1,0 +1,41 @@
+#ifndef MISSION_RESOURCE_VAGB_HEADER
+#define MISSION_RESOURCE_VAGB_HEADER
+
+#include "WAVResource.h"
+
+namespace Data {
+
+namespace Mission {
+
+class VAGBResource : public Resource {
+public:
+    static const std::string FILE_EXTENSION;
+    static const uint32_t IDENTIFIER_TAG;
+
+private:
+    WAVResource sound;
+
+public:
+    VAGBResource();
+    VAGBResource( const VAGBResource &obj );
+
+    virtual std::string getFileExtension() const;
+
+    virtual uint32_t getResourceTagID() const;
+
+    virtual bool noResourceID() const;
+
+    const WAVResource *const soundAccessor() const { return &sound; }
+
+    virtual bool parse( const ParseSettings &settings = Data::Mission::Resource::DEFAULT_PARSE_SETTINGS );
+
+    virtual int write( const std::string& file_path, const Data::Mission::IFFOptions &iff_options = IFFOptions() ) const;
+
+    virtual Resource * duplicate() const;
+};
+
+}
+
+}
+
+#endif // MISSION_RESOURCE_VAGB_HEADER

--- a/src/Data/Mission/VAGMResource.cpp
+++ b/src/Data/Mission/VAGMResource.cpp
@@ -1,0 +1,38 @@
+#include "VAGMResource.h"
+
+namespace Data {
+namespace Mission {
+
+const std::string VAGMResource::FILE_EXTENSION = "vagm";
+const uint32_t VAGMResource::IDENTIFIER_TAG = 0x5641474D; // which is { 0x56, 0x41, 0x47, 0x4D } or { 'V', 'A', 'G', 'M' } or "VAGM"
+
+VAGMResource::VAGMResource() {}
+
+VAGMResource::VAGMResource( const VAGMResource &obj ) : Resource( obj ), sound( obj.sound ) {}
+
+std::string VAGMResource::getFileExtension() const {
+    return FILE_EXTENSION;
+}
+
+uint32_t VAGMResource::getResourceTagID() const {
+    return IDENTIFIER_TAG;
+}
+
+bool VAGMResource::noResourceID() const {
+    return true;
+}
+
+bool VAGMResource::parse( const ParseSettings &settings ) {
+    return true;
+}
+
+int VAGMResource::write( const std::string& file_path, const IFFOptions &iff_options ) const {
+    return 0;
+}
+
+Resource * VAGMResource::duplicate() const {
+    return new VAGMResource( *this );
+}
+
+}
+}

--- a/src/Data/Mission/VAGMResource.h
+++ b/src/Data/Mission/VAGMResource.h
@@ -1,0 +1,41 @@
+#ifndef MISSION_RESOURCE_VAGM_HEADER
+#define MISSION_RESOURCE_VAGM_HEADER
+
+#include "WAVResource.h"
+
+namespace Data {
+
+namespace Mission {
+
+class VAGMResource : public Resource {
+public:
+    static const std::string FILE_EXTENSION;
+    static const uint32_t IDENTIFIER_TAG;
+
+private:
+    WAVResource sound;
+
+public:
+    VAGMResource();
+    VAGMResource( const VAGMResource &obj );
+
+    virtual std::string getFileExtension() const;
+
+    virtual uint32_t getResourceTagID() const;
+
+    virtual bool noResourceID() const;
+
+    const WAVResource *const soundAccessor() const { return &sound; }
+
+    virtual bool parse( const ParseSettings &settings = Data::Mission::Resource::DEFAULT_PARSE_SETTINGS );
+
+    virtual int write( const std::string& file_path, const Data::Mission::IFFOptions &iff_options = IFFOptions() ) const;
+
+    virtual Resource * duplicate() const;
+};
+
+}
+
+}
+
+#endif // MISSION_RESOURCE_VAGM_HEADER

--- a/src/Data/Mission/VKBResource.cpp
+++ b/src/Data/Mission/VKBResource.cpp
@@ -1,0 +1,36 @@
+#include "VKBResource.h"
+
+namespace Data {
+namespace Mission {
+
+const std::string VKBResource::FILE_EXTENSION = "vkb";
+const uint32_t VKBResource::IDENTIFIER_TAG = 0x43766b62; // which is { 0x43, 0x76, 0x6b, 0x62 } or { 'C', 'v', 'k', 'b' } or "Cvkb"
+
+VKBResource::VKBResource() : WAVResource() {}
+
+VKBResource::VKBResource( const VKBResource &obj ) : WAVResource(obj) {}
+
+// TODO Remove these when fully supporting PS1 files.
+// These lines prevent the program from treating this data as a WAV file.
+std::string VKBResource::getFileExtension() const {
+    return FILE_EXTENSION;
+}
+
+uint32_t VKBResource::getResourceTagID() const {
+    return IDENTIFIER_TAG;
+}
+
+bool VKBResource::parse( const ParseSettings &settings) {
+    return true;
+}
+
+Resource * VKBResource::duplicate() const {
+    return new VKBResource( *this );
+}
+
+int VKBResource::write( const std::string& file_path, const IFFOptions &iff_options) const {
+    return 0;
+}
+
+}
+}

--- a/src/Data/Mission/VKBResource.h
+++ b/src/Data/Mission/VKBResource.h
@@ -1,0 +1,34 @@
+#ifndef MISSION_RESOURCE_VKB_HEADER
+#define MISSION_RESOURCE_VKB_HEADER
+
+#include "WAVResource.h"
+
+namespace Data {
+
+namespace Mission {
+
+class VKBResource : public WAVResource {
+public:
+    static const std::string FILE_EXTENSION;
+    static const uint32_t IDENTIFIER_TAG;
+
+public:
+    VKBResource();
+    VKBResource( const VKBResource &obj );
+
+    virtual std::string getFileExtension() const;
+
+    virtual uint32_t getResourceTagID() const;
+
+    virtual bool parse( const ParseSettings &settings = Data::Mission::Resource::DEFAULT_PARSE_SETTINGS );
+
+    virtual Resource * duplicate() const;
+
+    virtual int write( const std::string& file_path, const Data::Mission::IFFOptions &iff_options = IFFOptions() ) const;
+};
+
+}
+
+}
+
+#endif // MISSION_RESOURCE_VKB_HEADER


### PR DESCRIPTION
This makes my software actually read the PS1 SWVR Data.

However, my software does not have the ability to decode PS1 audio data yet. I would need a library like ffmpeg to support that.