### PR TITLE
PixelFormats Are Treated as Constant Global Data

### DIFF
--- a/src/Data/Mission/ANMResource.cpp
+++ b/src/Data/Mission/ANMResource.cpp
@@ -105,7 +105,7 @@ const uint32_t              Data::Mission::ANMResource::IDENTIFIER_TAG = 0x63616
 
 // TODO Figure out why changing Utilities::PixelFormatColor_R5G5B5A1() to Utilities::PixelFormatColor_R5G5B5A1::linear causes the Windows build to segfault.
 Data::Mission::ANMResource::ANMResource() :
-    palette( Utilities::PixelFormatColor_R5G5B5A1(Utilities::PixelFormatColor::LINEAR) ), total_scanlines( 0 ), scanline_raw_bytes_p( nullptr )
+    palette( Utilities::PixelFormatColor_R5G5B5A1::linear ), total_scanlines( 0 ), scanline_raw_bytes_p( nullptr )
 {}
 
 Data::Mission::ANMResource::ANMResource( const ANMResource &obj ) : Resource( obj ), palette( obj.palette ), total_scanlines( obj.total_scanlines ), scanline_raw_bytes_p( nullptr )

--- a/src/Data/Mission/ANMResource.cpp
+++ b/src/Data/Mission/ANMResource.cpp
@@ -105,7 +105,7 @@ const uint32_t              Data::Mission::ANMResource::IDENTIFIER_TAG = 0x63616
 
 // TODO Figure out why changing Utilities::PixelFormatColor_R5G5B5A1() to Utilities::PixelFormatColor_R5G5B5A1::linear causes the Windows build to segfault.
 Data::Mission::ANMResource::ANMResource() :
-    palette( Utilities::PixelFormatColor_R5G5B5A1() ), total_scanlines( 0 ), scanline_raw_bytes_p( nullptr )
+    palette( Utilities::PixelFormatColor_R5G5B5A1(Utilities::PixelFormatColor::LINEAR) ), total_scanlines( 0 ), scanline_raw_bytes_p( nullptr )
 {}
 
 Data::Mission::ANMResource::ANMResource( const ANMResource &obj ) : Resource( obj ), palette( obj.palette ), total_scanlines( obj.total_scanlines ), scanline_raw_bytes_p( nullptr )

