### PR TITLE
Fixing Mac and Windows bug

### DIFF
--- a/src/Data/Mission/MSICResource.cpp
+++ b/src/Data/Mission/MSICResource.cpp
@@ -33,8 +33,8 @@ bool Data::Mission::MSICResource::parse( const ParseSettings &settings ) {
 
     if( this->data != nullptr )
     {
-        sound.setChannelNumber( 1 );
-        sound.setSampleRate( 28000 ); // Assumed rate
+        sound.setChannelNumber( 2 );
+        sound.setSampleRate( 14000 ); // Assumed rate
         sound.setBitsPerSample( 8 );
         
         auto reader = this->getDataReader();


### PR DESCRIPTION
I encountered a bug of SDL2-compat which caused MojoAL to end every audio early.
However, this has been fixed. I wish my package manager updates this library soon.