--- a/src/Tests/Data/Mission/ANMResource.cpp
+++ b/src/Tests/Data/Mission/ANMResource.cpp
@@ -78,7 +78,7 @@ int testANM( Utilities::Buffer::Endian endian, std::string name, const uint8_t *
         if( dynamic_cast<const Utilities::PixelFormatColor_R5G5B5A1*>( frame->getPixelFormat() ) == nullptr ) {
             std::cout << full_name << " does not have the correct color palette!" << std::endl;
             std::cout << "  actual colors = " << frame->getPixelFormat()->getName() << std::endl;
-            std::cout << "  expected colors = " << Utilities::PixelFormatColor_R5G5B5A1().getName()<< std::endl;
+            std::cout << "  expected colors = " << Utilities::PixelFormatColor_R5G5B5A1::linear.getName()<< std::endl;
             is_not_success = true;
         }
 

--- a/src/Tests/Utilities/PixelFormat.cpp
+++ b/src/Tests/Utilities/PixelFormat.cpp
@@ -15,7 +15,6 @@ int testColorProfiles( const Utilities::PixelFormatColor::ChannelInterpolation i
     // Brute force will be used to test the various color formats.
     
     {
-        Utilities::PixelFormatColor_W8 white( interpolate );
         Utilities::PixelFormatColor_W8::Color color[2];
         
         for( uint16_t i = 0; i <= 255; i++ )
@@ -39,7 +38,6 @@ int testColorProfiles( const Utilities::PixelFormatColor::ChannelInterpolation i
     }
     
     {
-        Utilities::PixelFormatColor_W8A8 white_alpha( interpolate );
         Utilities::PixelFormatColor_W8A8::Color color[2];
         
         for( uint16_t w = 0; w <= 255; w++ )
@@ -89,7 +87,6 @@ int testColorProfiles( const Utilities::PixelFormatColor::ChannelInterpolation i
     }
     
     {
-        Utilities::PixelFormatColor_R5G5B5A1 r5g5b5a1( interpolate );
         Utilities::PixelFormatColor_R5G5B5A1::Color color[2];
         
         for( uint16_t v = 0; v <= 31; v++ )
@@ -160,7 +157,6 @@ int testColorProfiles( const Utilities::PixelFormatColor::ChannelInterpolation i
     }
     
     {
-        Utilities::PixelFormatColor_R8G8B8 r8g8b8( interpolate );
         Utilities::PixelFormatColor_R8G8B8::Color color[2];
         
         for( uint16_t v = 0; v <= 255; v++ )
@@ -228,7 +224,6 @@ int testColorProfiles( const Utilities::PixelFormatColor::ChannelInterpolation i
     }
     
     {
-        Utilities::PixelFormatColor_R8G8B8A8 r8g8b8( interpolate );
         Utilities::PixelFormatColor_R8G8B8A8::Color color[2];
         
         for( uint16_t v = 0; v <= 255; v++ )

--- a/src/Tests/Utilities/PixelFormat.cpp
+++ b/src/Tests/Utilities/PixelFormat.cpp
@@ -27,11 +27,11 @@ int testColorProfiles( const Utilities::PixelFormatColor::ChannelInterpolation i
             
             if( color[0].white != color[1].white )
             {
-                std::cout << "The color conversion for PixelFormatColor_W8 test has failed!" << std::endl;
-                std::cout << "  At " << i << " the colors do not match." << std::endl;
-                std::cout << "  Color[0] " << static_cast<uint32_t>(color[0].white) << std::endl;
-                std::cout << "  Color[1] " << static_cast<uint32_t>(color[1].white) << std::endl;
-                std::cout << "Generic: "<< generic.getString() << std::endl;
+                std::cout << "The color conversion for PixelFormatColor_W8 test has failed!\n"
+                    << "  At " << i << " the colors do not match.\n"
+                    << "  Color[0] " << static_cast<uint32_t>(color[0].white) << "\n"
+                    << "  Color[1] " << static_cast<uint32_t>(color[1].white) << "\n"
+                    << "Generic: "<< generic.getString() << std::endl;
                 //i = 256;
                 problem = 1;
             }

--- a/src/Utilities/Image2D.cpp
+++ b/src/Utilities/Image2D.cpp
@@ -180,7 +180,7 @@ Utilities::Image2D::Image2D( const ImageMorbin2D &obj  ) : Image2D( obj.getWidth
     fillInImage<grid_2d_unit, ImageMorbin2D, Image2D>( obj, 0, 0, obj.getWidth(), obj.getHeight(), *this, 0, 0, getWidth(), getHeight() );
 }
 
-Utilities::Image2D::Image2D( const Image2D &obj ) : Image2D( obj, *obj.pixel_format_p )
+Utilities::Image2D::Image2D( const Image2D &obj ) : Image2D( obj, *obj.pixel_format_r )
 {
 }
 
@@ -270,7 +270,7 @@ Utilities::ImageMorbin2D::ImageMorbin2D( const Image2D &obj  ) : ImageMorbin2D( 
     fillInImage<grid_2d_unit, Image2D, ImageMorbin2D>( obj, 0, 0, obj.getWidth(), obj.getHeight(), *this, 0, 0, getWidth(), getHeight() );
 }
 
-Utilities::ImageMorbin2D::ImageMorbin2D( const ImageMorbin2D &obj ) : ImageMorbin2D( obj, *obj.pixel_format_p )
+Utilities::ImageMorbin2D::ImageMorbin2D( const ImageMorbin2D &obj ) : ImageMorbin2D( obj, *obj.pixel_format_r )
 {
 }
 

--- a/src/Utilities/Image2D.h
+++ b/src/Utilities/Image2D.h
@@ -69,14 +69,14 @@ public:
 template<class placement, class grid_2d_value = uint8_t>
 class ImageColor2D : public ImageBase2D<placement, grid_2d_value> {
 protected:
-    PixelFormatColor *pixel_format_p;
+    const PixelFormatColor *pixel_format_r;
     Buffer::Endian endian;
     
     virtual void updateCellBuffer() {
         this->cells.resize(
             static_cast<uint32_t>( this->getWidth() ) *
             static_cast<uint32_t>( this->getHeight()) *
-            static_cast<uint32_t>( this->pixel_format_p->byteSize() ) );
+            static_cast<uint32_t>( this->pixel_format_r->byteSize() ) );
         this->placement.updatePlacement();
     }
 public:
@@ -84,15 +84,11 @@ public:
         ImageColor2D(0, 0, PixelFormatColor_R8G8B8::linear, endian ) {}
     ImageColor2D( grid_2d_unit width, grid_2d_unit height, const PixelFormatColor& format, Buffer::Endian endian_param = Buffer::Endian::NO_SWAP  ) :
         ImageBase2D<placement, grid_2d_value>( width, height ), endian( endian_param ) {
-        pixel_format_p = dynamic_cast<PixelFormatColor*>( format.duplicate() );
+        this->pixel_format_r = &format;
         updateCellBuffer();
     }
     
-    virtual ~ImageColor2D() {
-        if( pixel_format_p != nullptr )
-            delete pixel_format_p;
-        pixel_format_p = nullptr;
-    }
+    virtual ~ImageColor2D() {}
     
     /**
      * @return the endianess
@@ -105,7 +101,7 @@ public:
      * @return the pixel format.
      */
     virtual const PixelFormatColor *const getPixelFormat() const {
-        return pixel_format_p;
+        return this->pixel_format_r;
     }
     
     virtual bool inscribeSubImage( grid_2d_unit x, grid_2d_unit y, const ImageBase2D<placement>& ref ) = 0;
@@ -119,7 +115,7 @@ public:
         {
             const size_t OFFSET = this->placement.getOffset(x, y);
             
-            this->cells[ OFFSET * static_cast<size_t>( pixel_format_p->byteSize() ) ] = pixel;
+            this->cells[ OFFSET * static_cast<size_t>( this->pixel_format_r->byteSize() ) ] = pixel;
         }
     }
 
@@ -133,7 +129,7 @@ public:
         {
             const size_t OFFSET = this->placement.getOffset(x, y);
             
-            return this->cells[ OFFSET * static_cast<size_t>( pixel_format_p->byteSize() ) ];
+            return this->cells[ OFFSET * static_cast<size_t>( this->pixel_format_r->byteSize() ) ];
         }
     }
     
@@ -150,7 +146,7 @@ public:
             return nullptr;
         else
         {
-            const size_t OFFSET = this->placement.getOffset(x, y) * static_cast<size_t>( pixel_format_p->byteSize() );
+            const size_t OFFSET = this->placement.getOffset(x, y) * static_cast<size_t>( this->pixel_format_r->byteSize() );
             
             assert( OFFSET < this->cells.size() );
             

--- a/src/Utilities/PixelFormat.cpp
+++ b/src/Utilities/PixelFormat.cpp
@@ -441,23 +441,20 @@ Utilities::PixelFormatColor::GenericColor Utilities::PixelFormatColor_R8G8B8A8::
 const Utilities::PixelFormatColor_R8G8B8A8 Utilities::PixelFormatColor_R8G8B8A8::linear = Utilities::PixelFormatColor_R8G8B8A8(Utilities::PixelFormatColor::LINEAR);
 const Utilities::PixelFormatColor_R8G8B8A8 Utilities::PixelFormatColor_R8G8B8A8::s_rgb  = Utilities::PixelFormatColor_R8G8B8A8(Utilities::PixelFormatColor::sRGB);
 
-Utilities::ColorPalette::ColorPalette( const Utilities::PixelFormatColor& color_palette, Buffer::Endian endianess_param ) : color_p(nullptr), buffer(), endianess( endianess_param )
+Utilities::ColorPalette::ColorPalette( const Utilities::PixelFormatColor& color_palette, Buffer::Endian endianess_param ) :
+    color_r( &color_palette ), buffer(), endianess( endianess_param )
 {
-    color_p = dynamic_cast<PixelFormatColor*>( color_palette.duplicate() );
-    
-    assert( color_p != nullptr );
+    assert( this->color_r != nullptr );
 }
 
 Utilities::ColorPalette::ColorPalette( Utilities::ColorPalette const &color ) :
-    color_p( nullptr ),  buffer( color.buffer ), endianess( color.endianess )
+    color_r( color.color_r ),  buffer( color.buffer ), endianess( color.endianess )
 {
-    color_p = dynamic_cast<PixelFormatColor*>( color.color_p->duplicate() );
-    
-    assert( color_p != nullptr );
+    assert( this->color_r != nullptr );
 }
 
 bool Utilities::ColorPalette::empty() const {
-    if( buffer.getReader().totalSize() < color_p->byteSize() )
+    if( buffer.getReader().totalSize() < this->color_r->byteSize() )
         return true;
     else
         return false;
@@ -468,22 +465,22 @@ uint_fast8_t Utilities::ColorPalette::getLastIndex() const
     if( empty() )
         return 0;
     else
-        return buffer.getReader().totalSize() / color_p->byteSize() - 1;
+        return buffer.getReader().totalSize() / this->color_r->byteSize() - 1;
 }
 
 Utilities::PixelFormatColor::GenericColor Utilities::ColorPalette::getIndex( palette_index index ) const
 {
-    auto reader = buffer.getReader( static_cast<size_t>(index) * color_p->byteSize(), color_p->byteSize() );
+    auto reader = buffer.getReader( static_cast<size_t>(index) * this->color_r->byteSize(), this->color_r->byteSize() );
     
-    return color_p->readPixel( reader, endianess );
+    return this->color_r->readPixel( reader, endianess );
 }
 
 bool Utilities::ColorPalette::setIndex( palette_index index, const PixelFormatColor::GenericColor& color )
 {
     if( !empty() && index <= getLastIndex() ) {
-        auto writer = buffer.getWriter( static_cast<size_t>(index) * color_p->byteSize(), color_p->byteSize() );
+        auto writer = buffer.getWriter( static_cast<size_t>(index) * this->color_r->byteSize(), this->color_r->byteSize() );
         
-        color_p->writePixel( writer, endianess, color );
+        this->color_r->writePixel( writer, endianess, color );
         
         return true;
     }
@@ -495,7 +492,7 @@ bool Utilities::ColorPalette::setAmount( uint16_t amount )
     if( amount > 256 )
         amount = 256;
     
-    auto palette_buffer_size = static_cast<size_t>( amount ) * static_cast<size_t>( color_p->byteSize() );
+    auto palette_buffer_size = static_cast<size_t>( amount ) * static_cast<size_t>( this->color_r->byteSize() );
     
     if( palette_buffer_size != buffer.getReader().totalSize() )
     {

--- a/src/Utilities/PixelFormat.h
+++ b/src/Utilities/PixelFormat.h
@@ -14,7 +14,6 @@ namespace Utilities {
     class PixelFormat {
     public:
         virtual ~PixelFormat() {}
-        virtual PixelFormat* duplicate() const = 0;
         virtual std::string getName() const = 0;
         virtual uint_fast8_t byteSize() const = 0;
     };
@@ -79,9 +78,6 @@ namespace Utilities {
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
         
-        virtual PixelFormat* duplicate() const {
-            return new PixelFormatColor_W8( interpolation );
-        }
         virtual uint_fast8_t byteSize() const { return 1; }
         virtual void writePixel( Buffer::Writer &buffer, Buffer::Endian endian, const PixelFormatColor::GenericColor& color ) const;
         virtual PixelFormatColor::GenericColor readPixel( Buffer::Reader &buffer, Buffer::Endian endian = Buffer::Endian::NO_SWAP ) const;
@@ -107,9 +103,6 @@ namespace Utilities {
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
         
-        virtual PixelFormat* duplicate() const {
-            return new PixelFormatColor_W8A8( interpolation );
-        }
         virtual uint_fast8_t byteSize() const { return 2; }
         virtual void writePixel( Buffer::Writer &buffer, Buffer::Endian endian, const PixelFormatColor::GenericColor& color ) const;
         virtual PixelFormatColor::GenericColor readPixel( Buffer::Reader &buffer, Buffer::Endian endian = Buffer::Endian::NO_SWAP ) const;
@@ -136,9 +129,6 @@ namespace Utilities {
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
         
-        virtual PixelFormat* duplicate() const {
-            return new PixelFormatColor_R5G5B5A1( interpolation );
-        }
         virtual uint_fast8_t byteSize() const { return 2; }
         virtual void writePixel( Buffer::Writer &buffer, Buffer::Endian endian, const PixelFormatColor::GenericColor& color ) const;
         virtual PixelFormatColor::GenericColor readPixel( Buffer::Reader &buffer, Buffer::Endian endian = Buffer::Endian::NO_SWAP ) const;
@@ -165,9 +155,6 @@ namespace Utilities {
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
         
-        virtual PixelFormat* duplicate() const {
-            return new PixelFormatColor_B5G5R5A1( interpolation );
-        }
         virtual uint_fast8_t byteSize() const { return 2; }
         virtual void writePixel( Buffer::Writer &buffer, Buffer::Endian endian, const PixelFormatColor::GenericColor& color ) const;
         virtual PixelFormatColor::GenericColor readPixel( Buffer::Reader &buffer, Buffer::Endian endian = Buffer::Endian::NO_SWAP ) const;
@@ -193,10 +180,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        
-        virtual PixelFormat* duplicate() const {
-            return new PixelFormatColor_R5G5B5T1( interpolation );
-        }
         
         virtual uint_fast8_t byteSize() const { return 2; }
         
@@ -226,10 +209,6 @@ namespace Utilities {
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
         
-        virtual PixelFormat* duplicate() const {
-            return new PixelFormatColor_B5G5R5T1( interpolation );
-        }
-        
         virtual uint_fast8_t byteSize() const { return 2; }
         
         virtual void writePixel( Utilities::Buffer::Writer &buffer, Utilities::Buffer::Endian endian, const PixelFormatColor::GenericColor& coloring ) const;
@@ -256,9 +235,6 @@ namespace Utilities {
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
         
-        virtual PixelFormat* duplicate() const {
-            return new PixelFormatColor_R8G8B8( interpolation );
-        }
         virtual uint_fast8_t byteSize() const { return 3; }
         virtual void writePixel( Buffer::Writer &buffer, Buffer::Endian endian, const PixelFormatColor::GenericColor& color ) const;
         virtual PixelFormatColor::GenericColor readPixel( Buffer::Reader &buffer, Buffer::Endian endian = Buffer::Endian::NO_SWAP ) const;
@@ -285,9 +261,6 @@ namespace Utilities {
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
         
-        virtual PixelFormat* duplicate() const {
-            return new PixelFormatColor_R8G8B8A8( interpolation );
-        }
         virtual uint_fast8_t byteSize() const { return 4; }
         virtual void writePixel( Buffer::Writer &buffer, Buffer::Endian endian, const PixelFormatColor::GenericColor& color ) const;
         virtual PixelFormatColor::GenericColor readPixel( Buffer::Reader &buffer, Buffer::Endian endian = Buffer::Endian::NO_SWAP ) const;

--- a/src/Utilities/PixelFormat.h
+++ b/src/Utilities/PixelFormat.h
@@ -120,6 +120,9 @@ namespace Utilities {
     };
 
     class PixelFormatColor_R5G5B5A1 : public PixelFormatColor {
+    private:
+        PixelFormatColor_R5G5B5A1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
+
     public:
         struct Color {
             uint16_t red   : 5;
@@ -132,7 +135,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_R5G5B5A1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
             return new PixelFormatColor_R5G5B5A1( interpolation );
@@ -297,24 +299,22 @@ namespace Utilities {
 
     class ColorPalette {
     private:
-        PixelFormatColor *color_p;
+        const PixelFormatColor *color_r;
         Buffer buffer;
         Buffer::Endian endianess;
     public:
         ColorPalette( const ColorPalette& palette );
         ColorPalette( const PixelFormatColor& palette_color, Buffer::Endian endianess = Buffer::Endian::NO_SWAP );
-        virtual ~ColorPalette() {
-            delete color_p;
-        }
+        virtual ~ColorPalette() {}
         
         bool empty() const;
         
-        const PixelFormatColor* getColorFormat() const { return color_p; }
+        const PixelFormatColor* getColorFormat() const { return this->color_r; }
         PixelFormatColor::GenericColor getIndex( palette_index index ) const;
         uint_fast8_t getLastIndex() const;
         Buffer::Endian getEndian() const { return endianess; }
         Buffer::Reader getReader() const { return buffer.getReader(); }
-        Buffer::Reader getReader( palette_index index ) const { return buffer.getReader( static_cast<size_t>( index ) * color_p->byteSize(), color_p->byteSize() ); }
+        Buffer::Reader getReader( palette_index index ) const { return buffer.getReader( static_cast<size_t>( index ) * this->color_r->byteSize(), this->color_r->byteSize() ); }
         
         bool setIndex( palette_index index, const PixelFormatColor::GenericColor &color );
         bool setAmount( uint16_t amount );

--- a/src/Utilities/PixelFormat.h
+++ b/src/Utilities/PixelFormat.h
@@ -66,6 +66,9 @@ namespace Utilities {
     };
 
     class PixelFormatColor_W8 : public PixelFormatColor {
+    private:
+        PixelFormatColor_W8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
+
     public:
         struct Color {
             uint8_t white;
@@ -75,7 +78,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_W8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
             return new PixelFormatColor_W8( interpolation );
@@ -91,6 +93,9 @@ namespace Utilities {
     };
 
     class PixelFormatColor_W8A8 : public PixelFormatColor {
+    private:
+        PixelFormatColor_W8A8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
+
     public:
         struct Color {
             uint8_t white;
@@ -101,7 +106,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_W8A8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
             return new PixelFormatColor_W8A8( interpolation );
@@ -143,6 +147,9 @@ namespace Utilities {
     };
     
     class PixelFormatColor_B5G5R5A1 : public PixelFormatColor {
+    private:
+        PixelFormatColor_B5G5R5A1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
+
     public:
         struct Color {
             uint16_t blue  : 5;
@@ -155,7 +162,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_B5G5R5A1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
             return new PixelFormatColor_B5G5R5A1( interpolation );
@@ -170,6 +176,9 @@ namespace Utilities {
     };
 
     class PixelFormatColor_R5G5B5T1 : public PixelFormatColor {
+    private:
+        PixelFormatColor_R5G5B5T1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
+
     public:
         struct Color {
             uint16_t red   : 5;
@@ -182,7 +191,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_R5G5B5T1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
             return new PixelFormatColor_R5G5B5T1( interpolation );
@@ -200,6 +208,9 @@ namespace Utilities {
     };
 
     class PixelFormatColor_B5G5R5T1 : public Utilities::PixelFormatColor {
+    private:
+        PixelFormatColor_B5G5R5T1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
+
     public:
         struct Color {
             uint16_t red   : 5;
@@ -212,7 +223,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_B5G5R5T1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
             return new PixelFormatColor_B5G5R5T1( interpolation );
@@ -229,6 +239,9 @@ namespace Utilities {
     };
 
     class PixelFormatColor_R8G8B8 : public PixelFormatColor {
+    private:
+        PixelFormatColor_R8G8B8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
+
     public:
         struct Color {
             uint8_t red;
@@ -240,7 +253,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_R8G8B8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
             return new PixelFormatColor_R8G8B8( interpolation );
@@ -255,6 +267,9 @@ namespace Utilities {
     };
 
     class PixelFormatColor_R8G8B8A8 : public PixelFormatColor {
+    private:
+        PixelFormatColor_R8G8B8A8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
+
     public:
         struct Color {
             uint8_t red;
@@ -267,7 +282,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_R8G8B8A8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
             return new PixelFormatColor_R8G8B8A8( interpolation );

--- a/src/Utilities/PixelFormat.h
+++ b/src/Utilities/PixelFormat.h
@@ -75,7 +75,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_W8() : PixelFormatColor(PixelFormatColor::LINEAR) {}
         PixelFormatColor_W8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
@@ -102,7 +101,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_W8A8() : PixelFormatColor(PixelFormatColor::LINEAR) {}
         PixelFormatColor_W8A8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
@@ -130,7 +128,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_R5G5B5A1() : PixelFormatColor(PixelFormatColor::LINEAR) {}
         PixelFormatColor_R5G5B5A1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
@@ -158,7 +155,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_B5G5R5A1() : PixelFormatColor(PixelFormatColor::LINEAR) {}
         PixelFormatColor_B5G5R5A1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
@@ -186,7 +182,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_R5G5B5T1() : PixelFormatColor(PixelFormatColor::LINEAR) {}
         PixelFormatColor_R5G5B5T1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
@@ -217,7 +212,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_B5G5R5T1() : PixelFormatColor(PixelFormatColor::LINEAR) {}
         PixelFormatColor_B5G5R5T1( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
@@ -246,7 +240,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_R8G8B8() : PixelFormatColor(PixelFormatColor::LINEAR) {}
         PixelFormatColor_R8G8B8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {
@@ -274,7 +267,6 @@ namespace Utilities {
             
             PixelFormatColor::GenericColor toGeneric( PixelFormatColor::ChannelInterpolation interpolate ) const;
         };
-        PixelFormatColor_R8G8B8A8() : PixelFormatColor(PixelFormatColor::LINEAR) {}
         PixelFormatColor_R8G8B8A8( PixelFormatColor::ChannelInterpolation color ) : PixelFormatColor(color) {}
         
         virtual PixelFormat* duplicate() const {


### PR DESCRIPTION
This paradigm is cleaner and it saves kilobytes of memory.